### PR TITLE
Requests received metric

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -74,7 +74,7 @@ func (proxy *Proxy) Lookup(request *http.Request) (*route.Endpoint, bool) {
 }
 
 func (proxy *Proxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
-	proxy.Varz.CaptureRequestReceived()
+	proxy.Varz.CaptureReceivedRequest()
 	startedAt := time.Now()
 	originalURL := request.URL
 	request.URL = &url.URL{Host: originalURL.Host, Opaque: request.RequestURI}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -34,7 +34,7 @@ func (_ nullVarz) CaptureBadRequest(req *http.Request)                          
 func (_ nullVarz) CaptureBadGateway(req *http.Request)                                           {}
 func (_ nullVarz) CaptureRoutingRequest(b *route.Endpoint, req *http.Request)                    {}
 func (_ nullVarz) CaptureRoutingResponse(b *route.Endpoint, res *http.Response, d time.Duration) {}
-func (_ nullVarz) CaptureRequestReceived() {}
+func (_ nullVarz) CaptureReceivedRequest() {}
 
 type httpConn struct {
 	net.Conn

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -219,7 +219,7 @@ func (s *RouterSuite) TestVarz(c *C) {
 	app.Unregister()
 }
 
-func (s *RouterSuite) TestRequestsReceivedVsRequests(c *C) {
+func (s *RouterSuite) TestReceivedRequestsVsRequests(c *C) {
 	app := test.NewGreetApp([]route.Uri{"count.vcap.me"}, s.Config.Port, s.mbusClient, map[string]string{"framework": "rails"})
 	app.Listen()
 	go app.RegisterRepeatedly(100 *time.Millisecond)
@@ -241,10 +241,10 @@ func (s *RouterSuite) TestRequestsReceivedVsRequests(c *C) {
 	requestCount := int(updatedRequestCount - initialRequestCount)
 	c.Check(requestCount, Equals, 0)
 
-	initialRequestsReceivedCount := fetchRecursively(initial_varz, "requests_received").(float64)
-	updatedRequestsReceivedCount := fetchRecursively(updated_varz, "requests_received").(float64)
-	requestsReceivedCount := int(updatedRequestsReceivedCount - initialRequestsReceivedCount)
-	c.Check(requestsReceivedCount, Equals, 1)
+	initialReceivedRequestsCount := fetchRecursively(initial_varz, "received_requests").(float64)
+	updatedReceivedRequestsCount := fetchRecursively(updated_varz, "received_requests").(float64)
+	receivedRequestsCount := int(updatedReceivedRequestsCount - initialReceivedRequestsCount)
+	c.Check(receivedRequestsCount, Equals, 1)
 
 	app.Unregister()
 }

--- a/varz/varz.go
+++ b/varz/varz.go
@@ -28,7 +28,7 @@ type varz struct {
 	Urls     int `json:"urls"`
 	Droplets int `json:"droplets"`
 
-	RequestsReceived    int     `json:"requests_received"`
+	ReceivedRequests    int     `json:"received_requests"`
 	BadRequests    int     `json:"bad_requests"`
 	BadGateways    int     `json:"bad_gateways"`
 	RequestsPerSec float64 `json:"requests_per_sec"`
@@ -160,7 +160,7 @@ func (x TaggedHttpMetric) CaptureResponse(t string, y *http.Response, z time.Dur
 
 type Varz interface {
 	json.Marshaler
-	CaptureRequestReceived()
+	CaptureReceivedRequest()
 	CaptureBadRequest(req *http.Request)
 	CaptureBadGateway(req *http.Request)
 	CaptureRoutingRequest(b *route.Endpoint, req *http.Request)
@@ -261,11 +261,11 @@ func (x *RealVarz) CaptureRoutingResponse(endpoint *route.Endpoint, response *ht
 	x.varz.All.CaptureResponse(response, duration)
 }
 
-func (x *RealVarz) CaptureRequestReceived() {
+func (x *RealVarz) CaptureReceivedRequest() {
 	x.Lock()
 	defer x.Unlock()
 
-	x.RequestsReceived++
+	x.ReceivedRequests++
 }
 
 func transform(x interface{}, y map[string]interface{}) error {

--- a/varz/varz_test.go
+++ b/varz/varz_test.go
@@ -147,12 +147,12 @@ func (s *VarzSuite) TestUpdateBadGateways(c *C) {
 	c.Check(s.findValue("bad_gateways"), Equals, float64(2))
 }
 
-func (s *VarzSuite) TestUpdateRequestReceived(c *C) {
-	c.Check(s.findValue("requests_received"), Equals, float64(0))
-	s.Varz.CaptureRequestReceived()
-	c.Check(s.findValue("requests_received"), Equals, float64(1))
-	s.Varz.CaptureRequestReceived()
-	c.Check(s.findValue("requests_received"), Equals, float64(2))
+func (s *VarzSuite) TestUpdateReceivedRequest(c *C) {
+	c.Check(s.findValue("received_requests"), Equals, float64(0))
+	s.Varz.CaptureReceivedRequest()
+	c.Check(s.findValue("received_requests"), Equals, float64(1))
+	s.Varz.CaptureReceivedRequest()
+	c.Check(s.findValue("received_requests"), Equals, float64(2))
 }
 
 func (s *VarzSuite) TestUpdateRequests(c *C) {


### PR DESCRIPTION
Metric to record each received request, regardless of the outcome. This is to support a change requested by the CF Metrics team. 
