### PR TITLE
Adjust VCAP_ID as endpoint/sticky cookie changes

### DIFF
--- a/proxy/proxy_suite_test.go
+++ b/proxy/proxy_suite_test.go
@@ -1,13 +1,95 @@
 package proxy_test
 
 import (
+	"net"
+	"net/http"
+
+	"github.com/cloudfoundry/dropsonde"
+	"github.com/cloudfoundry/dropsonde/emitter/fake"
+	"github.com/cloudfoundry/gorouter/access_log"
+	"github.com/cloudfoundry/gorouter/config"
+	"github.com/cloudfoundry/gorouter/proxy"
+	"github.com/cloudfoundry/gorouter/registry"
+	"github.com/cloudfoundry/gorouter/test_util"
+	"github.com/cloudfoundry/yagnats/fakeyagnats"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"testing"
+	"time"
+)
+
+var (
+	r             *registry.RouteRegistry
+	p             proxy.Proxy
+	conf          *config.Config
+	proxyServer   net.Listener
+	accessLog     access_log.AccessLogger
+	accessLogFile *test_util.FakeFile
 )
 
 func TestProxy(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Proxy Suite")
+}
+
+var _ = BeforeEach(func() {
+	conf = config.DefaultConfig()
+	conf.TraceKey = "my_trace_key"
+	conf.EndpointTimeout = 500 * time.Millisecond
+})
+
+var _ = JustBeforeEach(func() {
+	mbus := fakeyagnats.Connect()
+	r = registry.NewRouteRegistry(conf, mbus)
+
+	fakeEmitter := fake.NewFakeEventEmitter("fake")
+	dropsonde.InitializeWithEmitter(fakeEmitter)
+
+	accessLogFile = new(test_util.FakeFile)
+	accessLog = access_log.NewFileAndLoggregatorAccessLogger(accessLogFile, "")
+	go accessLog.Run()
+
+	p = proxy.NewProxy(proxy.ProxyArgs{
+		EndpointTimeout: conf.EndpointTimeout,
+		Ip:              conf.Ip,
+		TraceKey:        conf.TraceKey,
+		Registry:        r,
+		Reporter:        nullVarz{},
+		AccessLogger:    accessLog,
+		SecureCookies:   conf.SecureCookies,
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	Ω(err).NotTo(HaveOccurred())
+
+	server := http.Server{Handler: p}
+	go server.Serve(ln)
+
+	proxyServer = ln
+})
+
+var _ = AfterEach(func() {
+	proxyServer.Close()
+	accessLog.Stop()
+})
+
+func shouldEcho(input string, expected string) {
+	ln := registerHandler(r, "encoding", func(x *test_util.HttpConn) {
+		x.CheckLine("GET " + expected + " HTTP/1.1")
+		resp := test_util.NewResponse(http.StatusOK)
+		x.WriteResponse(resp)
+		x.Close()
+	})
+	defer ln.Close()
+
+	x := dialProxy(proxyServer)
+
+	req := test_util.NewRequest("GET", input, nil)
+	req.Host = "encoding"
+	x.WriteRequest(req)
+	resp, _ := x.ReadResponse()
+
+	Ω(resp.StatusCode).To(Equal(http.StatusOK))
 }

--- a/proxy/session_affinity_test.go
+++ b/proxy/session_affinity_test.go
@@ -1,0 +1,252 @@
+package proxy_test
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/cloudfoundry/gorouter/proxy"
+	"github.com/cloudfoundry/gorouter/test_util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Session Affinity", func() {
+	var done chan bool
+	var jSessionIdCookie *http.Cookie
+
+	responseNoCookies := func(x *test_util.HttpConn) {
+		_, err := http.ReadRequest(x.Reader)
+		Ω(err).NotTo(HaveOccurred())
+
+		resp := test_util.NewResponse(http.StatusOK)
+		x.WriteResponse(resp)
+		x.Close()
+		done <- true
+	}
+
+	responseWithJSessionID := func(x *test_util.HttpConn) {
+		_, err := http.ReadRequest(x.Reader)
+		Ω(err).NotTo(HaveOccurred())
+
+		resp := test_util.NewResponse(http.StatusOK)
+		resp.Header.Add("Set-Cookie", jSessionIdCookie.String())
+		x.WriteResponse(resp)
+		x.Close()
+		done <- true
+	}
+
+	BeforeEach(func() {
+		done = make(chan bool)
+		conf.SecureCookies = false
+
+		jSessionIdCookie = &http.Cookie{
+			Name:    proxy.StickyCookieKey,
+			Value:   "xxx",
+			MaxAge:  1,
+			Expires: time.Now(),
+		}
+	})
+
+	Context("first request", func() {
+		Context("when the response does not contain a JESSIONID cookie", func() {
+			It("does not respond with a VCAP_ID cookie", func() {
+				ln := registerHandlerWithInstanceId(r, "app", responseNoCookies, "my-id")
+				defer ln.Close()
+
+				x := dialProxy(proxyServer)
+				req := test_util.NewRequest("GET", "/", nil)
+				req.Host = "app"
+				x.WriteRequest(req)
+
+				Eventually(done).Should(Receive())
+
+				resp, _ := x.ReadResponse()
+				Ω(getCookie(proxy.VcapCookieId, resp.Cookies())).Should(BeNil())
+			})
+		})
+
+		Context("when the response contains a JESSIONID cookie", func() {
+			It("responds with a VCAP_ID cookie scoped to the session", func() {
+				ln := registerHandlerWithInstanceId(r, "app", responseWithJSessionID, "my-id")
+				defer ln.Close()
+
+				x := dialProxy(proxyServer)
+				req := test_util.NewRequest("GET", "/", nil)
+				req.Host = "app"
+				x.WriteRequest(req)
+
+				Eventually(done).Should(Receive())
+
+				resp, _ := x.ReadResponse()
+				jsessionId := getCookie(proxy.StickyCookieKey, resp.Cookies())
+				Ω(jsessionId).ShouldNot(BeNil())
+
+				cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+				Ω(cookie).ShouldNot(BeNil())
+				Ω(cookie.Value).Should(Equal("my-id"))
+				Ω(cookie.Secure).Should(BeFalse())
+				Ω(cookie.MaxAge).Should(BeZero())
+				Ω(cookie.Expires).Should(BeZero())
+			})
+
+			Context("with secure cookies enabled", func() {
+				BeforeEach(func() {
+					conf.SecureCookies = true
+				})
+
+				It("marks the cookie as secure only", func() {
+					ln := registerHandlerWithInstanceId(r, "app", responseWithJSessionID, "my-id")
+					defer ln.Close()
+
+					x := dialProxy(proxyServer)
+					req := test_util.NewRequest("GET", "/", nil)
+					req.Host = "app"
+					x.WriteRequest(req)
+
+					Eventually(done).Should(Receive())
+
+					resp, _ := x.ReadResponse()
+					jsessionId := getCookie(proxy.StickyCookieKey, resp.Cookies())
+					Ω(jsessionId).ShouldNot(BeNil())
+
+					cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+					Ω(cookie).ShouldNot(BeNil())
+					Ω(cookie.Value).Should(Equal("my-id"))
+					Ω(cookie.Secure).Should(BeTrue())
+					Ω(cookie.MaxAge).Should(BeZero())
+					Ω(cookie.Expires).Should(BeZero())
+				})
+			})
+		})
+	})
+
+	Context("subsequent requests", func() {
+		const host = "app"
+		var req *http.Request
+
+		BeforeEach(func() {
+			cookie := &http.Cookie{
+				Name:  proxy.VcapCookieId,
+				Value: "my-id",
+				Path:  "/",
+
+				HttpOnly: true,
+				Secure:   false,
+			}
+
+			req = test_util.NewRequest("GET", "/", nil)
+			req.Host = host
+			req.AddCookie(cookie)
+
+			jSessionIdCookie := &http.Cookie{
+				Name:  proxy.StickyCookieKey,
+				Value: "xxx",
+			}
+			req.AddCookie(jSessionIdCookie)
+		})
+
+		Context("when the response does not contain a JESSIONID cookie", func() {
+			It("does not respond with a VCAP_ID cookie", func() {
+				ln := registerHandlerWithInstanceId(r, host, responseNoCookies, "my-id")
+				defer ln.Close()
+
+				x := dialProxy(proxyServer)
+
+				x.WriteRequest(req)
+
+				Eventually(done).Should(Receive())
+
+				resp, _ := x.ReadResponse()
+				Ω(getCookie(proxy.StickyCookieKey, resp.Cookies())).Should(BeNil())
+				Ω(getCookie(proxy.VcapCookieId, resp.Cookies())).Should(BeNil())
+			})
+
+			Context("when the preferred server is gone", func() {
+				It("updates the VCAP_ID with the new server", func() {
+					ln := registerHandlerWithInstanceId(r, host, responseNoCookies, "other-id")
+					defer ln.Close()
+
+					x := dialProxy(proxyServer)
+
+					x.WriteRequest(req)
+
+					Eventually(done).Should(Receive())
+
+					resp, _ := x.ReadResponse()
+					cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+					Ω(cookie).ShouldNot(BeNil())
+					Ω(cookie.Value).Should(Equal("other-id"))
+					Ω(cookie.Secure).Should(BeFalse())
+					Ω(cookie.MaxAge).Should(BeZero())
+					Ω(cookie.Expires).Should(BeZero())
+				})
+			})
+		})
+
+		Context("when the response contains a JESSIONID cookie", func() {
+			It("responds with a VCAP_ID cookie", func() {
+				ln := registerHandlerWithInstanceId(r, "app", responseWithJSessionID, "some-id")
+				defer ln.Close()
+
+				x := dialProxy(proxyServer)
+				req := test_util.NewRequest("GET", "/", nil)
+				req.Host = "app"
+				x.WriteRequest(req)
+
+				Eventually(done).Should(Receive())
+
+				resp, _ := x.ReadResponse()
+				jsessionId := getCookie(proxy.StickyCookieKey, resp.Cookies())
+				Ω(jsessionId).ShouldNot(BeNil())
+
+				cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+				Ω(cookie).ShouldNot(BeNil())
+				Ω(cookie.Value).Should(Equal("some-id"))
+				Ω(cookie.Secure).Should(BeFalse())
+				Ω(cookie.MaxAge).Should(BeZero())
+				Ω(cookie.Expires).Should(BeZero())
+			})
+
+			Context("when the JSESSIONID is expired", func() {
+				BeforeEach(func() {
+					jSessionIdCookie.MaxAge = -1
+				})
+
+				It("expires the VCAP_ID", func() {
+					ln := registerHandlerWithInstanceId(r, "app", responseWithJSessionID, "my-id")
+					defer ln.Close()
+
+					x := dialProxy(proxyServer)
+					req := test_util.NewRequest("GET", "/", nil)
+					req.Host = "app"
+					x.WriteRequest(req)
+
+					Eventually(done).Should(Receive())
+
+					resp, _ := x.ReadResponse()
+					jsessionId := getCookie(proxy.StickyCookieKey, resp.Cookies())
+					Ω(jsessionId).ShouldNot(BeNil())
+					Ω(jsessionId.MaxAge).Should(Equal(-1))
+
+					cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+					Ω(cookie).ShouldNot(BeNil())
+					Ω(cookie.Value).Should(Equal("my-id"))
+					Ω(cookie.Secure).Should(BeFalse())
+					Ω(cookie.MaxAge).Should(Equal(-1))
+					Ω(cookie.Expires).Should(BeZero())
+				})
+			})
+		})
+	})
+})
+
+func getCookie(name string, cookies []*http.Cookie) *http.Cookie {
+	for _, c := range cookies {
+		if c.Name == name {
+			return c
+		}
+	}
+
+	return nil
+}

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -615,7 +615,7 @@ var _ = Describe("Router", func() {
 
 			x := test_util.NewHttpConn(conn)
 
-			req := x.NewRequest("GET", "/chat", nil)
+			req := test_util.NewRequest("GET", "/chat", nil)
 			req.Host = "ws-app.vcap.me"
 			req.Header.Set("Upgrade", "websocket")
 			req.Header.Set("Connection", "upgrade")

--- a/test_util/http_conn.go
+++ b/test_util/http_conn.go
@@ -1,16 +1,16 @@
 package test_util
 
 import (
+	"io"
 	"io/ioutil"
-	"net/url"
 	"strings"
 
 	. "github.com/onsi/gomega"
 
 	"bufio"
-	"io"
 	"net"
 	"net/http"
+	"net/url"
 )
 
 type HttpConn struct {
@@ -36,13 +36,6 @@ func (x *HttpConn) ReadRequest() (*http.Request, string) {
 	Ω(err).NotTo(HaveOccurred())
 
 	return req, string(b)
-}
-
-func (x *HttpConn) NewRequest(method, urlStr string, body io.Reader) *http.Request {
-	req, err := http.NewRequest(method, urlStr, body)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	req.URL = &url.URL{Host: req.URL.Host, Opaque: urlStr}
-	return req
 }
 
 func (x *HttpConn) WriteRequest(req *http.Request) {
@@ -102,4 +95,11 @@ func (x *HttpConn) WriteLines(lines []string) {
 	}
 
 	x.WriteLine("")
+}
+
+func NewRequest(method, urlStr string, body io.Reader) *http.Request {
+	req, err := http.NewRequest(method, urlStr, body)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	req.URL = &url.URL{Host: req.URL.Host, Opaque: urlStr}
+	return req
 }


### PR DESCRIPTION
Handle missing endpoints on subsequent requests.
Handle when the JSESSIONID is deleted

[#79046748]