### PR TITLE
Add job_name to component.announce messages

### DIFF
--- a/common/component.go
+++ b/common/component.go
@@ -22,6 +22,7 @@ type VcapComponent struct {
 	// These fields are from individual components
 	Type        string                    `json:"type"`
 	Index       uint                      `json:"index"`
+	JobName     string                    `json:"job_name,omitempty"`
 	Host        string                    `json:"host"`
 	Credentials []string                  `json:"credentials"`
 	Config      interface{}               `json:"-"`

--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,7 @@ type Config struct {
 
 	Port           uint16 `yaml:"port"`
 	Index          uint   `yaml:"index"`
+	Name           string `yaml:"name"`
 	Zone           string `yaml:"zone"`
 	GoMaxProcs     int    `yaml:"go_max_procs,omitempty"`
 	TraceKey       string `yaml:"trace_key"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -105,6 +105,7 @@ trace_key: "foo"
 access_log: "/tmp/access_log"
 ssl_port: 4443
 enable_ssl: true
+name: router_z1
 `)
 
 			config.Initialize(b)
@@ -116,6 +117,7 @@ enable_ssl: true
 			Ω(config.AccessLog).To(Equal("/tmp/access_log"))
 			Ω(config.EnableSSL).To(Equal(true))
 			Ω(config.SSLPort).To(Equal(uint16(4443)))
+			Ω(config.Name).To(Equal("router_z1"))
 		})
 
 		It("sets the Routing Api config", func() {

--- a/router/router.go
+++ b/router/router.go
@@ -69,6 +69,7 @@ func NewRouter(cfg *config.Config, p proxy.Proxy, mbusClient yagnats.NATSConn, r
 	component := &vcap.VcapComponent{
 		Type:        "Router",
 		Index:       cfg.Index,
+		JobName:     cfg.Name,
 		Host:        host,
 		Credentials: []string{cfg.Status.User, cfg.Status.Pass},
 		Config:      cfg,


### PR DESCRIPTION
If the property 'name' in the config is empty, the message stays the same.