### PR TITLE
Omit configuration from /varz output.

### DIFF
--- a/common/component.go
+++ b/common/component.go
@@ -23,7 +23,7 @@ type VcapComponent struct {
 	Index       uint                      `json:"index"`
 	Host        string                    `json:"host"`
 	Credentials []string                  `json:"credentials"`
-	Config      interface{}               `json:"config"`
+	Config      interface{}               `json:"-"`
 	Varz        *Varz                     `json:"-"`
 	Healthz     *Healthz                  `json:"-"`
 	InfoRoutes  map[string]json.Marshaler `json:"-"`

--- a/common/varz_test.go
+++ b/common/varz_test.go
@@ -38,7 +38,6 @@ func (s *VarzSuite) TestEmptyVarz(c *C) {
 		"index",
 		"host",
 		"credentials",
-		"config",
 		"start",
 		"uuid",
 		"uptime",
@@ -52,6 +51,10 @@ func (s *VarzSuite) TestEmptyVarz(c *C) {
 		if _, ok := data[key]; !ok {
 			c.Fatalf(`member "%s" not found`, key)
 		}
+	}
+
+	if _, ok := data["config"]; ok {
+		c.Fatalf(`config should be omitted from /varz`)
 	}
 }
 


### PR DESCRIPTION
Recent exchanges on vcap-dev have resulted in proposals to remove configuration information from /varz outputs of various components.

Provided CF Runtime stories 65042430 and 65300526 result in the removal of configuration information from the ruby CF components, it seems to make sense to begin removing it from the go components as well.

In the case of the go router, omitting configuration will prevent the broadcast of NATS credentials and the loggregator shared secret.

If there's a desire to keep the config information but simply obfuscate or remove sensitive information such as credentials, I'm happy to rework the PR to meet those requirements but the current runtime stories imply config information will be removed from /varz altogether.
