### PR TITLE
Log router index

### DIFF
--- a/proxy/access_logger.go
+++ b/proxy/access_logger.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"regexp"
 	"time"
+	"strconv"
 )
 
 type AccessLogRecord struct {
@@ -76,16 +77,18 @@ type AccessLogger struct {
 	e emitter.Emitter
 	c chan AccessLogRecord
 	w io.Writer
+	index uint
 }
 
-func NewAccessLogger(f io.Writer, loggregatorUrl string) *AccessLogger {
+func NewAccessLogger(f io.Writer, loggregatorUrl string, index uint) *AccessLogger {
 	a := &AccessLogger{
 		w: f,
 		c: make(chan AccessLogRecord, 128),
+		index: index,
 	}
 
 	if isValidUrl(loggregatorUrl) {
-		a.e, _ = emitter.NewEmitter(loggregatorUrl, "ROUTER", steno.NewLogger("router.loggregator"))
+		a.e, _ = emitter.NewEmitter(loggregatorUrl, "ROUTER", strconv.FormatUint(uint64(index), 10), steno.NewLogger("router.loggregator"))
 	} else {
 		log.Errorf("Invalid loggregator url %s", loggregatorUrl)
 	}

--- a/proxy/access_logger_test.go
+++ b/proxy/access_logger_test.go
@@ -101,7 +101,7 @@ func (m *mockEmitter) Emit(appid, message string) {
 }
 
 func (s *AccessLoggerSuite) TestEmittingOfLogRecords(c *C) {
-	accessLogger := NewAccessLogger(nil, "localhost:9843")
+	accessLogger := NewAccessLogger(nil, "localhost:9843", 42)
 	testEmitter := &mockEmitter{emitted: false}
 	accessLogger.e = testEmitter
 
@@ -116,7 +116,7 @@ func (s *AccessLoggerSuite) TestEmittingOfLogRecords(c *C) {
 }
 
 func (s *AccessLoggerSuite) TestNotEmittingLogRecordsWithNoAppId(c *C) {
-	accessLogger := NewAccessLogger(nil, "localhost:9843")
+	accessLogger := NewAccessLogger(nil, "localhost:9843", 42)
 	testEmitter := &mockEmitter{emitted: false}
 	accessLogger.e = testEmitter
 
@@ -139,7 +139,7 @@ func (s *AccessLoggerSuite) TestNotEmittingLogRecordsWithNoAppId(c *C) {
 func (s *AccessLoggerSuite) TestWritingOfLogRecordsToTheFile(c *C) {
 	var fakeFile = new(fakeFile)
 
-	accessLogger := NewAccessLogger(fakeFile, "localhost:9843")
+	accessLogger := NewAccessLogger(fakeFile, "localhost:9843", 42)
 
 	accessLogger.Log(*s.CreateAccessLogRecord())
 	go accessLogger.Run()
@@ -150,32 +150,32 @@ func (s *AccessLoggerSuite) TestWritingOfLogRecordsToTheFile(c *C) {
 }
 
 func (s *AccessLoggerSuite) TestNotCreatingEmitterWhenNoValidUrlIsGiven(c *C) {
-	accessLogger := NewAccessLogger(nil, "this_is_not_a_url")
+	accessLogger := NewAccessLogger(nil, "this_is_not_a_url", 42)
 	c.Assert(accessLogger.e, IsNil)
 	accessLogger.Stop()
 
-	accessLogger = NewAccessLogger(nil, "localhost")
+	accessLogger = NewAccessLogger(nil, "localhost", 42)
 	c.Assert(accessLogger.e, IsNil)
 	accessLogger.Stop()
 
-	accessLogger = NewAccessLogger(nil, "10.10.16.14")
+	accessLogger = NewAccessLogger(nil, "10.10.16.14", 42)
 	c.Assert(accessLogger.e, IsNil)
 	accessLogger.Stop()
 
-	accessLogger = NewAccessLogger(nil, "")
+	accessLogger = NewAccessLogger(nil, "", 42)
 	c.Assert(accessLogger.e, IsNil)
 	accessLogger.Stop()
 }
 
 func (s *AccessLoggerSuite) TestCreatingEmitterWithIPAddressAndPort(c *C) {
-	accessLogger := NewAccessLogger(nil, "10.10.16.14:5432")
+	accessLogger := NewAccessLogger(nil, "10.10.16.14:5432", 42)
 
 	c.Assert(accessLogger.e, NotNil)
 	accessLogger.Stop()
 }
 
 func (s *AccessLoggerSuite) TestCreatingEmitterWithLocalhostt(c *C) {
-	accessLogger := NewAccessLogger(nil, "localhost:123")
+	accessLogger := NewAccessLogger(nil, "localhost:123", 42)
 
 	c.Assert(accessLogger.e, NotNil)
 	accessLogger.Stop()

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -48,7 +48,7 @@ func NewProxy(c *config.Config, registry *registry.Registry, v varz.Varz) *Proxy
 			panic(err)
 		}
 
-		p.AccessLogger = NewAccessLogger(f, loggregatorUrl)
+		p.AccessLogger = NewAccessLogger(f, loggregatorUrl, c.Index)
 		go p.AccessLogger.Run()
 	}
 


### PR DESCRIPTION
Add the index for the gorouter into the log message.

This will require getting the latest version of the loggregatorlib library.

Signed-off-by: Damien Le Berrigaud damien@pivotallabs.com
