### PR TITLE
Handle comma-seperated Connection header

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -309,12 +309,15 @@ func isTcpUpgrade(request *http.Request) bool {
 }
 
 func upgradeHeader(request *http.Request) string {
-	// upgrade should be case insensitive per RFC6455 4.2.1
-	if strings.ToLower(request.Header.Get("Connection")) == "upgrade" {
-		return request.Header.Get("Upgrade")
-	} else {
-		return ""
+	// handle multiple Connection field-values, either in a comma-separated string or multiple field-headers
+	for _, v := range request.Header[http.CanonicalHeaderKey("Connection")] {
+		// upgrade should be case insensitive per RFC6455 4.2.1
+		if strings.Contains(strings.ToLower(v), "upgrade") {
+			return request.Header.Get("Upgrade")
+		}
 	}
+
+	return ""
 }
 
 func setTraceHeaders(responseWriter http.ResponseWriter, routerIp, addr string) {


### PR DESCRIPTION
Specifically in the case of Firefox where the client sends multiple values in a comma-seperated format for the Connection header (ie. "Connection: keep-alive, Upgrade"). This was preventing Firefox (tested on v28) from properly connecting to servies which provide a websocket endpoint, while other browsers (ie. Chrome) were able to connect.

Reference: http://tools.ietf.org/html/rfc2616#section-4.2

Quote:

 Multiple message-header fields with the same field-name MAY be
   present in a message if and only if the entire field-value for that
   header field is defined as a comma-separated list [i.e., #(values)].
   It MUST be possible to combine the multiple header fields into one
   "field-name: field-value" pair, without changing the semantics of the
   message, by appending each subsequent field-value to the first, each
   separated by a comma. The order in which header fields with the same
   field-name are received is therefore significant to the
   interpretation of the combined field value, and thus a proxy MUST NOT
   change the order of these field values when a message is forwarded.
