### PR TITLE
Assert that "StartResponseDelayInterval" cannot be greater than "DropletStaleThreshold"

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"github.com/cloudfoundry-incubator/candiedyaml"
 	vcap "github.com/cloudfoundry/gorouter/common"
+	steno "github.com/cloudfoundry/gosteno"
 
 	"io/ioutil"
 	"time"
@@ -103,6 +104,8 @@ var defaultConfig = Config{
 	StartResponseDelayIntervalInSeconds:  5,
 }
 
+var log = steno.NewLogger("config.logger")
+
 func DefaultConfig() *Config {
 	c := defaultConfig
 
@@ -119,6 +122,11 @@ func (c *Config) Process() {
 	c.PublishActiveAppsInterval = time.Duration(c.PublishActiveAppsIntervalInSeconds) * time.Second
 	c.StartResponseDelayInterval = time.Duration(c.StartResponseDelayIntervalInSeconds) * time.Second
 	c.EndpointTimeout = time.Duration(c.EndpointTimeoutInSeconds) * time.Second
+
+	if c.StartResponseDelayInterval > c.DropletStaleThreshold {
+		c.DropletStaleThreshold = c.StartResponseDelayInterval
+		log.Warnf("DropletStaleThreshold(%s) is set equal to StartResponseDelayInterval(%s)", c.DropletStaleThreshold, c.StartResponseDelayInterval)
+	}
 
 	drain := c.DrainTimeoutInSeconds
 	if drain == 0 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -122,7 +122,7 @@ access_log: "/tmp/access_log"
 			var b = []byte(`
 publish_start_message_interval: 1
 prune_stale_droplets_interval: 2
-droplet_stale_threshold: 3
+droplet_stale_threshold: 30
 publish_active_apps_interval: 4
 start_response_delay_interval: 15
 `)
@@ -132,9 +132,24 @@ start_response_delay_interval: 15
 
 			Ω(config.PublishStartMessageIntervalInSeconds).To(Equal(1))
 			Ω(config.PruneStaleDropletsInterval).To(Equal(2 * time.Second))
-			Ω(config.DropletStaleThreshold).To(Equal(3 * time.Second))
+			Ω(config.DropletStaleThreshold).To(Equal(30 * time.Second))
 			Ω(config.PublishActiveAppsInterval).To(Equal(4 * time.Second))
 			Ω(config.StartResponseDelayInterval).To(Equal(15 * time.Second))
+		})
+
+		Context("When StartResponseDelayInterval is greater than DropletStaleThreshold", func() {
+			It("set DropletStaleThreshold equal to StartResponseDelayInterval", func() {
+				var b = []byte(`
+droplet_stale_threshold: 14
+start_response_delay_interval: 15
+`)
+
+				config.Initialize(b)
+				config.Process()
+
+				Ω(config.DropletStaleThreshold).To(Equal(15 * time.Second))
+				Ω(config.StartResponseDelayInterval).To(Equal(15 * time.Second))
+			})
 		})
 
 		Describe("Timeout", func() {


### PR DESCRIPTION
When StartResponseDelayInterval > DropletStaleThreshold, routers will be invalid in some time, so add a validation.

Issue: https://github.com/cloudfoundry/gorouter/issues/43
