### PR TITLE
Change router.register log message to Debug

### DIFF
--- a/router.go
+++ b/router.go
@@ -166,7 +166,7 @@ type registryMessage struct {
 
 func (r *Router) SubscribeRegister() {
 	r.subscribeRegistry("router.register", func(registryMessage *registryMessage) {
-		log.Infof("Got router.register: %v", registryMessage)
+		log.Debugf("Got router.register: %v", registryMessage)
 
 		for _, uri := range registryMessage.Uris {
 			r.registry.Register(


### PR DESCRIPTION
I think notifying logging of a router register should be a debug level message not info.
- Frequent router register log messages make it very hard to follow router logs when diagnosing an issue.
- We are sending all our CF logs to our Enterprise Splunk.  Splunk charges by the MB sent to splunk.  So par router.register messages are accounting for 75% of our log messages.
