### PR TITLE
Use pre-defined const value `ActiveAppsTrimInterval` intead of `1*time.Minute` 

### DIFF
--- a/stats/active_apps.go
+++ b/stats/active_apps.go
@@ -92,7 +92,7 @@ type ActiveApps struct {
 func NewActiveApps() *ActiveApps {
 	x := &ActiveApps{}
 
-	x.t = time.NewTicker(1 * time.Minute)
+	x.t = time.NewTicker(ActiveAppsTrimInterval)
 
 	x.m = make(map[string]*activeAppsEntry)
 	x.i.Init()


### PR DESCRIPTION
in `NewActiveApps`

There is a const value [ActiveAppsTrimInterval](https://github.com/cloudfoundry/gorouter/blob/master/stats/active_apps.go#L10) defined but no one use it. Actually, it should be used in [NewActiveApps](https://github.com/cloudfoundry/gorouter/blob/master/stats/active_apps.go#L95) to replace the magic number `1*time.Minute` there.
