### PR TITLE
Load balancing now allowed after session discarded and session cookie deleted

### DIFF
--- a/src/router/proxy.go
+++ b/src/router/proxy.go
@@ -102,11 +102,12 @@ func (p *Proxy) Lookup(req *http.Request) (*Backend, bool) {
 	h := hostWithoutPort(req)
 
 	// Try choosing a backend using sticky session
-	sticky, err := req.Cookie(VcapCookieId)
-	if err == nil {
-		b, ok := p.Registry.LookupByPrivateInstanceId(h, sticky.Value)
-		if ok {
-			return b, ok
+	if _, err := req.Cookie(StickyCookieKey); err == nil {
+		if sticky, err := req.Cookie(VcapCookieId); err == nil {
+			b, ok := p.Registry.LookupByPrivateInstanceId(h, sticky.Value)
+			if ok {
+				return b, ok
+			}
 		}
 	}
 

--- a/src/router/router_test.go
+++ b/src/router/router_test.go
@@ -187,11 +187,11 @@ func (s *RouterSuite) TestStickySession(c *C) {
 	for _, app := range apps {
 		c.Assert(s.waitAppRegistered(app, time.Millisecond*500), Equals, true)
 	}
-	session, port1, path := getSessionAndAppPort("sticky.vcap.me", s.Config.Port, c)
-	port2 := getAppPortWithSticky("sticky.vcap.me", s.Config.Port, session, c)
+	sessionCookie, vcapCookie, port1 := getSessionAndAppPort("sticky.vcap.me", s.Config.Port, c)
+	port2 := getAppPortWithSticky("sticky.vcap.me", s.Config.Port, sessionCookie, vcapCookie, c)
 
 	c.Check(port1, Equals, port2)
-	c.Check(path, Equals, "/")
+	c.Check(vcapCookie.Path, Equals, "/")
 
 	for _, app := range apps {
 		app.Unregister()
@@ -381,7 +381,7 @@ func sendRequests(c *C, url string, rPort uint16, times int) {
 	}
 }
 
-func getSessionAndAppPort(url string, rPort uint16, c *C) (string, string, string) {
+func getSessionAndAppPort(url string, rPort uint16, c *C) (*http.Cookie, *http.Cookie, string) {
 	var client http.Client
 	var req *http.Request
 	var resp *http.Response
@@ -396,19 +396,19 @@ func getSessionAndAppPort(url string, rPort uint16, c *C) (string, string, strin
 
 	port, err = ioutil.ReadAll(resp.Body)
 
-	var session string
-	var path string
+	var sessionCookie, vcapCookie *http.Cookie
 	for _, cookie := range resp.Cookies() {
-		if cookie.Name == "__VCAP_ID__" {
-			session = cookie.Value
-			path = cookie.Path
+		if cookie.Name == StickyCookieKey {
+			sessionCookie = cookie
+		} else if cookie.Name == VcapCookieId {
+			vcapCookie = cookie
 		}
 	}
 
-	return session, string(port), path
+	return sessionCookie, vcapCookie, string(port)
 }
 
-func getAppPortWithSticky(url string, rPort uint16, session string, c *C) string {
+func getAppPortWithSticky(url string, rPort uint16, sessionCookie, vcapCookie *http.Cookie, c *C) string {
 	var client http.Client
 	var req *http.Request
 	var resp *http.Response
@@ -418,11 +418,8 @@ func getAppPortWithSticky(url string, rPort uint16, session string, c *C) string
 	uri := fmt.Sprintf("http://%s:%d/sticky", url, rPort)
 	req, err = http.NewRequest("GET", uri, nil)
 
-	cookie := &http.Cookie{
-		Name:  "__VCAP_ID__",
-		Value: session,
-	}
-	req.AddCookie(cookie)
+	req.AddCookie(sessionCookie)
+	req.AddCookie(vcapCookie)
 
 	resp, err = client.Do(req)
 	c.Assert(err, IsNil)

--- a/src/router/test/sticky_app.go
+++ b/src/router/test/sticky_app.go
@@ -17,7 +17,7 @@ func NewStickyApp(urls []string, rPort uint16, mbusClient mbus.CFMessageBus, tag
 func stickyHandler(port uint16) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cookie := &http.Cookie{
-			Name:  "JSESSIONID",
+			Name:  StickyCookieKey,
 			Value: "xxx",
 		}
 		http.SetCookie(w, cookie)


### PR DESCRIPTION
A fix to allow proper request load balancing even after a session has been discarded and session cookie ('JSESSIONID') deleted.

In order to provide the session stickyness behaviour, the router considers only the vcap cookie ('**VCAP_ID**') to ensure a request is being routed to a proper backend, i.e. the backend with the right session instance. This works properly when session is valid, however when invalidated and session cookie deleted all the subsequent requests are being routed to the same backend as the vcap cookie was still present.

One solution is to somehow hook on an event when session is being invalidated and delete the vcap cookie as well, but, I have no idea how to capture such an event globally. The other solution is to consider the vcap cookie only if there is a session cookie ('JSESSIONID') present.

This fix implements the second approach has been used.

See https://groups.google.com/a/cloudfoundry.org/forum/#!topic/vcap-dev/lSLqQdPmgCk.
