### PR TITLE
Race conditions in registry and process_status of gorouter

### DIFF
--- a/common/component.go
+++ b/common/component.go
@@ -52,8 +52,10 @@ func UpdateVarz() *Varz {
 	varz.Lock()
 	defer varz.Unlock()
 
+	procStat.RLock()
 	varz.MemStat = procStat.MemRss
 	varz.Cpu = procStat.CpuUsage
+	procStat.RUnlock()
 	varz.Uptime = Component.Start.Elapsed()
 
 	return varz

--- a/common/process_status.go
+++ b/common/process_status.go
@@ -9,7 +9,7 @@ import (
 const RefreshInterval time.Duration = time.Second * 1
 
 type ProcessStatus struct {
-	sync.Mutex
+	sync.RWMutex
 	rusage      *syscall.Rusage
 	lastCpuTime int64
 	stopSignal  chan bool
@@ -44,6 +44,8 @@ func (p *ProcessStatus) Update() {
 		log.Fatal(e.Error())
 	}
 
+	p.Lock()
+	defer p.Unlock()
 	p.MemRss = int64(p.rusage.Maxrss)
 
 	t := p.rusage.Utime.Nano() + p.rusage.Stime.Nano()

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -162,6 +162,8 @@ func (registry *CFRegistry) NumUris() int {
 }
 
 func (r *CFRegistry) TimeOfLastUpdate() time.Time {
+	r.RLock()
+	defer r.RUnlock()
 	return r.timeOfLastUpdate
 }
 
@@ -204,6 +206,8 @@ func (r *CFRegistry) isEntryStale(entry *tableEntry) bool {
 }
 
 func (registry *CFRegistry) pauseStaleTracker() {
+	registry.Lock()
+	defer registry.Unlock()
 	for _, entry := range registry.table {
 		entry.updatedAt = time.Now()
 	}


### PR DESCRIPTION
- fixed race condition in updating registry.updateAt record of gorouter
# \* fixed race condition in updatig process_status of gorouter

Here is error which led to the fixes on component.go and process_status.go:
# 

WARNING: DATA RACE
Read by goroutine 148:
  github.com/cloudfoundry/gorouter/common.UpdateVarz()
      /Users/jackfeng/go/src/github.com/cloudfoundry/gorouter/common/component.go:55 +0xd7
  github.com/cloudfoundry/gorouter/common.func·003()
      /Users/jackfeng/go/src/github.com/cloudfoundry/gorouter/common/component.go:147 +0x1c2
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/pkg/net/http/server.go:1149 +0x4b
  net/http.(_ServeMux).ServeHTTP()
      /usr/local/go/src/pkg/net/http/server.go:1416 +0x145
  github.com/cloudfoundry/gorouter/common/http.(_BasicAuth).ServeHTTP()
      /Users/jackfeng/go/src/github.com/cloudfoundry/gorouter/common/http/basic_auth.go:44 +0x123
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/pkg/net/http/server.go:1517 +0x1c8
  net/http.(*conn).serve()
      /usr/local/go/src/pkg/net/http/server.go:1096 +0xc6f
  gosched0()
      /usr/local/go/src/pkg/runtime/proc.c:1218 +0x9f

Previous write by goroutine 139:
  github.com/cloudfoundry/gorouter/common.(*ProcessStatus).Update()
      /Users/jackfeng/go/src/github.com/cloudfoundry/gorouter/common/process_status.go:47 +0xca
  github.com/cloudfoundry/gorouter/common.func·006()
      /Users/jackfeng/go/src/github.com/cloudfoundry/gorouter/common/process_status.go:31 +0xa0
  gosched0()
      /usr/local/go/src/pkg/runtime/proc.c:1218 +0x9f

Goroutine 148 (running) created at:
  net/http.(_Server).Serve()
      /usr/local/go/src/pkg/net/http/server.go:1564 +0x29c
  net/http.(_Server).ListenAndServe()
      /usr/local/go/src/pkg/net/http/server.go:1532 +0xbe
  github.com/cloudfoundry/gorouter/common.(*VcapComponent).ListenAndServe()
      /Users/jackfeng/go/src/github.com/cloudfoundry/gorouter/common/component.go:169 +0x59b
  gosched0()
      /usr/local/go/src/pkg/runtime/proc.c:1218 +0x9f
# 
# 

And this is the error which led to the fixes on registry.go:
# 

WARNING: DATA RACE
Write by goroutine 9:
  github.com/cloudfoundry/gorouter/registry.(_CFRegistry).pauseStaleTracker()
      /Users/jackfeng/go/src/github.com/cloudfoundry/gorouter/registry/registry.go:208 +0xd8
  github.com/cloudfoundry/gorouter/registry.(_CFRegistry).PruneStaleDroplets()
      /Users/jackfeng/go/src/github.com/cloudfoundry/gorouter/registry/registry.go:147 +0x66
  github.com/cloudfoundry/gorouter/registry.(*CFRegistry).checkAndPrune()
      /Users/jackfeng/go/src/github.com/cloudfoundry/gorouter/registry/registry.go:222 +0xcc
  gosched0()
      /usr/local/go/src/pkg/runtime/proc.c:1218 +0x9f

Previous write by goroutine 39:
  github.com/cloudfoundry/gorouter/registry.(*CFRegistry).Register()
      /Users/jackfeng/go/src/github.com/cloudfoundry/gorouter/registry/registry.go:91 +0x2ff
  github.com/cloudfoundry/gorouter/router.func·003()
      /Users/jackfeng/go/src/github.com/cloudfoundry/gorouter/router/router.go:175 +0x39f
  github.com/cloudfoundry/gorouter/router.func·007()
      /Users/jackfeng/go/src/github.com/cloudfoundry/gorouter/router/router.go:281 +0x689
  gosched0()
      /usr/local/go/src/pkg/runtime/proc.c:1218 +0x9f
