### PR TITLE
Fix the bug caused by the callback in loop

### DIFF
--- a/common/component.go
+++ b/common/component.go
@@ -166,13 +166,14 @@ func (c *VcapComponent) ListenAndServe() {
 	})
 
 	for path, marshaler := range c.InfoRoutes {
+		m := marshaler
 		hs.HandleFunc(path, func(w http.ResponseWriter, req *http.Request) {
 			w.Header().Set("Connection", "close")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 
 			enc := json.NewEncoder(w)
-			enc.Encode(marshaler)
+			enc.Encode(m)
 		})
 	}
 

--- a/common/component_test.go
+++ b/common/component_test.go
@@ -57,6 +57,35 @@ var _ = Describe("Component", func() {
 		Ω(code).Should(Equal(401))
 	})
 
+	It("allows set multiple info routes", func() {
+		path1 := "/test1"
+		path2 := "/test2"
+		
+		component.InfoRoutes = map[string]json.Marshaler{
+			path1: &MarshalableValue{Value: map[string]string{"key": "value1"}},
+			path2: &MarshalableValue{Value: map[string]string{"key": "value2"}},
+		}
+		serveComponent(component)
+		
+		//access path1
+		req := buildGetRequest(component, path1)
+		req.SetBasicAuth("username", "password")
+
+		code, header, body := doGetRequest(req)
+		Ω(code).Should(Equal(200))
+		Ω(header.Get("Content-Type")).Should(Equal("application/json"))
+		Ω(body).Should(Equal(`{"key":"value1"}` + "\n"))
+
+		//access path2
+		req = buildGetRequest(component, path2)
+		req.SetBasicAuth("username", "password")
+
+		code, header, body = doGetRequest(req)
+		Ω(code).Should(Equal(200))
+		Ω(header.Get("Content-Type")).Should(Equal("application/json"))
+		Ω(body).Should(Equal(`{"key":"value2"}` + "\n"))
+	})
+	
 	It("allows authorized access", func() {
 		path := "/test"
 


### PR DESCRIPTION
When we added more routes into `c.InfoRoutes`, we found all the callbacks set in `hs.HandleFunc` were using the same `marshaler` value of the last one in `c.InfoRoutes`. The reason is that the life scope of `marshaler` is the for-loop, so actually all the callbacks use the same one `marshaler`. This [link](http://tobyho.com/2011/11/02/callbacks-in-loops/) may explain it well even it's not golang (Javascript).

To fix this issue, we can put callbacks outside of the loop and then the correct `marshaler` value can be passed into it.
**Update**: Using a local variable is another simpler way. Thanks @fraenkel :-)
