### PR TITLE
Fixes go get github.com/cloudfoundry/gorouter error

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 	}
 
 	if c.DebugAddr != "" {
-		cf_debug_server.Run(c.DebugAddr)
+		cf_debug_server.Run(c.DebugAddr, nil)
 	}
 
 	natsServers := c.NatsServers()


### PR DESCRIPTION
go get -v github.com/cloudfoundry/gorouter returns the following error:

$GOPATH/src/github.com/cloudfoundry/gorouter/main.go:60: not enough arguments in call to cf_debug_server.Run

The nil value fixes the default sink to be nil, but I am assuming there is more that needs to change.