### PR TITLE
Generate an X-VCAP-Request-ID for each request and capture it in the access log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/*
 /tmp
 *.iml
 .idea/
+tags

--- a/access_log/access_log_record.go
+++ b/access_log/access_log_record.go
@@ -52,6 +52,7 @@ func (r *AccessLogRecord) makeRecord() *bytes.Buffer {
 	fmt.Fprintf(b, `"%s" `, r.FormatRequestHeader("Referer"))
 	fmt.Fprintf(b, `"%s" `, r.FormatRequestHeader("User-Agent"))
 	fmt.Fprintf(b, `%s `, r.Request.RemoteAddr)
+	fmt.Fprintf(b, `vcap_request:%s `, r.FormatRequestHeader("X-Vcap-Request-Id"))
 
 	if r.ResponseTime() < 0 {
 		fmt.Fprintf(b, "response_time:MissingFinishedAt ")

--- a/access_log/access_log_record_test.go
+++ b/access_log/access_log_record_test.go
@@ -25,6 +25,7 @@ func CompleteAccessLogRecord() AccessLogRecord {
 			Header: http.Header{
 				"Referer":    []string{"FakeReferer"},
 				"User-Agent": []string{"FakeUserAgent"},
+				"X-Vcap-Request-Id": []string{"abc-123-xyz-pdq"},
 			},
 			RemoteAddr: "FakeRemoteAddr",
 		},
@@ -51,6 +52,7 @@ func (s *AccessLogRecordSuite) TestMakeRecordWithAllValues(c *C) {
 		"\"FakeReferer\" " +
 		"\"FakeUserAgent\" " +
 		"FakeRemoteAddr " +
+		"vcap_request:abc-123-xyz-pdq " +
 		"response_time:60.000000000 " +
 		"app_id:FakeApplicationId\n"
 
@@ -83,6 +85,7 @@ func (s *AccessLogRecordSuite) TestMakeRecordWithValuesMissing(c *C) {
 		"\"FakeReferer\" " +
 		"\"FakeUserAgent\" " +
 		"FakeRemoteAddr " +
+		"vcap_request:- " +
 		"response_time:MissingFinishedAt " +
 		"app_id:MissingRouteEndpointApplicationId\n"
 

--- a/proxy/request_handler.go
+++ b/proxy/request_handler.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudfoundry/gorouter/common"
 	"github.com/cloudfoundry/gorouter/route"
 	steno "github.com/cloudfoundry/gosteno"
 )
@@ -157,13 +158,13 @@ func (h *RequestHandler) copyToResponse(src io.ReadCloser) (int64, error) {
 	}
 
 	return copied, err
-
 }
 
 func (h *RequestHandler) setupRequest(endpoint *route.Endpoint) {
 	h.setRequestURL(endpoint.CanonicalAddr())
 	h.setRequestXForwardedFor()
 	h.setRequestXRequestStart()
+	h.setRequestXVcapRequestId()
 }
 
 func (h *RequestHandler) setRequestURL(addr string) {
@@ -188,6 +189,12 @@ func (h *RequestHandler) setRequestXRequestStart() {
 	if _, ok := h.request.Header[http.CanonicalHeaderKey("X-Request-Start")]; !ok {
 		h.request.Header.Set("X-Request-Start", strconv.FormatInt(time.Now().UnixNano()/1e6, 10))
 	}
+}
+
+func (h *RequestHandler) setRequestXVcapRequestId() {
+	uuid := common.GenerateUUID()
+        h.request.Header.Set("X-Vcap-Request-Id", uuid)
+        h.logger.Set("X-Vcap-Request-Id", uuid)
 }
 
 func (h *RequestHandler) setupConnection() {


### PR DESCRIPTION
Based on a suggestion from @phanle, add vcap request id to the access log for improved correlation between response times and request activity in the cc log.

```
api.10.244.0.34.xip.io - [25/02/2014:14:09:19 +0000] "GET /bulk/apps?batch_size=500&bulk_token={} HTTP/1.1" 200 281 "-" "Go 1.1 package http" 172.16.118.134:37262 vcap_request:0b5599bf-1247-48ed-aaf0-212142b41203 response_time:0.008804337 app_id:
```
