### PR TITLE
[#64865786] Rename "bad_requests" metric to "rejected_requests" for consistency with overall metrics naming scheme

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -24,7 +24,7 @@ type LookupRegistry interface {
 }
 
 type Reporter interface {
-	CaptureBadRequest(req *http.Request)
+	CaptureRejectedRequest(req *http.Request)
 	CaptureBadGateway(req *http.Request)
 	CaptureRoutingRequest(b *route.Endpoint, req *http.Request)
 	CaptureRoutingResponse(b *route.Endpoint, res *http.Response, t time.Time, d time.Duration)
@@ -121,7 +121,7 @@ func (p *proxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.Requ
 
 	routeEndpoint, found := p.lookup(request)
 	if !found {
-		p.reporter.CaptureBadRequest(request)
+		p.reporter.CaptureRejectedRequest(request)
 		handler.HandleMissingRoute()
 		return
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -32,7 +32,7 @@ type nullVarz struct{}
 
 func (_ nullVarz) MarshalJSON() ([]byte, error)                               { return json.Marshal(nil) }
 func (_ nullVarz) ActiveApps() *stats.ActiveApps                              { return stats.NewActiveApps() }
-func (_ nullVarz) CaptureBadRequest(req *http.Request)                        {}
+func (_ nullVarz) CaptureRejectedRequest(req *http.Request)                   {}
 func (_ nullVarz) CaptureBadGateway(req *http.Request)                        {}
 func (_ nullVarz) CaptureRoutingRequest(b *route.Endpoint, req *http.Request) {}
 func (_ nullVarz) CaptureRoutingResponse(b *route.Endpoint, res *http.Response, t time.Time, d time.Duration) {

--- a/varz/varz.go
+++ b/varz/varz.go
@@ -28,9 +28,9 @@ type varz struct {
 	Urls     int `json:"urls"`
 	Droplets int `json:"droplets"`
 
-	BadRequests    int     `json:"bad_requests"`
-	BadGateways    int     `json:"bad_gateways"`
-	RequestsPerSec float64 `json:"requests_per_sec"`
+	RejectedRequests int     `json:"rejected_requests"`
+	BadGateways      int     `json:"bad_gateways"`
+	RequestsPerSec   float64 `json:"requests_per_sec"`
 
 	TopApps []topAppsEntry `json:"top10_app_requests"`
 
@@ -162,7 +162,7 @@ type Varz interface {
 
 	ActiveApps() *stats.ActiveApps
 
-	CaptureBadRequest(req *http.Request)
+	CaptureRejectedRequest(req *http.Request)
 	CaptureBadGateway(req *http.Request)
 	CaptureRoutingRequest(b *route.Endpoint, req *http.Request)
 	CaptureRoutingResponse(b *route.Endpoint, res *http.Response, startedAt time.Time, d time.Duration)
@@ -227,11 +227,11 @@ func (x *RealVarz) ActiveApps() *stats.ActiveApps {
 	return x.activeApps
 }
 
-func (x *RealVarz) CaptureBadRequest(req *http.Request) {
+func (x *RealVarz) CaptureRejectedRequest(req *http.Request) {
 	x.Lock()
 	defer x.Unlock()
 
-	x.BadRequests++
+	x.RejectedRequests++
 }
 
 func (x *RealVarz) CaptureBadGateway(req *http.Request) {

--- a/varz/varz_test.go
+++ b/varz/varz_test.go
@@ -78,7 +78,7 @@ func (s *VarzSuite) TestMembersOfUniqueVarz(c *C) {
 		"urls",
 		"droplets",
 		"requests",
-		"bad_requests",
+		"rejected_requests",
 		"bad_gateways",
 		"requests_per_sec",
 		"top10_app_requests",
@@ -127,14 +127,14 @@ func (s *VarzSuite) TestUrlsInVarz(c *C) {
 	c.Check(s.findValue("urls"), Equals, float64(2))
 }
 
-func (s *VarzSuite) TestUpdateBadRequests(c *C) {
+func (s *VarzSuite) TestUpdateRejectedRequests(c *C) {
 	r := http.Request{}
 
-	s.CaptureBadRequest(&r)
-	c.Check(s.findValue("bad_requests"), Equals, float64(1))
+	s.CaptureRejectedRequest(&r)
+	c.Check(s.findValue("rejected_requests"), Equals, float64(1))
 
-	s.CaptureBadRequest(&r)
-	c.Check(s.findValue("bad_requests"), Equals, float64(2))
+	s.CaptureRejectedRequest(&r)
+	c.Check(s.findValue("rejected_requests"), Equals, float64(2))
 }
 
 func (s *VarzSuite) TestUpdateBadGateways(c *C) {


### PR DESCRIPTION
For our metrics initiative, we're providing a suite of metrics with consistent names: `received_requests`, `routed_requests`, etc. As such, we would like to rename `bad_requests` to `rejected_requests`.
