### PR TITLE
Add 'hosts' field to NATS 'router.start' message

### DIFF
--- a/src/router/common/component.go
+++ b/src/router/common/component.go
@@ -36,6 +36,11 @@ type Healthz struct {
 	Health interface{} `json:"health"`
 }
 
+type RouterStart struct {
+	Id string	`json:"id"`
+	Hosts []string	`json:"hosts"`
+}
+
 func UpdateHealthz() *Healthz {
 	return healthz
 }

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -145,7 +145,11 @@ func (r *Router) ScheduleFlushApps() {
 }
 
 func (r *Router) SendStartMessage() {
-	d := map[string]string{"id": vcap.GenerateUUID()}
+	host, err := vcap.LocalIP()
+	if err != nil {
+		panic(err)
+	}
+	d := vcap.RouterStart{vcap.GenerateUUID(), []string{host}}
 
 	b, err := json.Marshal(d)
 	if err != nil {


### PR DESCRIPTION
Added 'hosts' field to NATS 'router.start' messages so that DEAs can know the router's host for things such as firewall rules.
