### PR TITLE
Fix for command line argument for debugAddr

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,10 +48,13 @@ func main() {
 		runtime.GOMAXPROCS(c.GoMaxProcs)
 	}
 
+	// If config contains a Debug Address we set on debug server
 	if c.DebugAddr != "" {
 		cf_debug_server.SetAddr(c.DebugAddr)
-		cf_debug_server.Run()
 	}
+	// CF Debug attempt to parse flag for "debugAddr" if not set above.
+	// If neither is present then it returns without starting debug server.
+	cf_debug_server.Run()
 
 	InitLoggerFromConfig(c, logCounter)
 	logger := steno.NewLogger("router.main")


### PR DESCRIPTION
The `cf_debug_server` parses flag for `-debugAddr="": host:port for serving pprof debugging info`. Since this is using flag it prints under running the gorouter binary as `cf_debug_server` is loaded in main.go.
This does not work as the existing main.go code **only** calls `cf_debug_server` if DebugAddr is passed as part of config.

This fix uses the config value first and falls back to allow cf_debug_server to use the debugAddr argument. In the case of both missing a cf_debug_server is not started.

I am an Intel employee and should be covered under the existing Intel CLA.
