### PR TITLE
Use component's uuid as GreetMessage's uuid

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -251,13 +251,8 @@ func (r *Router) greetMessage() ([]byte, error) {
 		return nil, err
 	}
 
-	uuid, err := vcap.GenerateUUID()
-	if err != nil {
-		return nil, err
-	}
-
 	d := vcap.RouterStart{
-		Id:    uuid,
+		Id:    r.component.UUID,
 		Hosts: []string{host},
 		MinimumRegisterIntervalInSeconds: r.config.StartResponseDelayIntervalInSeconds,
 	}


### PR DESCRIPTION
Fix for issue #42 GreetMessage's uuid should use component's uuid
