### PR TITLE
Remove per-app metrics by updating Dropsonde

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -33,7 +33,7 @@
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry/dropsonde",
-			"Rev": "0afd306c305053e4cf1a90e9b58eb24cb1f126b5"
+			"Rev": "bcd67f4b34b7f744b9dc9bc0a0e1a228e3b24cd1"
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry/gosteno",
@@ -63,7 +63,7 @@
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/proto",
-			"Rev": "bc946d07d1016848dfd2507f90f0859c9471681e"
+			"Rev": "b9e369e8ffb6773efc654ea13594566404314ee1"
 		},
 		{
 			"ImportPath": "github.com/nu7hatch/gouuid",

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/.travis.yml
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/.travis.yml
@@ -16,11 +16,9 @@ after_success:
 install:
 - go get -d -v -t ./...
 
-script: PATH=$HOME/gopath/bin:$PATH ./test
+script: PATH=$HOME/gopath/bin:$PATH ./bin/test
 
 go:
-- 1.2
-- 1.3
 - 1.4
 - tip
 

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/bin/test
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/bin/test
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=`dirname $0`
+cd ${SCRIPT_DIR}/..
+
+echo "Go formatting..."
+go fmt ./...
+
+echo "Go vetting..."
+go vet ./...
+
+echo "Recursive ginkgo... ${*:+(with parameter(s) }$*${*:+)}"
+ginkgo -r --race --randomizeAllSpecs --failOnPending -cover $*

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/control/controlmessage.pb.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/control/controlmessage.pb.go
@@ -18,6 +18,12 @@ package control
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import io "io"
+import fmt "fmt"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = math.Inf
@@ -104,4 +110,307 @@ func (m *ControlMessage) GetHeartbeatRequest() *HeartbeatRequest {
 
 func init() {
 	proto.RegisterEnum("control.ControlMessage_ControlType", ControlMessage_ControlType_name, ControlMessage_ControlType_value)
+}
+func (m *ControlMessage) Unmarshal(data []byte) error {
+	var hasFields [1]uint64
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Origin", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Origin = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000001)
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Identifier", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Identifier == nil {
+				m.Identifier = &UUID{}
+			}
+			if err := m.Identifier.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+			hasFields[0] |= uint64(0x00000002)
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Timestamp = &v
+			hasFields[0] |= uint64(0x00000004)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ControlType", wireType)
+			}
+			var v ControlMessage_ControlType
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (ControlMessage_ControlType(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.ControlType = &v
+			hasFields[0] |= uint64(0x00000008)
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HeartbeatRequest", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.HeartbeatRequest == nil {
+				m.HeartbeatRequest = &HeartbeatRequest{}
+			}
+			if err := m.HeartbeatRequest.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	if hasFields[0]&uint64(0x00000001) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("origin")
+	}
+	if hasFields[0]&uint64(0x00000002) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("identifier")
+	}
+	if hasFields[0]&uint64(0x00000004) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("timestamp")
+	}
+	if hasFields[0]&uint64(0x00000008) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("controlType")
+	}
+
+	return nil
+}
+func (m *ControlMessage) Size() (n int) {
+	var l int
+	_ = l
+	if m.Origin != nil {
+		l = len(*m.Origin)
+		n += 1 + l + sovControlmessage(uint64(l))
+	}
+	if m.Identifier != nil {
+		l = m.Identifier.Size()
+		n += 1 + l + sovControlmessage(uint64(l))
+	}
+	if m.Timestamp != nil {
+		n += 1 + sovControlmessage(uint64(*m.Timestamp))
+	}
+	if m.ControlType != nil {
+		n += 1 + sovControlmessage(uint64(*m.ControlType))
+	}
+	if m.HeartbeatRequest != nil {
+		l = m.HeartbeatRequest.Size()
+		n += 1 + l + sovControlmessage(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func sovControlmessage(x uint64) (n int) {
+	for {
+		n++
+		x >>= 7
+		if x == 0 {
+			break
+		}
+	}
+	return n
+}
+func sozControlmessage(x uint64) (n int) {
+	return sovControlmessage(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *ControlMessage) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ControlMessage) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Origin == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("origin")
+	} else {
+		data[i] = 0xa
+		i++
+		i = encodeVarintControlmessage(data, i, uint64(len(*m.Origin)))
+		i += copy(data[i:], *m.Origin)
+	}
+	if m.Identifier == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("identifier")
+	} else {
+		data[i] = 0x12
+		i++
+		i = encodeVarintControlmessage(data, i, uint64(m.Identifier.Size()))
+		n1, err := m.Identifier.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n1
+	}
+	if m.Timestamp == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("timestamp")
+	} else {
+		data[i] = 0x18
+		i++
+		i = encodeVarintControlmessage(data, i, uint64(*m.Timestamp))
+	}
+	if m.ControlType == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("controlType")
+	} else {
+		data[i] = 0x20
+		i++
+		i = encodeVarintControlmessage(data, i, uint64(*m.ControlType))
+	}
+	if m.HeartbeatRequest != nil {
+		data[i] = 0x2a
+		i++
+		i = encodeVarintControlmessage(data, i, uint64(m.HeartbeatRequest.Size()))
+		n2, err := m.HeartbeatRequest.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n2
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func encodeFixed64Controlmessage(data []byte, offset int, v uint64) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	data[offset+4] = uint8(v >> 32)
+	data[offset+5] = uint8(v >> 40)
+	data[offset+6] = uint8(v >> 48)
+	data[offset+7] = uint8(v >> 56)
+	return offset + 8
+}
+func encodeFixed32Controlmessage(data []byte, offset int, v uint32) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	return offset + 4
+}
+func encodeVarintControlmessage(data []byte, offset int, v uint64) int {
+	for v >= 1<<7 {
+		data[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	data[offset] = uint8(v)
+	return offset + 1
 }

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/control/heartbeatrequest.pb.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/control/heartbeatrequest.pb.go
@@ -7,6 +7,11 @@ package control
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import io "io"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = math.Inf
@@ -21,4 +26,116 @@ func (m *HeartbeatRequest) String() string { return proto.CompactTextString(m) }
 func (*HeartbeatRequest) ProtoMessage()    {}
 
 func init() {
+}
+func (m *HeartbeatRequest) Unmarshal(data []byte) error {
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		switch fieldNum {
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+
+	return nil
+}
+func (m *HeartbeatRequest) Size() (n int) {
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func sovHeartbeatrequest(x uint64) (n int) {
+	for {
+		n++
+		x >>= 7
+		if x == 0 {
+			break
+		}
+	}
+	return n
+}
+func sozHeartbeatrequest(x uint64) (n int) {
+	return sovHeartbeatrequest(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *HeartbeatRequest) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *HeartbeatRequest) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func encodeFixed64Heartbeatrequest(data []byte, offset int, v uint64) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	data[offset+4] = uint8(v >> 32)
+	data[offset+5] = uint8(v >> 40)
+	data[offset+6] = uint8(v >> 48)
+	data[offset+7] = uint8(v >> 56)
+	return offset + 8
+}
+func encodeFixed32Heartbeatrequest(data []byte, offset int, v uint32) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	return offset + 4
+}
+func encodeVarintHeartbeatrequest(data []byte, offset int, v uint64) int {
+	for v >= 1<<7 {
+		data[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	data[offset] = uint8(v)
+	return offset + 1
 }

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/control/uuid.pb.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/control/uuid.pb.go
@@ -7,11 +7,19 @@ package control
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import io "io"
+import fmt "fmt"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = math.Inf
 
 // / Type representing a 128-bit UUID.
+//
+// The bytes of the UUID should be packed in little-endian **byte** (not bit) order. For example, the UUID `f47ac10b-58cc-4372-a567-0e02b2c3d479` should be encoded as `UUID{ low: 0x7243cc580bc17af4, high: 0x79d4c3b2020e67a5 }`
 type UUID struct {
 	Low              *uint64 `protobuf:"varint,1,req,name=low" json:"low,omitempty"`
 	High             *uint64 `protobuf:"varint,2,req,name=high" json:"high,omitempty"`
@@ -37,4 +45,180 @@ func (m *UUID) GetHigh() uint64 {
 }
 
 func init() {
+}
+func (m *UUID) Unmarshal(data []byte) error {
+	var hasFields [1]uint64
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Low", wireType)
+			}
+			var v uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Low = &v
+			hasFields[0] |= uint64(0x00000001)
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field High", wireType)
+			}
+			var v uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.High = &v
+			hasFields[0] |= uint64(0x00000002)
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	if hasFields[0]&uint64(0x00000001) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("low")
+	}
+	if hasFields[0]&uint64(0x00000002) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("high")
+	}
+
+	return nil
+}
+func (m *UUID) Size() (n int) {
+	var l int
+	_ = l
+	if m.Low != nil {
+		n += 1 + sovUuid(uint64(*m.Low))
+	}
+	if m.High != nil {
+		n += 1 + sovUuid(uint64(*m.High))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func sovUuid(x uint64) (n int) {
+	for {
+		n++
+		x >>= 7
+		if x == 0 {
+			break
+		}
+	}
+	return n
+}
+func sozUuid(x uint64) (n int) {
+	return sovUuid(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *UUID) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *UUID) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Low == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("low")
+	} else {
+		data[i] = 0x8
+		i++
+		i = encodeVarintUuid(data, i, uint64(*m.Low))
+	}
+	if m.High == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("high")
+	} else {
+		data[i] = 0x10
+		i++
+		i = encodeVarintUuid(data, i, uint64(*m.High))
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func encodeFixed64Uuid(data []byte, offset int, v uint64) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	data[offset+4] = uint8(v >> 32)
+	data[offset+5] = uint8(v >> 40)
+	data[offset+6] = uint8(v >> 48)
+	data[offset+7] = uint8(v >> 56)
+	return offset + 8
+}
+func encodeFixed32Uuid(data []byte, offset int, v uint32) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	return offset + 4
+}
+func encodeVarintUuid(data []byte, offset int, v uint64) int {
+	for v >= 1<<7 {
+		data[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	data[offset] = uint8(v)
+	return offset + 1
 }

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_marshaller/dropsonde_marshaller.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_marshaller/dropsonde_marshaller.go
@@ -16,13 +16,14 @@
 package dropsonde_marshaller
 
 import (
+	"sync/atomic"
+	"unicode"
+
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/gosteno"
 	"github.com/cloudfoundry/loggregatorlib/cfcomponent/instrumentation"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gogo/protobuf/proto"
-	"sync/atomic"
-	"unicode"
 )
 
 // A DropsondeMarshaller is an self-instrumenting tool for converting dropsonde

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller/dropsonde_unmarshaller.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller/dropsonde_unmarshaller.go
@@ -16,14 +16,16 @@
 package dropsonde_unmarshaller
 
 import (
+	"sync"
+	"sync/atomic"
+	"unicode"
+
 	"github.com/cloudfoundry/dropsonde/events"
+	"github.com/cloudfoundry/dropsonde/metrics"
 	"github.com/cloudfoundry/gosteno"
 	"github.com/cloudfoundry/loggregatorlib/cfcomponent/instrumentation"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gogo/protobuf/proto"
-	"sync"
-	"sync/atomic"
-	"unicode"
 )
 
 // A DropsondeUnmarshaller is an self-instrumenting tool for converting Protocol
@@ -76,6 +78,7 @@ func (u *dropsondeUnmarshaller) UnmarshallMessage(message []byte) (*events.Envel
 	err := proto.Unmarshal(message, envelope)
 	if err != nil {
 		u.logger.Debugf("dropsondeUnmarshaller: unmarshal error %v for message %v", err, message)
+		metrics.BatchIncrementCounter("dropsondeUnmarshaller.unmarshalErrors")
 		incrementCount(&u.unmarshalErrorCount)
 		return nil, err
 	}
@@ -92,6 +95,8 @@ func (u *dropsondeUnmarshaller) UnmarshallMessage(message []byte) (*events.Envel
 }
 
 func (u *dropsondeUnmarshaller) incrementLogMessageReceiveCount(appID string) {
+	metrics.BatchIncrementCounter("dropsondeUnmarshaller.logMessageTotal")
+
 	_, ok := u.logMessageReceiveCounts[appID]
 	if ok == false {
 		var count uint64
@@ -104,6 +109,12 @@ func (u *dropsondeUnmarshaller) incrementLogMessageReceiveCount(appID string) {
 }
 
 func (u *dropsondeUnmarshaller) incrementReceiveCount(eventType events.Envelope_EventType) {
+	modifiedEventName := []rune(eventType.String())
+	modifiedEventName[0] = unicode.ToLower(modifiedEventName[0])
+	metricName := string(modifiedEventName) + "Received"
+
+	metrics.BatchIncrementCounter("dropsondeUnmarshaller." + metricName)
+
 	incrementCount(u.receiveCounts[eventType])
 }
 
@@ -115,15 +126,9 @@ func (u *dropsondeUnmarshaller) metrics() []instrumentation.Metric {
 	var metrics []instrumentation.Metric
 
 	u.RLock()
-	for appID, count := range u.logMessageReceiveCounts {
-		metricValue := atomic.LoadUint64(count)
-		tags := make(map[string]interface{})
-		tags["appId"] = appID
-		metrics = append(metrics, instrumentation.Metric{Name: "logMessageReceived", Value: metricValue, Tags: tags})
-	}
 
 	metricValue := atomic.LoadUint64(u.receiveCounts[events.Envelope_LogMessage])
-	metrics = append(metrics, instrumentation.Metric{Name: "logMessageTotal", Value: metricValue})
+	metrics = append(metrics, instrumentation.Metric{Name: logMessageTotal, Value: metricValue})
 
 	u.RUnlock()
 
@@ -139,7 +144,7 @@ func (u *dropsondeUnmarshaller) metrics() []instrumentation.Metric {
 	}
 
 	metrics = append(metrics, instrumentation.Metric{
-		Name:  "unmarshalErrors",
+		Name:  unmarshalErrors,
 		Value: atomic.LoadUint64(&u.unmarshalErrorCount),
 	})
 

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller/dropsonde_unmarshaller_collection.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller/dropsonde_unmarshaller_collection.go
@@ -1,0 +1,109 @@
+package dropsonde_unmarshaller
+
+import (
+	"github.com/cloudfoundry/dropsonde/events"
+	"github.com/cloudfoundry/gosteno"
+	"github.com/cloudfoundry/loggregatorlib/cfcomponent/instrumentation"
+	"sync"
+)
+
+// A DropsondeUnmarshallerCollection is a collection of DropsondeUnmarshaller instances.
+type DropsondeUnmarshallerCollection interface {
+	instrumentation.Instrumentable
+	Run(inputChan <-chan []byte, outputChan chan<- *events.Envelope, waitGroup *sync.WaitGroup)
+	Size() int
+}
+
+// NewDropsondeUnmarshallerCollection instantiates a DropsondeUnmarshallerCollection,
+// creates the specified number of DropsondeUnmarshaller instances and logs to the
+// provided logger.
+func NewDropsondeUnmarshallerCollection(logger *gosteno.Logger, size int) DropsondeUnmarshallerCollection {
+	var unmarshallers []DropsondeUnmarshaller
+	for i := 0; i < size; i++ {
+		unmarshallers = append(unmarshallers, NewDropsondeUnmarshaller(logger))
+	}
+
+	logger.Debugf("dropsondeUnmarshallerCollection: created %v unmarshallers", size)
+
+	return &dropsondeUnmarshallerCollection{
+		logger:        logger,
+		unmarshallers: unmarshallers,
+	}
+}
+
+type dropsondeUnmarshallerCollection struct {
+	unmarshallers []DropsondeUnmarshaller
+	logger        *gosteno.Logger
+}
+
+// Returns the number of unmarshallers in its collection.
+func (u *dropsondeUnmarshallerCollection) Size() int {
+	return len(u.unmarshallers)
+}
+
+// Run calls Run on each marshaller in its collection.
+// This is done in separate go routines.
+func (u *dropsondeUnmarshallerCollection) Run(inputChan <-chan []byte, outputChan chan<- *events.Envelope, waitGroup *sync.WaitGroup) {
+	for _, unmarshaller := range u.unmarshallers {
+		go func(um DropsondeUnmarshaller) {
+			defer waitGroup.Done()
+			um.Run(inputChan, outputChan)
+		}(unmarshaller)
+	}
+}
+
+// Emit returns the current metrics the DropsondeMarshallerCollection keeps about itself.
+func (u *dropsondeUnmarshallerCollection) Emit() instrumentation.Context {
+	return instrumentation.Context{
+		Name:    "dropsondeUnmarshaller",
+		Metrics: u.metrics(),
+	}
+}
+
+func (u *dropsondeUnmarshallerCollection) metrics() []instrumentation.Metric {
+	var internalMetrics []instrumentation.Metric
+	for _, u := range u.unmarshallers {
+		internalMetrics = append(internalMetrics, u.Emit().Metrics...)
+	}
+
+	metricsByName := make(map[string][]instrumentation.Metric)
+	for _, metric := range internalMetrics {
+		metricsEntry := metricsByName[metric.Name]
+		metricsByName[metric.Name] = append(metricsEntry, metric)
+	}
+
+	var metrics []instrumentation.Metric
+	metrics = concatTotalLogMessages(metricsByName, metrics)
+	metrics = concatOtherEventTypes(metricsByName, metrics)
+
+	return metrics
+}
+
+func concatTotalLogMessages(metricsByName map[string][]instrumentation.Metric, metrics []instrumentation.Metric) []instrumentation.Metric {
+	totalLogs := uint64(0)
+	for _, metric := range metricsByName[logMessageTotal] {
+		totalLogs += metric.Value.(uint64)
+	}
+
+	return append(metrics, instrumentation.Metric{Name: logMessageTotal, Value: totalLogs})
+}
+
+func concatOtherEventTypes(metricsByName map[string][]instrumentation.Metric, metrics []instrumentation.Metric) []instrumentation.Metric {
+	metricsByEventType := make(map[string]uint64)
+
+	for eventType, eventTypeMetrics := range metricsByName {
+		if eventType == logMessageTotal {
+			continue
+		}
+
+		for _, metric := range eventTypeMetrics {
+			metricsByEventType[eventType] += metric.Value.(uint64)
+		}
+	}
+
+	for eventType, count := range metricsByEventType {
+		metrics = append(metrics, instrumentation.Metric{Name: eventType, Value: count})
+	}
+
+	return metrics
+}

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller/dropsonde_unmarshaller_collection_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller/dropsonde_unmarshaller_collection_test.go
@@ -1,0 +1,153 @@
+package dropsonde_unmarshaller_test
+
+import (
+	"github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller"
+	"github.com/cloudfoundry/loggregatorlib/loggertesthelper"
+
+	"fmt"
+	"github.com/cloudfoundry/dropsonde/events"
+	"github.com/cloudfoundry/dropsonde/factories"
+	"github.com/gogo/protobuf/proto"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"runtime"
+	"sync"
+)
+
+var _ = Describe("DropsondeUnmarshallerCollection", func() {
+	var (
+		inputChan  chan []byte
+		outputChan chan *events.Envelope
+		collection dropsonde_unmarshaller.DropsondeUnmarshallerCollection
+		waitGroup  *sync.WaitGroup
+	)
+	BeforeEach(func() {
+		inputChan = make(chan []byte, 10)
+		outputChan = make(chan *events.Envelope, 10)
+		collection = dropsonde_unmarshaller.NewDropsondeUnmarshallerCollection(loggertesthelper.Logger(), 5)
+		waitGroup = &sync.WaitGroup{}
+	})
+
+	Context("DropsondeUnmarshallerCollection", func() {
+		It("creates the right number of unmarshallers", func() {
+			Expect(collection.Size()).To(Equal(5))
+		})
+
+	})
+
+	Context("Run", func() {
+		It("runs its collection of unmarshallers in separate go routines", func() {
+			startingCountGoroutines := runtime.NumGoroutine()
+			collection.Run(inputChan, outputChan, waitGroup)
+			Expect(startingCountGoroutines + 5).To(Equal(runtime.NumGoroutine()))
+		})
+	})
+
+	Context("metrics", func() {
+		It("emits a total log messages concatenated from the different unmarshallers", func() {
+			for n := 0; n < 5; n++ {
+				envelope := &events.Envelope{
+					Origin:     proto.String("fake-origin-3"),
+					EventType:  events.Envelope_LogMessage.Enum(),
+					LogMessage: factories.NewLogMessage(events.LogMessage_OUT, "test log message "+string(n), "fake-app-id-1", "DEA"),
+				}
+				message, _ := proto.Marshal(envelope)
+
+				inputChan <- message
+			}
+
+			collection.Run(inputChan, outputChan, waitGroup)
+
+			for n := 0; n < 5; n++ {
+				<-outputChan
+			}
+
+			metrics := collection.Emit().Metrics
+
+			Expect(metrics).NotTo(BeNil())
+
+			metricsNameMap := make(map[string]int)
+			for _, m := range metrics {
+				metricsNameMap[m.Name]++
+			}
+
+			Expect(metricsNameMap["logMessageTotal"]).To(Equal(1))
+			for _, metric := range metrics {
+				if metric.Name == "logMessageTotal" {
+					Expect(metric.Value.(uint64)).To(Equal(uint64(5)))
+				}
+			}
+
+			for name, count := range metricsNameMap {
+				Expect(count).To(Equal(1), fmt.Sprintf("%v has %v metrics, expected only ONE", name, count))
+			}
+		})
+
+		It("emits log messages metrics per app concatenated from the different unmarshallers", func() {
+			collection.Run(inputChan, outputChan, waitGroup)
+
+			for n := 0; n < 25; n++ {
+				envelope := &events.Envelope{
+					Origin:     proto.String("fake-origin-3"),
+					EventType:  events.Envelope_LogMessage.Enum(),
+					LogMessage: factories.NewLogMessage(events.LogMessage_OUT, "test log message "+string(n), "fake-app-id-"+string(n%5), "DEA"),
+				}
+				message, _ := proto.Marshal(envelope)
+
+				inputChan <- message
+			}
+
+			for n := 0; n < 25; n++ {
+				<-outputChan
+			}
+
+			metrics := collection.Emit().Metrics
+
+			Expect(metrics).NotTo(BeNil())
+
+			metricsNameMap := make(map[string]int)
+			for _, m := range metrics {
+				metricsNameMap[m.Name]++
+			}
+		})
+
+		It("emits event type metrics concatenated from the different unmarshallers", func() {
+			collection.Run(inputChan, outputChan, waitGroup)
+
+			for n := 0; n < 7; n++ {
+				envelope := &events.Envelope{
+					Origin:    proto.String("fake-origin-1"),
+					EventType: events.Envelope_Heartbeat.Enum(),
+					Heartbeat: factories.NewHeartbeat(1, 2, 3),
+				}
+				message, _ := proto.Marshal(envelope)
+
+				inputChan <- message
+			}
+
+			for n := 0; n < 7; n++ {
+				<-outputChan
+			}
+
+			metrics := collection.Emit().Metrics
+
+			Expect(metrics).NotTo(BeNil())
+
+			metricsNameMap := make(map[string]int)
+			for _, m := range metrics {
+				metricsNameMap[m.Name]++
+			}
+
+			Expect(metricsNameMap["heartbeatReceived"]).To(Equal(1))
+			for _, metric := range metrics {
+				if metric.Name == "heartbeatReceived" {
+					Expect(metric.Value.(uint64)).To(Equal(uint64(7)))
+				}
+			}
+		})
+
+		It("emits the correct metrics context", func() {
+			Expect(collection.Emit().Name).To(Equal("dropsondeUnmarshaller"))
+		})
+	})
+})

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller/dropsonde_unmarshaller_suite_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller/dropsonde_unmarshaller_suite_test.go
@@ -1,6 +1,13 @@
 package dropsonde_unmarshaller_test
 
 import (
+	"time"
+
+	"github.com/cloudfoundry/dropsonde/emitter/fake"
+	"github.com/cloudfoundry/dropsonde/metric_sender"
+	"github.com/cloudfoundry/dropsonde/metricbatcher"
+	"github.com/cloudfoundry/dropsonde/metrics"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -11,3 +18,12 @@ func TestUnmarshaller(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Dropsonde Unmarshaller Suite")
 }
+
+var fakeEventEmitter = fake.NewFakeEventEmitter("doppler")
+var metricBatcher *metricbatcher.MetricBatcher
+
+var _ = BeforeSuite(func() {
+	sender := metric_sender.NewMetricSender(fakeEventEmitter)
+	metricBatcher = metricbatcher.New(sender, 100*time.Millisecond)
+	metrics.Initialize(sender, metricBatcher)
+})

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller/dropsonde_unmarshaller_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller/dropsonde_unmarshaller_test.go
@@ -21,10 +21,16 @@ var _ = Describe("DropsondeUnmarshaller", func() {
 		unmarshaller dropsonde_unmarshaller.DropsondeUnmarshaller
 	)
 
-	Context("Unmarshall", func() {
+	BeforeEach(func() {
+		fakeEventEmitter.Reset()
+		metricBatcher.Reset()
+	})
+
+	Context("UnmarshallMessage", func() {
 		BeforeEach(func() {
 			unmarshaller = dropsonde_unmarshaller.NewDropsondeUnmarshaller(loggertesthelper.Logger())
 		})
+
 		It("unmarshalls bytes", func() {
 			input := &events.Envelope{
 				Origin:    proto.String("fake-origin-3"),
@@ -37,6 +43,7 @@ var _ = Describe("DropsondeUnmarshaller", func() {
 
 			Expect(output).To(Equal(input))
 		})
+
 		It("handles bad input gracefully", func() {
 			output, err := unmarshaller.UnmarshallMessage(make([]byte, 4))
 			Expect(output).To(BeNil())
@@ -94,6 +101,7 @@ var _ = Describe("DropsondeUnmarshaller", func() {
 			close(inputChan)
 			Eventually(runComplete).Should(BeClosed())
 		})
+
 		It("emits the correct metrics context", func() {
 			Expect(unmarshaller.Emit().Name).To(Equal("dropsondeUnmarshaller"))
 		})
@@ -108,35 +116,12 @@ var _ = Describe("DropsondeUnmarshaller", func() {
 
 			inputChan <- message
 			testhelpers.EventuallyExpectMetric(unmarshaller, "heartbeatReceived", 1)
-		})
 
-		It("emits a log message counter tagged with app id", func() {
-			envelope1 := &events.Envelope{
-				Origin:     proto.String("fake-origin-3"),
-				EventType:  events.Envelope_LogMessage.Enum(),
-				LogMessage: factories.NewLogMessage(events.LogMessage_OUT, "test log message 1", "fake-app-id-1", "DEA"),
-			}
-
-			envelope2 := &events.Envelope{
-				Origin:     proto.String("fake-origin-3"),
-				EventType:  events.Envelope_LogMessage.Enum(),
-				LogMessage: factories.NewLogMessage(events.LogMessage_OUT, "test log message 2", "fake-app-id-2", "DEA"),
-			}
-
-			message1, _ := proto.Marshal(envelope1)
-			message2, _ := proto.Marshal(envelope2)
-
-			inputChan <- message1
-			inputChan <- message1
-			inputChan <- message2
-
-			Eventually(func() uint64 {
-				return getLogMessageCountByAppId(unmarshaller, "fake-app-id-1")
-			}).Should(BeNumerically("==", 2))
-
-			Eventually(func() uint64 {
-				return getLogMessageCountByAppId(unmarshaller, "fake-app-id-2")
-			}).Should(BeNumerically("==", 1))
+			Eventually(fakeEventEmitter.GetMessages).Should(HaveLen(1))
+			Expect(fakeEventEmitter.GetMessages()[0].Event.(*events.CounterEvent)).To(Equal(&events.CounterEvent{
+				Name:  proto.String("dropsondeUnmarshaller.heartbeatReceived"),
+				Delta: proto.Uint64(1),
+			}))
 		})
 
 		It("emits a total log message counter", func() {
@@ -162,6 +147,12 @@ var _ = Describe("DropsondeUnmarshaller", func() {
 			Eventually(func() uint64 {
 				return getTotalLogMessageCount(unmarshaller)
 			}).Should(BeNumerically("==", 3))
+
+			Eventually(fakeEventEmitter.GetMessages).Should(HaveLen(1))
+			Expect(fakeEventEmitter.GetMessages()[0].Event.(*events.CounterEvent)).To(Equal(&events.CounterEvent{
+				Name:  proto.String("dropsondeUnmarshaller.logMessageTotal"),
+				Delta: proto.Uint64(3),
+			}))
 		})
 
 		It("has consistency between total log message counter and per-app counters", func() {
@@ -188,33 +179,25 @@ var _ = Describe("DropsondeUnmarshaller", func() {
 				return getTotalLogMessageCount(unmarshaller)
 			}).Should(BeNumerically("==", 3))
 
-			var totalFromApps uint64
-			for _, metric := range unmarshaller.Emit().Metrics {
-				if metric.Name == "logMessageReceived" {
-					totalFromApps += metric.Value.(uint64)
-				}
-			}
-
-			Expect(totalFromApps).To(BeNumerically("==", 3))
+			Eventually(fakeEventEmitter.GetMessages).Should(HaveLen(1))
+			Expect(fakeEventEmitter.GetMessages()[0].Event.(*events.CounterEvent)).To(Equal(&events.CounterEvent{
+				Name:  proto.String("dropsondeUnmarshaller.logMessageTotal"),
+				Delta: proto.Uint64(3),
+			}))
 		})
 
 		It("emits an unmarshal error counter", func() {
 			inputChan <- []byte{1, 2, 3}
 			testhelpers.EventuallyExpectMetric(unmarshaller, "unmarshalErrors", 1)
+
+			Eventually(fakeEventEmitter.GetMessages).Should(HaveLen(1))
+			Expect(fakeEventEmitter.GetMessages()[0].Event.(*events.CounterEvent)).To(Equal(&events.CounterEvent{
+				Name:  proto.String("dropsondeUnmarshaller.unmarshalErrors"),
+				Delta: proto.Uint64(1),
+			}))
 		})
 	})
 })
-
-func getLogMessageCountByAppId(instrumentable instrumentation.Instrumentable, appId string) uint64 {
-	for _, metric := range instrumentable.Emit().Metrics {
-		if metric.Name == "logMessageReceived" {
-			if metric.Tags["appId"] == appId {
-				return metric.Value.(uint64)
-			}
-		}
-	}
-	return uint64(0)
-}
 
 func getTotalLogMessageCount(instrumentable instrumentation.Instrumentable) uint64 {
 	for _, metric := range instrumentable.Emit().Metrics {

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller/metric_names.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller/metric_names.go
@@ -1,0 +1,10 @@
+package dropsonde_unmarshaller
+
+const (
+	logMessageTotal = "logMessageTotal"
+	unmarshalErrors = "unmarshalErrors"
+)
+
+const (
+	appIdTag = "appId"
+)

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/event_emitter.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/event_emitter.go
@@ -2,6 +2,7 @@ package emitter
 
 import (
 	"fmt"
+
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/gogo/protobuf/proto"
 )

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/event_formatter.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/event_formatter.go
@@ -2,9 +2,10 @@ package emitter
 
 import (
 	"errors"
+	"time"
+
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/gogo/protobuf/proto"
-	"time"
 )
 
 var ErrorMissingOrigin = errors.New("Event not emitted due to missing origin information")

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/fake/fake_event_emitter.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/fake/fake_event_emitter.go
@@ -1,8 +1,9 @@
 package fake
 
 import (
-	"github.com/cloudfoundry/dropsonde/events"
 	"sync"
+
+	"github.com/cloudfoundry/dropsonde/events"
 )
 
 type envelope struct {
@@ -12,7 +13,7 @@ type envelope struct {
 
 type FakeEventEmitter struct {
 	ReturnError error
-	Messages    []envelope
+	messages    []envelope
 	Origin      string
 	isClosed    bool
 	sync.RWMutex
@@ -21,6 +22,7 @@ type FakeEventEmitter struct {
 func NewFakeEventEmitter(origin string) *FakeEventEmitter {
 	return &FakeEventEmitter{Origin: origin}
 }
+
 func (f *FakeEventEmitter) Emit(e events.Event) error {
 
 	f.Lock()
@@ -32,7 +34,7 @@ func (f *FakeEventEmitter) Emit(e events.Event) error {
 		return err
 	}
 
-	f.Messages = append(f.Messages, envelope{e, f.Origin})
+	f.messages = append(f.messages, envelope{e, f.Origin})
 	return nil
 }
 
@@ -40,8 +42,8 @@ func (f *FakeEventEmitter) GetMessages() (messages []envelope) {
 	f.Lock()
 	defer f.Unlock()
 
-	messages = make([]envelope, len(f.Messages))
-	copy(messages, f.Messages)
+	messages = make([]envelope, len(f.messages))
+	copy(messages, f.messages)
 	return
 }
 
@@ -64,4 +66,13 @@ func (f *FakeEventEmitter) IsClosed() bool {
 	f.RLock()
 	defer f.RUnlock()
 	return f.isClosed
+}
+
+func (f *FakeEventEmitter) Reset() {
+	f.Lock()
+	defer f.Unlock()
+
+	f.isClosed = false
+	f.messages = []envelope{}
+	f.ReturnError = nil
 }

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/logemitter/emit.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/logemitter/emit.go
@@ -2,14 +2,15 @@ package logemitter
 
 import (
 	"errors"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/loggregatorlib/cfcomponent/generic_logger"
 	"github.com/cloudfoundry/loggregatorlib/loggregatorclient"
 	"github.com/cloudfoundry/loggregatorlib/logmessage"
 	"github.com/gogo/protobuf/proto"
-	"os"
-	"strings"
-	"time"
 )
 
 var (

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/logemitter/emit_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/logemitter/emit_test.go
@@ -1,18 +1,20 @@
 package logemitter_test
 
 import (
-	. "github.com/cloudfoundry/dropsonde/emitter/logemitter"
-	"github.com/cloudfoundry/dropsonde/emitter/logemitter/testhelpers"
-	"github.com/cloudfoundry/loggregatorlib/logmessage"
-	"github.com/gogo/protobuf/proto"
 	"log"
 	"os"
 	"strings"
 
+	. "github.com/cloudfoundry/dropsonde/emitter/logemitter"
+	"github.com/cloudfoundry/dropsonde/emitter/logemitter/testhelpers"
+	"github.com/cloudfoundry/loggregatorlib/logmessage"
+	"github.com/gogo/protobuf/proto"
+
+	"io/ioutil"
+
 	"github.com/cloudfoundry/loggregatorlib/loggregatorclient/fake"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
 )
 
 var _ = BeforeSuite(func() {

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/logemitter/testhelpers/logmessage_testhelper.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/logemitter/testhelpers/logmessage_testhelper.go
@@ -1,9 +1,10 @@
 package testhelpers
 
 import (
+	"time"
+
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/gogo/protobuf/proto"
-	"time"
 )
 
 func NewLogMessage(messageString, appId string) *events.LogMessage {

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/udp_emitter.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/emitter/udp_emitter.go
@@ -1,9 +1,10 @@
 package emitter
 
 import (
+	"net"
+
 	"github.com/cloudfoundry/dropsonde/control"
 	"github.com/gogo/protobuf/proto"
-	"net"
 )
 
 type udpEmitter struct {

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/envelope_extensions/envelope_extensions.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/envelope_extensions/envelope_extensions.go
@@ -3,6 +3,7 @@ package envelope_extensions
 import (
 	"encoding/binary"
 	"fmt"
+
 	"github.com/cloudfoundry/dropsonde/events"
 )
 

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/envelope.pb.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/envelope.pb.go
@@ -3,24 +3,30 @@
 // DO NOT EDIT!
 
 /*
-Package events is a generated protocol buffer package.
+	Package events is a generated protocol buffer package.
 
-It is generated from these files:
-	envelope.proto
-	error.proto
-	heartbeat.proto
-	http.proto
-	log.proto
-	metric.proto
-	uuid.proto
+	It is generated from these files:
+		envelope.proto
+		error.proto
+		heartbeat.proto
+		http.proto
+		log.proto
+		metric.proto
+		uuid.proto
 
-It has these top-level messages:
-	Envelope
+	It has these top-level messages:
+		Envelope
 */
 package events
 
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
+
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import io "io"
+import fmt "fmt"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -86,6 +92,10 @@ type Envelope struct {
 	Origin           *string             `protobuf:"bytes,1,req,name=origin" json:"origin,omitempty"`
 	EventType        *Envelope_EventType `protobuf:"varint,2,req,name=eventType,enum=events.Envelope_EventType" json:"eventType,omitempty"`
 	Timestamp        *int64              `protobuf:"varint,6,opt,name=timestamp" json:"timestamp,omitempty"`
+	Deployment       *string             `protobuf:"bytes,13,opt,name=deployment" json:"deployment,omitempty"`
+	Job              *string             `protobuf:"bytes,14,opt,name=job" json:"job,omitempty"`
+	Index            *string             `protobuf:"bytes,15,opt,name=index" json:"index,omitempty"`
+	Ip               *string             `protobuf:"bytes,16,opt,name=ip" json:"ip,omitempty"`
 	Heartbeat        *Heartbeat          `protobuf:"bytes,3,opt,name=heartbeat" json:"heartbeat,omitempty"`
 	HttpStart        *HttpStart          `protobuf:"bytes,4,opt,name=httpStart" json:"httpStart,omitempty"`
 	HttpStop         *HttpStop           `protobuf:"bytes,5,opt,name=httpStop" json:"httpStop,omitempty"`
@@ -121,6 +131,34 @@ func (m *Envelope) GetTimestamp() int64 {
 		return *m.Timestamp
 	}
 	return 0
+}
+
+func (m *Envelope) GetDeployment() string {
+	if m != nil && m.Deployment != nil {
+		return *m.Deployment
+	}
+	return ""
+}
+
+func (m *Envelope) GetJob() string {
+	if m != nil && m.Job != nil {
+		return *m.Job
+	}
+	return ""
+}
+
+func (m *Envelope) GetIndex() string {
+	if m != nil && m.Index != nil {
+		return *m.Index
+	}
+	return ""
+}
+
+func (m *Envelope) GetIp() string {
+	if m != nil && m.Ip != nil {
+		return *m.Ip
+	}
+	return ""
 }
 
 func (m *Envelope) GetHeartbeat() *Heartbeat {
@@ -188,4 +226,716 @@ func (m *Envelope) GetContainerMetric() *ContainerMetric {
 
 func init() {
 	proto.RegisterEnum("events.Envelope_EventType", Envelope_EventType_name, Envelope_EventType_value)
+}
+func (m *Envelope) Unmarshal(data []byte) error {
+	var hasFields [1]uint64
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Origin", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Origin = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000001)
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EventType", wireType)
+			}
+			var v Envelope_EventType
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (Envelope_EventType(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.EventType = &v
+			hasFields[0] |= uint64(0x00000002)
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Timestamp = &v
+		case 13:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Deployment", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Deployment = &s
+			index = postIndex
+		case 14:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Job", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Job = &s
+			index = postIndex
+		case 15:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Index", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Index = &s
+			index = postIndex
+		case 16:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ip", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Ip = &s
+			index = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Heartbeat", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Heartbeat == nil {
+				m.Heartbeat = &Heartbeat{}
+			}
+			if err := m.Heartbeat.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HttpStart", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.HttpStart == nil {
+				m.HttpStart = &HttpStart{}
+			}
+			if err := m.HttpStart.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HttpStop", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.HttpStop == nil {
+				m.HttpStop = &HttpStop{}
+			}
+			if err := m.HttpStop.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HttpStartStop", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.HttpStartStop == nil {
+				m.HttpStartStop = &HttpStartStop{}
+			}
+			if err := m.HttpStartStop.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LogMessage", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LogMessage == nil {
+				m.LogMessage = &LogMessage{}
+			}
+			if err := m.LogMessage.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ValueMetric", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ValueMetric == nil {
+				m.ValueMetric = &ValueMetric{}
+			}
+			if err := m.ValueMetric.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CounterEvent", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CounterEvent == nil {
+				m.CounterEvent = &CounterEvent{}
+			}
+			if err := m.CounterEvent.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Error", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Error == nil {
+				m.Error = &Error{}
+			}
+			if err := m.Error.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ContainerMetric", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ContainerMetric == nil {
+				m.ContainerMetric = &ContainerMetric{}
+			}
+			if err := m.ContainerMetric.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	if hasFields[0]&uint64(0x00000001) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("origin")
+	}
+	if hasFields[0]&uint64(0x00000002) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("eventType")
+	}
+
+	return nil
+}
+func (m *Envelope) Size() (n int) {
+	var l int
+	_ = l
+	if m.Origin != nil {
+		l = len(*m.Origin)
+		n += 1 + l + sovEnvelope(uint64(l))
+	}
+	if m.EventType != nil {
+		n += 1 + sovEnvelope(uint64(*m.EventType))
+	}
+	if m.Timestamp != nil {
+		n += 1 + sovEnvelope(uint64(*m.Timestamp))
+	}
+	if m.Deployment != nil {
+		l = len(*m.Deployment)
+		n += 1 + l + sovEnvelope(uint64(l))
+	}
+	if m.Job != nil {
+		l = len(*m.Job)
+		n += 1 + l + sovEnvelope(uint64(l))
+	}
+	if m.Index != nil {
+		l = len(*m.Index)
+		n += 1 + l + sovEnvelope(uint64(l))
+	}
+	if m.Ip != nil {
+		l = len(*m.Ip)
+		n += 2 + l + sovEnvelope(uint64(l))
+	}
+	if m.Heartbeat != nil {
+		l = m.Heartbeat.Size()
+		n += 1 + l + sovEnvelope(uint64(l))
+	}
+	if m.HttpStart != nil {
+		l = m.HttpStart.Size()
+		n += 1 + l + sovEnvelope(uint64(l))
+	}
+	if m.HttpStop != nil {
+		l = m.HttpStop.Size()
+		n += 1 + l + sovEnvelope(uint64(l))
+	}
+	if m.HttpStartStop != nil {
+		l = m.HttpStartStop.Size()
+		n += 1 + l + sovEnvelope(uint64(l))
+	}
+	if m.LogMessage != nil {
+		l = m.LogMessage.Size()
+		n += 1 + l + sovEnvelope(uint64(l))
+	}
+	if m.ValueMetric != nil {
+		l = m.ValueMetric.Size()
+		n += 1 + l + sovEnvelope(uint64(l))
+	}
+	if m.CounterEvent != nil {
+		l = m.CounterEvent.Size()
+		n += 1 + l + sovEnvelope(uint64(l))
+	}
+	if m.Error != nil {
+		l = m.Error.Size()
+		n += 1 + l + sovEnvelope(uint64(l))
+	}
+	if m.ContainerMetric != nil {
+		l = m.ContainerMetric.Size()
+		n += 1 + l + sovEnvelope(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func sovEnvelope(x uint64) (n int) {
+	for {
+		n++
+		x >>= 7
+		if x == 0 {
+			break
+		}
+	}
+	return n
+}
+func sozEnvelope(x uint64) (n int) {
+	return sovEnvelope(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *Envelope) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *Envelope) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Origin == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("origin")
+	} else {
+		data[i] = 0xa
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(len(*m.Origin)))
+		i += copy(data[i:], *m.Origin)
+	}
+	if m.EventType == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("eventType")
+	} else {
+		data[i] = 0x10
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(*m.EventType))
+	}
+	if m.Timestamp != nil {
+		data[i] = 0x30
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(*m.Timestamp))
+	}
+	if m.Deployment != nil {
+		data[i] = 0x6a
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(len(*m.Deployment)))
+		i += copy(data[i:], *m.Deployment)
+	}
+	if m.Job != nil {
+		data[i] = 0x72
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(len(*m.Job)))
+		i += copy(data[i:], *m.Job)
+	}
+	if m.Index != nil {
+		data[i] = 0x7a
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(len(*m.Index)))
+		i += copy(data[i:], *m.Index)
+	}
+	if m.Ip != nil {
+		data[i] = 0x82
+		i++
+		data[i] = 0x1
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(len(*m.Ip)))
+		i += copy(data[i:], *m.Ip)
+	}
+	if m.Heartbeat != nil {
+		data[i] = 0x1a
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(m.Heartbeat.Size()))
+		n1, err := m.Heartbeat.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n1
+	}
+	if m.HttpStart != nil {
+		data[i] = 0x22
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(m.HttpStart.Size()))
+		n2, err := m.HttpStart.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n2
+	}
+	if m.HttpStop != nil {
+		data[i] = 0x2a
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(m.HttpStop.Size()))
+		n3, err := m.HttpStop.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n3
+	}
+	if m.HttpStartStop != nil {
+		data[i] = 0x3a
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(m.HttpStartStop.Size()))
+		n4, err := m.HttpStartStop.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n4
+	}
+	if m.LogMessage != nil {
+		data[i] = 0x42
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(m.LogMessage.Size()))
+		n5, err := m.LogMessage.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n5
+	}
+	if m.ValueMetric != nil {
+		data[i] = 0x4a
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(m.ValueMetric.Size()))
+		n6, err := m.ValueMetric.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n6
+	}
+	if m.CounterEvent != nil {
+		data[i] = 0x52
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(m.CounterEvent.Size()))
+		n7, err := m.CounterEvent.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n7
+	}
+	if m.Error != nil {
+		data[i] = 0x5a
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(m.Error.Size()))
+		n8, err := m.Error.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n8
+	}
+	if m.ContainerMetric != nil {
+		data[i] = 0x62
+		i++
+		i = encodeVarintEnvelope(data, i, uint64(m.ContainerMetric.Size()))
+		n9, err := m.ContainerMetric.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n9
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func encodeFixed64Envelope(data []byte, offset int, v uint64) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	data[offset+4] = uint8(v >> 32)
+	data[offset+5] = uint8(v >> 40)
+	data[offset+6] = uint8(v >> 48)
+	data[offset+7] = uint8(v >> 56)
+	return offset + 8
+}
+func encodeFixed32Envelope(data []byte, offset int, v uint32) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	return offset + 4
+}
+func encodeVarintEnvelope(data []byte, offset int, v uint64) int {
+	for v >= 1<<7 {
+		data[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	data[offset] = uint8(v)
+	return offset + 1
 }

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/error.pb.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/error.pb.go
@@ -7,6 +7,12 @@ package events
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import io "io"
+import fmt "fmt"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = math.Inf
@@ -45,4 +51,227 @@ func (m *Error) GetMessage() string {
 }
 
 func init() {
+}
+func (m *Error) Unmarshal(data []byte) error {
+	var hasFields [1]uint64
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Source", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Source = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000001)
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Code", wireType)
+			}
+			var v int32
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Code = &v
+			hasFields[0] |= uint64(0x00000002)
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Message", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Message = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000004)
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	if hasFields[0]&uint64(0x00000001) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("source")
+	}
+	if hasFields[0]&uint64(0x00000002) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("code")
+	}
+	if hasFields[0]&uint64(0x00000004) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("message")
+	}
+
+	return nil
+}
+func (m *Error) Size() (n int) {
+	var l int
+	_ = l
+	if m.Source != nil {
+		l = len(*m.Source)
+		n += 1 + l + sovError(uint64(l))
+	}
+	if m.Code != nil {
+		n += 1 + sovError(uint64(*m.Code))
+	}
+	if m.Message != nil {
+		l = len(*m.Message)
+		n += 1 + l + sovError(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func sovError(x uint64) (n int) {
+	for {
+		n++
+		x >>= 7
+		if x == 0 {
+			break
+		}
+	}
+	return n
+}
+func sozError(x uint64) (n int) {
+	return sovError(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *Error) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *Error) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Source == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("source")
+	} else {
+		data[i] = 0xa
+		i++
+		i = encodeVarintError(data, i, uint64(len(*m.Source)))
+		i += copy(data[i:], *m.Source)
+	}
+	if m.Code == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("code")
+	} else {
+		data[i] = 0x10
+		i++
+		i = encodeVarintError(data, i, uint64(*m.Code))
+	}
+	if m.Message == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("message")
+	} else {
+		data[i] = 0x1a
+		i++
+		i = encodeVarintError(data, i, uint64(len(*m.Message)))
+		i += copy(data[i:], *m.Message)
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func encodeFixed64Error(data []byte, offset int, v uint64) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	data[offset+4] = uint8(v >> 32)
+	data[offset+5] = uint8(v >> 40)
+	data[offset+6] = uint8(v >> 48)
+	data[offset+7] = uint8(v >> 56)
+	return offset + 8
+}
+func encodeFixed32Error(data []byte, offset int, v uint32) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	return offset + 4
+}
+func encodeVarintError(data []byte, offset int, v uint64) int {
+	for v >= 1<<7 {
+		data[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	data[offset] = uint8(v)
+	return offset + 1
 }

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/heartbeat.pb.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/heartbeat.pb.go
@@ -7,6 +7,12 @@ package events
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import io "io"
+import fmt "fmt"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = math.Inf
@@ -53,4 +59,252 @@ func (m *Heartbeat) GetControlMessageIdentifier() *UUID {
 }
 
 func init() {
+}
+func (m *Heartbeat) Unmarshal(data []byte) error {
+	var hasFields [1]uint64
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SentCount", wireType)
+			}
+			var v uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.SentCount = &v
+			hasFields[0] |= uint64(0x00000001)
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReceivedCount", wireType)
+			}
+			var v uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.ReceivedCount = &v
+			hasFields[0] |= uint64(0x00000002)
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ErrorCount", wireType)
+			}
+			var v uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.ErrorCount = &v
+			hasFields[0] |= uint64(0x00000004)
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ControlMessageIdentifier", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ControlMessageIdentifier == nil {
+				m.ControlMessageIdentifier = &UUID{}
+			}
+			if err := m.ControlMessageIdentifier.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	if hasFields[0]&uint64(0x00000001) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("sentCount")
+	}
+	if hasFields[0]&uint64(0x00000002) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("receivedCount")
+	}
+	if hasFields[0]&uint64(0x00000004) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("errorCount")
+	}
+
+	return nil
+}
+func (m *Heartbeat) Size() (n int) {
+	var l int
+	_ = l
+	if m.SentCount != nil {
+		n += 1 + sovHeartbeat(uint64(*m.SentCount))
+	}
+	if m.ReceivedCount != nil {
+		n += 1 + sovHeartbeat(uint64(*m.ReceivedCount))
+	}
+	if m.ErrorCount != nil {
+		n += 1 + sovHeartbeat(uint64(*m.ErrorCount))
+	}
+	if m.ControlMessageIdentifier != nil {
+		l = m.ControlMessageIdentifier.Size()
+		n += 1 + l + sovHeartbeat(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func sovHeartbeat(x uint64) (n int) {
+	for {
+		n++
+		x >>= 7
+		if x == 0 {
+			break
+		}
+	}
+	return n
+}
+func sozHeartbeat(x uint64) (n int) {
+	return sovHeartbeat(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *Heartbeat) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *Heartbeat) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.SentCount == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("sentCount")
+	} else {
+		data[i] = 0x8
+		i++
+		i = encodeVarintHeartbeat(data, i, uint64(*m.SentCount))
+	}
+	if m.ReceivedCount == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("receivedCount")
+	} else {
+		data[i] = 0x10
+		i++
+		i = encodeVarintHeartbeat(data, i, uint64(*m.ReceivedCount))
+	}
+	if m.ErrorCount == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("errorCount")
+	} else {
+		data[i] = 0x18
+		i++
+		i = encodeVarintHeartbeat(data, i, uint64(*m.ErrorCount))
+	}
+	if m.ControlMessageIdentifier != nil {
+		data[i] = 0x22
+		i++
+		i = encodeVarintHeartbeat(data, i, uint64(m.ControlMessageIdentifier.Size()))
+		n1, err := m.ControlMessageIdentifier.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n1
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func encodeFixed64Heartbeat(data []byte, offset int, v uint64) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	data[offset+4] = uint8(v >> 32)
+	data[offset+5] = uint8(v >> 40)
+	data[offset+6] = uint8(v >> 48)
+	data[offset+7] = uint8(v >> 56)
+	return offset + 8
+}
+func encodeFixed32Heartbeat(data []byte, offset int, v uint32) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	return offset + 4
+}
+func encodeVarintHeartbeat(data []byte, offset int, v uint64) int {
+	for v >= 1<<7 {
+		data[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	data[offset] = uint8(v)
+	return offset + 1
 }

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/http.pb.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/http.pb.go
@@ -7,6 +7,12 @@ package events
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import io "io"
+import fmt "fmt"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = math.Inf
@@ -374,4 +380,1404 @@ func (m *HttpStartStop) GetInstanceId() string {
 func init() {
 	proto.RegisterEnum("events.PeerType", PeerType_name, PeerType_value)
 	proto.RegisterEnum("events.Method", Method_name, Method_value)
+}
+func (m *HttpStart) Unmarshal(data []byte) error {
+	var hasFields [1]uint64
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Timestamp = &v
+			hasFields[0] |= uint64(0x00000001)
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequestId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.RequestId == nil {
+				m.RequestId = &UUID{}
+			}
+			if err := m.RequestId.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+			hasFields[0] |= uint64(0x00000002)
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PeerType", wireType)
+			}
+			var v PeerType
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (PeerType(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.PeerType = &v
+			hasFields[0] |= uint64(0x00000004)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Method", wireType)
+			}
+			var v Method
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (Method(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Method = &v
+			hasFields[0] |= uint64(0x00000008)
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Uri", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Uri = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000010)
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RemoteAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.RemoteAddress = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000020)
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UserAgent", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.UserAgent = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000040)
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ParentRequestId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ParentRequestId == nil {
+				m.ParentRequestId = &UUID{}
+			}
+			if err := m.ParentRequestId.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ApplicationId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ApplicationId == nil {
+				m.ApplicationId = &UUID{}
+			}
+			if err := m.ApplicationId.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InstanceIndex", wireType)
+			}
+			var v int32
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.InstanceIndex = &v
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InstanceId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.InstanceId = &s
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	if hasFields[0]&uint64(0x00000001) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("timestamp")
+	}
+	if hasFields[0]&uint64(0x00000002) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("requestId")
+	}
+	if hasFields[0]&uint64(0x00000004) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("peerType")
+	}
+	if hasFields[0]&uint64(0x00000008) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("method")
+	}
+	if hasFields[0]&uint64(0x00000010) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("uri")
+	}
+	if hasFields[0]&uint64(0x00000020) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("remoteAddress")
+	}
+	if hasFields[0]&uint64(0x00000040) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("userAgent")
+	}
+
+	return nil
+}
+func (m *HttpStop) Unmarshal(data []byte) error {
+	var hasFields [1]uint64
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Timestamp = &v
+			hasFields[0] |= uint64(0x00000001)
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Uri", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Uri = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000002)
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequestId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.RequestId == nil {
+				m.RequestId = &UUID{}
+			}
+			if err := m.RequestId.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+			hasFields[0] |= uint64(0x00000004)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PeerType", wireType)
+			}
+			var v PeerType
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (PeerType(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.PeerType = &v
+			hasFields[0] |= uint64(0x00000008)
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StatusCode", wireType)
+			}
+			var v int32
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.StatusCode = &v
+			hasFields[0] |= uint64(0x00000010)
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ContentLength", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.ContentLength = &v
+			hasFields[0] |= uint64(0x00000020)
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ApplicationId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ApplicationId == nil {
+				m.ApplicationId = &UUID{}
+			}
+			if err := m.ApplicationId.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	if hasFields[0]&uint64(0x00000001) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("timestamp")
+	}
+	if hasFields[0]&uint64(0x00000002) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("uri")
+	}
+	if hasFields[0]&uint64(0x00000004) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("requestId")
+	}
+	if hasFields[0]&uint64(0x00000008) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("peerType")
+	}
+	if hasFields[0]&uint64(0x00000010) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("statusCode")
+	}
+	if hasFields[0]&uint64(0x00000020) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("contentLength")
+	}
+
+	return nil
+}
+func (m *HttpStartStop) Unmarshal(data []byte) error {
+	var hasFields [1]uint64
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StartTimestamp", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.StartTimestamp = &v
+			hasFields[0] |= uint64(0x00000001)
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StopTimestamp", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.StopTimestamp = &v
+			hasFields[0] |= uint64(0x00000002)
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequestId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.RequestId == nil {
+				m.RequestId = &UUID{}
+			}
+			if err := m.RequestId.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+			hasFields[0] |= uint64(0x00000004)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PeerType", wireType)
+			}
+			var v PeerType
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (PeerType(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.PeerType = &v
+			hasFields[0] |= uint64(0x00000008)
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Method", wireType)
+			}
+			var v Method
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (Method(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Method = &v
+			hasFields[0] |= uint64(0x00000010)
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Uri", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Uri = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000020)
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RemoteAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.RemoteAddress = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000040)
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UserAgent", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.UserAgent = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000080)
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StatusCode", wireType)
+			}
+			var v int32
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.StatusCode = &v
+			hasFields[0] |= uint64(0x00000100)
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ContentLength", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.ContentLength = &v
+			hasFields[0] |= uint64(0x00000200)
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ParentRequestId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ParentRequestId == nil {
+				m.ParentRequestId = &UUID{}
+			}
+			if err := m.ParentRequestId.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ApplicationId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ApplicationId == nil {
+				m.ApplicationId = &UUID{}
+			}
+			if err := m.ApplicationId.Unmarshal(data[index:postIndex]); err != nil {
+				return err
+			}
+			index = postIndex
+		case 13:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InstanceIndex", wireType)
+			}
+			var v int32
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.InstanceIndex = &v
+		case 14:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InstanceId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.InstanceId = &s
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	if hasFields[0]&uint64(0x00000001) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("startTimestamp")
+	}
+	if hasFields[0]&uint64(0x00000002) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("stopTimestamp")
+	}
+	if hasFields[0]&uint64(0x00000004) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("requestId")
+	}
+	if hasFields[0]&uint64(0x00000008) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("peerType")
+	}
+	if hasFields[0]&uint64(0x00000010) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("method")
+	}
+	if hasFields[0]&uint64(0x00000020) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("uri")
+	}
+	if hasFields[0]&uint64(0x00000040) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("remoteAddress")
+	}
+	if hasFields[0]&uint64(0x00000080) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("userAgent")
+	}
+	if hasFields[0]&uint64(0x00000100) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("statusCode")
+	}
+	if hasFields[0]&uint64(0x00000200) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("contentLength")
+	}
+
+	return nil
+}
+func (m *HttpStart) Size() (n int) {
+	var l int
+	_ = l
+	if m.Timestamp != nil {
+		n += 1 + sovHttp(uint64(*m.Timestamp))
+	}
+	if m.RequestId != nil {
+		l = m.RequestId.Size()
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.PeerType != nil {
+		n += 1 + sovHttp(uint64(*m.PeerType))
+	}
+	if m.Method != nil {
+		n += 1 + sovHttp(uint64(*m.Method))
+	}
+	if m.Uri != nil {
+		l = len(*m.Uri)
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.RemoteAddress != nil {
+		l = len(*m.RemoteAddress)
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.UserAgent != nil {
+		l = len(*m.UserAgent)
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.ParentRequestId != nil {
+		l = m.ParentRequestId.Size()
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.ApplicationId != nil {
+		l = m.ApplicationId.Size()
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.InstanceIndex != nil {
+		n += 1 + sovHttp(uint64(*m.InstanceIndex))
+	}
+	if m.InstanceId != nil {
+		l = len(*m.InstanceId)
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *HttpStop) Size() (n int) {
+	var l int
+	_ = l
+	if m.Timestamp != nil {
+		n += 1 + sovHttp(uint64(*m.Timestamp))
+	}
+	if m.Uri != nil {
+		l = len(*m.Uri)
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.RequestId != nil {
+		l = m.RequestId.Size()
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.PeerType != nil {
+		n += 1 + sovHttp(uint64(*m.PeerType))
+	}
+	if m.StatusCode != nil {
+		n += 1 + sovHttp(uint64(*m.StatusCode))
+	}
+	if m.ContentLength != nil {
+		n += 1 + sovHttp(uint64(*m.ContentLength))
+	}
+	if m.ApplicationId != nil {
+		l = m.ApplicationId.Size()
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *HttpStartStop) Size() (n int) {
+	var l int
+	_ = l
+	if m.StartTimestamp != nil {
+		n += 1 + sovHttp(uint64(*m.StartTimestamp))
+	}
+	if m.StopTimestamp != nil {
+		n += 1 + sovHttp(uint64(*m.StopTimestamp))
+	}
+	if m.RequestId != nil {
+		l = m.RequestId.Size()
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.PeerType != nil {
+		n += 1 + sovHttp(uint64(*m.PeerType))
+	}
+	if m.Method != nil {
+		n += 1 + sovHttp(uint64(*m.Method))
+	}
+	if m.Uri != nil {
+		l = len(*m.Uri)
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.RemoteAddress != nil {
+		l = len(*m.RemoteAddress)
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.UserAgent != nil {
+		l = len(*m.UserAgent)
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.StatusCode != nil {
+		n += 1 + sovHttp(uint64(*m.StatusCode))
+	}
+	if m.ContentLength != nil {
+		n += 1 + sovHttp(uint64(*m.ContentLength))
+	}
+	if m.ParentRequestId != nil {
+		l = m.ParentRequestId.Size()
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.ApplicationId != nil {
+		l = m.ApplicationId.Size()
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.InstanceIndex != nil {
+		n += 1 + sovHttp(uint64(*m.InstanceIndex))
+	}
+	if m.InstanceId != nil {
+		l = len(*m.InstanceId)
+		n += 1 + l + sovHttp(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func sovHttp(x uint64) (n int) {
+	for {
+		n++
+		x >>= 7
+		if x == 0 {
+			break
+		}
+	}
+	return n
+}
+func sozHttp(x uint64) (n int) {
+	return sovHttp(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *HttpStart) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *HttpStart) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Timestamp == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("timestamp")
+	} else {
+		data[i] = 0x8
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.Timestamp))
+	}
+	if m.RequestId == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("requestId")
+	} else {
+		data[i] = 0x12
+		i++
+		i = encodeVarintHttp(data, i, uint64(m.RequestId.Size()))
+		n1, err := m.RequestId.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n1
+	}
+	if m.PeerType == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("peerType")
+	} else {
+		data[i] = 0x18
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.PeerType))
+	}
+	if m.Method == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("method")
+	} else {
+		data[i] = 0x20
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.Method))
+	}
+	if m.Uri == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("uri")
+	} else {
+		data[i] = 0x2a
+		i++
+		i = encodeVarintHttp(data, i, uint64(len(*m.Uri)))
+		i += copy(data[i:], *m.Uri)
+	}
+	if m.RemoteAddress == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("remoteAddress")
+	} else {
+		data[i] = 0x32
+		i++
+		i = encodeVarintHttp(data, i, uint64(len(*m.RemoteAddress)))
+		i += copy(data[i:], *m.RemoteAddress)
+	}
+	if m.UserAgent == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("userAgent")
+	} else {
+		data[i] = 0x3a
+		i++
+		i = encodeVarintHttp(data, i, uint64(len(*m.UserAgent)))
+		i += copy(data[i:], *m.UserAgent)
+	}
+	if m.ParentRequestId != nil {
+		data[i] = 0x42
+		i++
+		i = encodeVarintHttp(data, i, uint64(m.ParentRequestId.Size()))
+		n2, err := m.ParentRequestId.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n2
+	}
+	if m.ApplicationId != nil {
+		data[i] = 0x4a
+		i++
+		i = encodeVarintHttp(data, i, uint64(m.ApplicationId.Size()))
+		n3, err := m.ApplicationId.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n3
+	}
+	if m.InstanceIndex != nil {
+		data[i] = 0x50
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.InstanceIndex))
+	}
+	if m.InstanceId != nil {
+		data[i] = 0x5a
+		i++
+		i = encodeVarintHttp(data, i, uint64(len(*m.InstanceId)))
+		i += copy(data[i:], *m.InstanceId)
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *HttpStop) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *HttpStop) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Timestamp == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("timestamp")
+	} else {
+		data[i] = 0x8
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.Timestamp))
+	}
+	if m.Uri == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("uri")
+	} else {
+		data[i] = 0x12
+		i++
+		i = encodeVarintHttp(data, i, uint64(len(*m.Uri)))
+		i += copy(data[i:], *m.Uri)
+	}
+	if m.RequestId == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("requestId")
+	} else {
+		data[i] = 0x1a
+		i++
+		i = encodeVarintHttp(data, i, uint64(m.RequestId.Size()))
+		n4, err := m.RequestId.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n4
+	}
+	if m.PeerType == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("peerType")
+	} else {
+		data[i] = 0x20
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.PeerType))
+	}
+	if m.StatusCode == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("statusCode")
+	} else {
+		data[i] = 0x28
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.StatusCode))
+	}
+	if m.ContentLength == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("contentLength")
+	} else {
+		data[i] = 0x30
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.ContentLength))
+	}
+	if m.ApplicationId != nil {
+		data[i] = 0x3a
+		i++
+		i = encodeVarintHttp(data, i, uint64(m.ApplicationId.Size()))
+		n5, err := m.ApplicationId.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n5
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *HttpStartStop) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *HttpStartStop) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.StartTimestamp == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("startTimestamp")
+	} else {
+		data[i] = 0x8
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.StartTimestamp))
+	}
+	if m.StopTimestamp == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("stopTimestamp")
+	} else {
+		data[i] = 0x10
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.StopTimestamp))
+	}
+	if m.RequestId == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("requestId")
+	} else {
+		data[i] = 0x1a
+		i++
+		i = encodeVarintHttp(data, i, uint64(m.RequestId.Size()))
+		n6, err := m.RequestId.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n6
+	}
+	if m.PeerType == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("peerType")
+	} else {
+		data[i] = 0x20
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.PeerType))
+	}
+	if m.Method == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("method")
+	} else {
+		data[i] = 0x28
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.Method))
+	}
+	if m.Uri == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("uri")
+	} else {
+		data[i] = 0x32
+		i++
+		i = encodeVarintHttp(data, i, uint64(len(*m.Uri)))
+		i += copy(data[i:], *m.Uri)
+	}
+	if m.RemoteAddress == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("remoteAddress")
+	} else {
+		data[i] = 0x3a
+		i++
+		i = encodeVarintHttp(data, i, uint64(len(*m.RemoteAddress)))
+		i += copy(data[i:], *m.RemoteAddress)
+	}
+	if m.UserAgent == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("userAgent")
+	} else {
+		data[i] = 0x42
+		i++
+		i = encodeVarintHttp(data, i, uint64(len(*m.UserAgent)))
+		i += copy(data[i:], *m.UserAgent)
+	}
+	if m.StatusCode == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("statusCode")
+	} else {
+		data[i] = 0x48
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.StatusCode))
+	}
+	if m.ContentLength == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("contentLength")
+	} else {
+		data[i] = 0x50
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.ContentLength))
+	}
+	if m.ParentRequestId != nil {
+		data[i] = 0x5a
+		i++
+		i = encodeVarintHttp(data, i, uint64(m.ParentRequestId.Size()))
+		n7, err := m.ParentRequestId.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n7
+	}
+	if m.ApplicationId != nil {
+		data[i] = 0x62
+		i++
+		i = encodeVarintHttp(data, i, uint64(m.ApplicationId.Size()))
+		n8, err := m.ApplicationId.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n8
+	}
+	if m.InstanceIndex != nil {
+		data[i] = 0x68
+		i++
+		i = encodeVarintHttp(data, i, uint64(*m.InstanceIndex))
+	}
+	if m.InstanceId != nil {
+		data[i] = 0x72
+		i++
+		i = encodeVarintHttp(data, i, uint64(len(*m.InstanceId)))
+		i += copy(data[i:], *m.InstanceId)
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func encodeFixed64Http(data []byte, offset int, v uint64) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	data[offset+4] = uint8(v >> 32)
+	data[offset+5] = uint8(v >> 40)
+	data[offset+6] = uint8(v >> 48)
+	data[offset+7] = uint8(v >> 56)
+	return offset + 8
+}
+func encodeFixed32Http(data []byte, offset int, v uint32) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	return offset + 4
+}
+func encodeVarintHttp(data []byte, offset int, v uint64) int {
+	for v >= 1<<7 {
+		data[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	data[offset] = uint8(v)
+	return offset + 1
 }

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/log.pb.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/log.pb.go
@@ -7,6 +7,12 @@ package events
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import io "io"
+import fmt "fmt"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = math.Inf
@@ -104,4 +110,317 @@ func (m *LogMessage) GetSourceInstance() string {
 
 func init() {
 	proto.RegisterEnum("events.LogMessage_MessageType", LogMessage_MessageType_name, LogMessage_MessageType_value)
+}
+func (m *LogMessage) Unmarshal(data []byte) error {
+	var hasFields [1]uint64
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Message", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Message = append([]byte{}, data[index:postIndex]...)
+			index = postIndex
+			hasFields[0] |= uint64(0x00000001)
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MessageType", wireType)
+			}
+			var v LogMessage_MessageType
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (LogMessage_MessageType(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.MessageType = &v
+			hasFields[0] |= uint64(0x00000002)
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Timestamp", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Timestamp = &v
+			hasFields[0] |= uint64(0x00000004)
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AppId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.AppId = &s
+			index = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SourceType", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.SourceType = &s
+			index = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SourceInstance", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.SourceInstance = &s
+			index = postIndex
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	if hasFields[0]&uint64(0x00000001) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("message")
+	}
+	if hasFields[0]&uint64(0x00000002) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("message_type")
+	}
+	if hasFields[0]&uint64(0x00000004) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("timestamp")
+	}
+
+	return nil
+}
+func (m *LogMessage) Size() (n int) {
+	var l int
+	_ = l
+	if m.Message != nil {
+		l = len(m.Message)
+		n += 1 + l + sovLog(uint64(l))
+	}
+	if m.MessageType != nil {
+		n += 1 + sovLog(uint64(*m.MessageType))
+	}
+	if m.Timestamp != nil {
+		n += 1 + sovLog(uint64(*m.Timestamp))
+	}
+	if m.AppId != nil {
+		l = len(*m.AppId)
+		n += 1 + l + sovLog(uint64(l))
+	}
+	if m.SourceType != nil {
+		l = len(*m.SourceType)
+		n += 1 + l + sovLog(uint64(l))
+	}
+	if m.SourceInstance != nil {
+		l = len(*m.SourceInstance)
+		n += 1 + l + sovLog(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func sovLog(x uint64) (n int) {
+	for {
+		n++
+		x >>= 7
+		if x == 0 {
+			break
+		}
+	}
+	return n
+}
+func sozLog(x uint64) (n int) {
+	return sovLog(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *LogMessage) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *LogMessage) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Message == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("message")
+	} else {
+		data[i] = 0xa
+		i++
+		i = encodeVarintLog(data, i, uint64(len(m.Message)))
+		i += copy(data[i:], m.Message)
+	}
+	if m.MessageType == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("message_type")
+	} else {
+		data[i] = 0x10
+		i++
+		i = encodeVarintLog(data, i, uint64(*m.MessageType))
+	}
+	if m.Timestamp == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("timestamp")
+	} else {
+		data[i] = 0x18
+		i++
+		i = encodeVarintLog(data, i, uint64(*m.Timestamp))
+	}
+	if m.AppId != nil {
+		data[i] = 0x22
+		i++
+		i = encodeVarintLog(data, i, uint64(len(*m.AppId)))
+		i += copy(data[i:], *m.AppId)
+	}
+	if m.SourceType != nil {
+		data[i] = 0x2a
+		i++
+		i = encodeVarintLog(data, i, uint64(len(*m.SourceType)))
+		i += copy(data[i:], *m.SourceType)
+	}
+	if m.SourceInstance != nil {
+		data[i] = 0x32
+		i++
+		i = encodeVarintLog(data, i, uint64(len(*m.SourceInstance)))
+		i += copy(data[i:], *m.SourceInstance)
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func encodeFixed64Log(data []byte, offset int, v uint64) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	data[offset+4] = uint8(v >> 32)
+	data[offset+5] = uint8(v >> 40)
+	data[offset+6] = uint8(v >> 48)
+	data[offset+7] = uint8(v >> 56)
+	return offset + 8
+}
+func encodeFixed32Log(data []byte, offset int, v uint32) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	return offset + 4
+}
+func encodeVarintLog(data []byte, offset int, v uint64) int {
+	for v >= 1<<7 {
+		data[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	data[offset] = uint8(v)
+	return offset + 1
 }

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/metric.pb.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/metric.pb.go
@@ -7,6 +7,12 @@ package events
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import io "io"
+import fmt "fmt"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = math.Inf
@@ -127,4 +133,639 @@ func (m *ContainerMetric) GetDiskBytes() uint64 {
 }
 
 func init() {
+}
+func (m *ValueMetric) Unmarshal(data []byte) error {
+	var hasFields [1]uint64
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Name = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000001)
+		case 2:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
+			}
+			var v uint64
+			i := index + 8
+			if i > l {
+				return io.ErrUnexpectedEOF
+			}
+			index = i
+			v = uint64(data[i-8])
+			v |= uint64(data[i-7]) << 8
+			v |= uint64(data[i-6]) << 16
+			v |= uint64(data[i-5]) << 24
+			v |= uint64(data[i-4]) << 32
+			v |= uint64(data[i-3]) << 40
+			v |= uint64(data[i-2]) << 48
+			v |= uint64(data[i-1]) << 56
+			v2 := math.Float64frombits(v)
+			m.Value = &v2
+			hasFields[0] |= uint64(0x00000002)
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Unit", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Unit = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000004)
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	if hasFields[0]&uint64(0x00000001) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("name")
+	}
+	if hasFields[0]&uint64(0x00000002) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("value")
+	}
+	if hasFields[0]&uint64(0x00000004) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("unit")
+	}
+
+	return nil
+}
+func (m *CounterEvent) Unmarshal(data []byte) error {
+	var hasFields [1]uint64
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.Name = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000001)
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Delta", wireType)
+			}
+			var v uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Delta = &v
+			hasFields[0] |= uint64(0x00000002)
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Total", wireType)
+			}
+			var v uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Total = &v
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	if hasFields[0]&uint64(0x00000001) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("name")
+	}
+	if hasFields[0]&uint64(0x00000002) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("delta")
+	}
+
+	return nil
+}
+func (m *ContainerMetric) Unmarshal(data []byte) error {
+	var hasFields [1]uint64
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ApplicationId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			postIndex := index + int(stringLen)
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(data[index:postIndex])
+			m.ApplicationId = &s
+			index = postIndex
+			hasFields[0] |= uint64(0x00000001)
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InstanceIndex", wireType)
+			}
+			var v int32
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.InstanceIndex = &v
+			hasFields[0] |= uint64(0x00000002)
+		case 3:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CpuPercentage", wireType)
+			}
+			var v uint64
+			i := index + 8
+			if i > l {
+				return io.ErrUnexpectedEOF
+			}
+			index = i
+			v = uint64(data[i-8])
+			v |= uint64(data[i-7]) << 8
+			v |= uint64(data[i-6]) << 16
+			v |= uint64(data[i-5]) << 24
+			v |= uint64(data[i-4]) << 32
+			v |= uint64(data[i-3]) << 40
+			v |= uint64(data[i-2]) << 48
+			v |= uint64(data[i-1]) << 56
+			v2 := math.Float64frombits(v)
+			m.CpuPercentage = &v2
+			hasFields[0] |= uint64(0x00000004)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MemoryBytes", wireType)
+			}
+			var v uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.MemoryBytes = &v
+			hasFields[0] |= uint64(0x00000008)
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DiskBytes", wireType)
+			}
+			var v uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.DiskBytes = &v
+			hasFields[0] |= uint64(0x00000010)
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	if hasFields[0]&uint64(0x00000001) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("applicationId")
+	}
+	if hasFields[0]&uint64(0x00000002) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("instanceIndex")
+	}
+	if hasFields[0]&uint64(0x00000004) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("cpuPercentage")
+	}
+	if hasFields[0]&uint64(0x00000008) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("memoryBytes")
+	}
+	if hasFields[0]&uint64(0x00000010) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("diskBytes")
+	}
+
+	return nil
+}
+func (m *ValueMetric) Size() (n int) {
+	var l int
+	_ = l
+	if m.Name != nil {
+		l = len(*m.Name)
+		n += 1 + l + sovMetric(uint64(l))
+	}
+	if m.Value != nil {
+		n += 9
+	}
+	if m.Unit != nil {
+		l = len(*m.Unit)
+		n += 1 + l + sovMetric(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *CounterEvent) Size() (n int) {
+	var l int
+	_ = l
+	if m.Name != nil {
+		l = len(*m.Name)
+		n += 1 + l + sovMetric(uint64(l))
+	}
+	if m.Delta != nil {
+		n += 1 + sovMetric(uint64(*m.Delta))
+	}
+	if m.Total != nil {
+		n += 1 + sovMetric(uint64(*m.Total))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *ContainerMetric) Size() (n int) {
+	var l int
+	_ = l
+	if m.ApplicationId != nil {
+		l = len(*m.ApplicationId)
+		n += 1 + l + sovMetric(uint64(l))
+	}
+	if m.InstanceIndex != nil {
+		n += 1 + sovMetric(uint64(*m.InstanceIndex))
+	}
+	if m.CpuPercentage != nil {
+		n += 9
+	}
+	if m.MemoryBytes != nil {
+		n += 1 + sovMetric(uint64(*m.MemoryBytes))
+	}
+	if m.DiskBytes != nil {
+		n += 1 + sovMetric(uint64(*m.DiskBytes))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func sovMetric(x uint64) (n int) {
+	for {
+		n++
+		x >>= 7
+		if x == 0 {
+			break
+		}
+	}
+	return n
+}
+func sozMetric(x uint64) (n int) {
+	return sovMetric(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *ValueMetric) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ValueMetric) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Name == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("name")
+	} else {
+		data[i] = 0xa
+		i++
+		i = encodeVarintMetric(data, i, uint64(len(*m.Name)))
+		i += copy(data[i:], *m.Name)
+	}
+	if m.Value == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("value")
+	} else {
+		data[i] = 0x11
+		i++
+		i = encodeFixed64Metric(data, i, uint64(math.Float64bits(*m.Value)))
+	}
+	if m.Unit == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("unit")
+	} else {
+		data[i] = 0x1a
+		i++
+		i = encodeVarintMetric(data, i, uint64(len(*m.Unit)))
+		i += copy(data[i:], *m.Unit)
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *CounterEvent) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *CounterEvent) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Name == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("name")
+	} else {
+		data[i] = 0xa
+		i++
+		i = encodeVarintMetric(data, i, uint64(len(*m.Name)))
+		i += copy(data[i:], *m.Name)
+	}
+	if m.Delta == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("delta")
+	} else {
+		data[i] = 0x10
+		i++
+		i = encodeVarintMetric(data, i, uint64(*m.Delta))
+	}
+	if m.Total != nil {
+		data[i] = 0x18
+		i++
+		i = encodeVarintMetric(data, i, uint64(*m.Total))
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *ContainerMetric) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ContainerMetric) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.ApplicationId == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("applicationId")
+	} else {
+		data[i] = 0xa
+		i++
+		i = encodeVarintMetric(data, i, uint64(len(*m.ApplicationId)))
+		i += copy(data[i:], *m.ApplicationId)
+	}
+	if m.InstanceIndex == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("instanceIndex")
+	} else {
+		data[i] = 0x10
+		i++
+		i = encodeVarintMetric(data, i, uint64(*m.InstanceIndex))
+	}
+	if m.CpuPercentage == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("cpuPercentage")
+	} else {
+		data[i] = 0x19
+		i++
+		i = encodeFixed64Metric(data, i, uint64(math.Float64bits(*m.CpuPercentage)))
+	}
+	if m.MemoryBytes == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("memoryBytes")
+	} else {
+		data[i] = 0x20
+		i++
+		i = encodeVarintMetric(data, i, uint64(*m.MemoryBytes))
+	}
+	if m.DiskBytes == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("diskBytes")
+	} else {
+		data[i] = 0x28
+		i++
+		i = encodeVarintMetric(data, i, uint64(*m.DiskBytes))
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func encodeFixed64Metric(data []byte, offset int, v uint64) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	data[offset+4] = uint8(v >> 32)
+	data[offset+5] = uint8(v >> 40)
+	data[offset+6] = uint8(v >> 48)
+	data[offset+7] = uint8(v >> 56)
+	return offset + 8
+}
+func encodeFixed32Metric(data []byte, offset int, v uint32) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	return offset + 4
+}
+func encodeVarintMetric(data []byte, offset int, v uint64) int {
+	for v >= 1<<7 {
+		data[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	data[offset] = uint8(v)
+	return offset + 1
 }

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/uuid.pb.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/events/uuid.pb.go
@@ -7,11 +7,19 @@ package events
 import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
+// discarding unused import gogoproto "github.com/gogo/protobuf/gogoproto/gogo.pb"
+
+import io "io"
+import fmt "fmt"
+import github_com_gogo_protobuf_proto "github.com/gogo/protobuf/proto"
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = math.Inf
 
 // / Type representing a 128-bit UUID.
+//
+// The bytes of the UUID should be packed in little-endian **byte** (not bit) order. For example, the UUID `f47ac10b-58cc-4372-a567-0e02b2c3d479` should be encoded as `UUID{ low: 0x7243cc580bc17af4, high: 0x79d4c3b2020e67a5 }`
 type UUID struct {
 	Low              *uint64 `protobuf:"varint,1,req,name=low" json:"low,omitempty"`
 	High             *uint64 `protobuf:"varint,2,req,name=high" json:"high,omitempty"`
@@ -37,4 +45,180 @@ func (m *UUID) GetHigh() uint64 {
 }
 
 func init() {
+}
+func (m *UUID) Unmarshal(data []byte) error {
+	var hasFields [1]uint64
+	l := len(data)
+	index := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if index >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Low", wireType)
+			}
+			var v uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Low = &v
+			hasFields[0] |= uint64(0x00000001)
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field High", wireType)
+			}
+			var v uint64
+			for shift := uint(0); ; shift += 7 {
+				if index >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				v |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.High = &v
+			hasFields[0] |= uint64(0x00000002)
+		default:
+			var sizeOfWire int
+			for {
+				sizeOfWire++
+				wire >>= 7
+				if wire == 0 {
+					break
+				}
+			}
+			index -= sizeOfWire
+			skippy, err := github_com_gogo_protobuf_proto.Skip(data[index:])
+			if err != nil {
+				return err
+			}
+			if (index + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, data[index:index+skippy]...)
+			index += skippy
+		}
+	}
+	if hasFields[0]&uint64(0x00000001) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("low")
+	}
+	if hasFields[0]&uint64(0x00000002) == 0 {
+		return github_com_gogo_protobuf_proto.NewRequiredNotSetError("high")
+	}
+
+	return nil
+}
+func (m *UUID) Size() (n int) {
+	var l int
+	_ = l
+	if m.Low != nil {
+		n += 1 + sovUuid(uint64(*m.Low))
+	}
+	if m.High != nil {
+		n += 1 + sovUuid(uint64(*m.High))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func sovUuid(x uint64) (n int) {
+	for {
+		n++
+		x >>= 7
+		if x == 0 {
+			break
+		}
+	}
+	return n
+}
+func sozUuid(x uint64) (n int) {
+	return sovUuid(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *UUID) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *UUID) MarshalTo(data []byte) (n int, err error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Low == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("low")
+	} else {
+		data[i] = 0x8
+		i++
+		i = encodeVarintUuid(data, i, uint64(*m.Low))
+	}
+	if m.High == nil {
+		return 0, github_com_gogo_protobuf_proto.NewRequiredNotSetError("high")
+	} else {
+		data[i] = 0x10
+		i++
+		i = encodeVarintUuid(data, i, uint64(*m.High))
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(data[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func encodeFixed64Uuid(data []byte, offset int, v uint64) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	data[offset+4] = uint8(v >> 32)
+	data[offset+5] = uint8(v >> 40)
+	data[offset+6] = uint8(v >> 48)
+	data[offset+7] = uint8(v >> 56)
+	return offset + 8
+}
+func encodeFixed32Uuid(data []byte, offset int, v uint32) int {
+	data[offset] = uint8(v)
+	data[offset+1] = uint8(v >> 8)
+	data[offset+2] = uint8(v >> 16)
+	data[offset+3] = uint8(v >> 24)
+	return offset + 4
+}
+func encodeVarintUuid(data []byte, offset int, v uint64) int {
+	for v >= 1<<7 {
+		data[offset] = uint8(v&0x7f | 0x80)
+		v >>= 7
+		offset++
+	}
+	data[offset] = uint8(v)
+	return offset + 1
 }

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/factories/factories.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/factories/factories.go
@@ -3,13 +3,14 @@ package factories
 import (
 	"encoding/binary"
 	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
 	"github.com/cloudfoundry/dropsonde/control"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/gogo/protobuf/proto"
 	uuid "github.com/nu7hatch/gouuid"
-	"net/http"
-	"strconv"
-	"time"
 )
 
 func NewUUID(id *uuid.UUID) *events.UUID {

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/factories/factories_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/factories/factories_test.go
@@ -5,10 +5,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"net/http"
+
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/dropsonde/factories"
 	"github.com/gogo/protobuf/proto"
-	"net/http"
 )
 
 var _ = Describe("HTTP event creation", func() {

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/instrumented_handler/instrumented_handler_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/instrumented_handler/instrumented_handler_test.go
@@ -3,14 +3,15 @@ package instrumented_handler_test
 import (
 	"bufio"
 	"errors"
-	"github.com/cloudfoundry/dropsonde/emitter/fake"
-	"github.com/cloudfoundry/dropsonde/events"
-	"github.com/cloudfoundry/dropsonde/instrumented_handler"
-	uuid "github.com/nu7hatch/gouuid"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"time"
+
+	"github.com/cloudfoundry/dropsonde/emitter/fake"
+	"github.com/cloudfoundry/dropsonde/events"
+	"github.com/cloudfoundry/dropsonde/instrumented_handler"
+	uuid "github.com/nu7hatch/gouuid"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -90,13 +91,13 @@ var _ = Describe("InstrumentedHandler", func() {
 			})
 
 			It("should emit a start event with the right origin", func() {
-				Expect(fakeEmitter.Messages[0].Event).To(BeAssignableToTypeOf(new(events.HttpStart)))
-				Expect(fakeEmitter.Messages[0].Origin).To(Equal("testHandler/41"))
+				Expect(fakeEmitter.GetMessages()[0].Event).To(BeAssignableToTypeOf(new(events.HttpStart)))
+				Expect(fakeEmitter.GetMessages()[0].Origin).To(Equal("testHandler/41"))
 			})
 
 			It("should emit a stop event", func() {
-				Expect(fakeEmitter.Messages[1].Event).To(BeAssignableToTypeOf(new(events.HttpStop)))
-				stopEvent := fakeEmitter.Messages[1].Event.(*events.HttpStop)
+				Expect(fakeEmitter.GetMessages()[1].Event).To(BeAssignableToTypeOf(new(events.HttpStop)))
+				stopEvent := fakeEmitter.GetMessages()[1].Event.(*events.HttpStop)
 				Expect(stopEvent.GetStatusCode()).To(BeNumerically("==", 123))
 				Expect(stopEvent.GetContentLength()).To(BeNumerically("==", 12))
 			})

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/instrumented_round_tripper/instrumented_round_tripper_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/instrumented_round_tripper/instrumented_round_tripper_test.go
@@ -103,8 +103,8 @@ var _ = Describe("InstrumentedRoundTripper", func() {
 	Context("event emission", func() {
 		It("should emit a start event", func() {
 			rt.RoundTrip(req)
-			Expect(fakeEmitter.Messages[0].Event).To(BeAssignableToTypeOf(new(events.HttpStart)))
-			Expect(fakeEmitter.Messages[0].Origin).To(Equal("testRoundtripper/42"))
+			Expect(fakeEmitter.GetMessages()[0].Event).To(BeAssignableToTypeOf(new(events.HttpStart)))
+			Expect(fakeEmitter.GetMessages()[0].Origin).To(Equal("testRoundtripper/42"))
 		})
 
 		Context("if request ID already exists", func() {
@@ -117,7 +117,7 @@ var _ = Describe("InstrumentedRoundTripper", func() {
 
 			It("should emit the existing request ID as the parent request ID", func() {
 				rt.RoundTrip(req)
-				startEvent := fakeEmitter.Messages[0].Event.(*events.HttpStart)
+				startEvent := fakeEmitter.GetMessages()[0].Event.(*events.HttpStart)
 				Expect(startEvent.GetParentRequestId()).To(Equal(factories.NewUUID(existingRequestId)))
 			})
 		})
@@ -127,9 +127,9 @@ var _ = Describe("InstrumentedRoundTripper", func() {
 				fakeRoundTripper.fakeError = errors.New("fakeEmitter error")
 				rt.RoundTrip(req)
 
-				Expect(fakeEmitter.Messages[1].Event).To(BeAssignableToTypeOf(new(events.HttpStop)))
+				Expect(fakeEmitter.GetMessages()[1].Event).To(BeAssignableToTypeOf(new(events.HttpStop)))
 
-				stopEvent := fakeEmitter.Messages[1].Event.(*events.HttpStop)
+				stopEvent := fakeEmitter.GetMessages()[1].Event.(*events.HttpStop)
 				Expect(stopEvent.GetStatusCode()).To(BeNumerically("==", 0))
 				Expect(stopEvent.GetContentLength()).To(BeNumerically("==", 0))
 			})
@@ -139,9 +139,9 @@ var _ = Describe("InstrumentedRoundTripper", func() {
 			It("should emit a stop event with the round tripper's response", func() {
 				rt.RoundTrip(req)
 
-				Expect(fakeEmitter.Messages[1].Event).To(BeAssignableToTypeOf(new(events.HttpStop)))
+				Expect(fakeEmitter.GetMessages()[1].Event).To(BeAssignableToTypeOf(new(events.HttpStop)))
 
-				stopEvent := fakeEmitter.Messages[1].Event.(*events.HttpStop)
+				stopEvent := fakeEmitter.GetMessages()[1].Event.(*events.HttpStop)
 				Expect(stopEvent.GetStatusCode()).To(BeNumerically("==", 123))
 				Expect(stopEvent.GetContentLength()).To(BeNumerically("==", 1234))
 			})

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/log_sender/log_sender_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/log_sender/log_sender_test.go
@@ -3,6 +3,7 @@ package log_sender_test
 import (
 	"bytes"
 	"errors"
+
 	"github.com/cloudfoundry/dropsonde/emitter/fake"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/dropsonde/log_sender"
@@ -40,8 +41,8 @@ var _ = Describe("LogSender", func() {
 			err := sender.SendAppLog("app-id", "custom-log-message", "App", "0")
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(emitter.Messages).To(HaveLen(1))
-			log := emitter.Messages[0].Event.(*events.LogMessage)
+			Expect(emitter.GetMessages()).To(HaveLen(1))
+			log := emitter.GetMessages()[0].Event.(*events.LogMessage)
 			Expect(log.GetMessageType()).To(Equal(events.LogMessage_OUT))
 			Expect(log.GetMessage()).To(BeEquivalentTo("custom-log-message"))
 			Expect(log.GetAppId()).To(Equal("app-id"))
@@ -56,15 +57,6 @@ var _ = Describe("LogSender", func() {
 
 			Eventually(emitter.GetEvents).Should(ContainElement(&events.ValueMetric{Name: proto.String("logSenderTotalMessagesRead"), Value: proto.Float64(2), Unit: proto.String("count")}))
 		})
-
-		It("counts number of log messages read per app", func() {
-			sender.SendAppLog("app-id1", "custom-log-message", "App", "0")
-			sender.SendAppLog("app-id1", "custom-log-message", "App", "0")
-			sender.SendAppLog("app-id2", "custom-log-message", "App", "0")
-
-			Eventually(emitter.GetEvents).Should(ContainElement(&events.ValueMetric{Name: proto.String("logSenderTotalMessagesRead.app-id1"), Value: proto.Float64(2), Unit: proto.String("count")}))
-			Eventually(emitter.GetEvents).Should(ContainElement(&events.ValueMetric{Name: proto.String("logSenderTotalMessagesRead.app-id2"), Value: proto.Float64(1), Unit: proto.String("count")}))
-		})
 	})
 
 	Describe("SendAppErrorLog", func() {
@@ -72,8 +64,8 @@ var _ = Describe("LogSender", func() {
 			err := sender.SendAppErrorLog("app-id", "custom-log-error-message", "App", "0")
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(emitter.Messages).To(HaveLen(1))
-			log := emitter.Messages[0].Event.(*events.LogMessage)
+			Expect(emitter.GetMessages()).To(HaveLen(1))
+			log := emitter.GetMessages()[0].Event.(*events.LogMessage)
 			Expect(log.GetMessageType()).To(Equal(events.LogMessage_ERR))
 			Expect(log.GetMessage()).To(BeEquivalentTo("custom-log-error-message"))
 			Expect(log.GetAppId()).To(Equal("app-id"))
@@ -87,15 +79,6 @@ var _ = Describe("LogSender", func() {
 			sender.SendAppErrorLog("app-id", "custom-log-message", "App", "0")
 
 			Eventually(emitter.GetEvents).Should(ContainElement(&events.ValueMetric{Name: proto.String("logSenderTotalMessagesRead"), Value: proto.Float64(2), Unit: proto.String("count")}))
-		})
-
-		It("counts number of log messages read per app", func() {
-			sender.SendAppErrorLog("app-id1", "custom-log-message", "App", "0")
-			sender.SendAppErrorLog("app-id1", "custom-log-message", "App", "0")
-			sender.SendAppErrorLog("app-id2", "custom-log-message", "App", "0")
-
-			Eventually(emitter.GetEvents).Should(ContainElement(&events.ValueMetric{Name: proto.String("logSenderTotalMessagesRead.app-id1"), Value: proto.Float64(2), Unit: proto.String("count")}))
-			Eventually(emitter.GetEvents).Should(ContainElement(&events.ValueMetric{Name: proto.String("logSenderTotalMessagesRead.app-id2"), Value: proto.Float64(1), Unit: proto.String("count")}))
 		})
 	})
 
@@ -145,14 +128,14 @@ var _ = Describe("LogSender", func() {
 			messages := emitter.GetMessages()
 			Expect(messages).To(HaveLen(2))
 
-			log := emitter.Messages[0].Event.(*events.LogMessage)
+			log := emitter.GetMessages()[0].Event.(*events.LogMessage)
 			Expect(log.GetMessage()).To(BeEquivalentTo("line 1"))
 			Expect(log.GetMessageType()).To(Equal(events.LogMessage_OUT))
 			Expect(log.GetAppId()).To(Equal("someId"))
 			Expect(log.GetSourceType()).To(Equal("app"))
 			Expect(log.GetSourceInstance()).To(Equal("0"))
 
-			log = emitter.Messages[1].Event.(*events.LogMessage)
+			log = emitter.GetMessages()[1].Event.(*events.LogMessage)
 			Expect(log.GetMessage()).To(BeEquivalentTo("line 2"))
 			Expect(log.GetMessageType()).To(Equal(events.LogMessage_OUT))
 		})
@@ -164,7 +147,7 @@ var _ = Describe("LogSender", func() {
 			messages := emitter.GetMessages()
 			Expect(messages).To(HaveLen(1))
 
-			log := emitter.Messages[0].Event.(*events.LogMessage)
+			log := emitter.GetMessages()[0].Event.(*events.LogMessage)
 			Expect(log.GetMessageType()).To(Equal(events.LogMessage_OUT))
 			Expect(log.GetMessage()).To(BeEquivalentTo("one"))
 
@@ -231,14 +214,14 @@ var _ = Describe("LogSender", func() {
 			messages := emitter.GetMessages()
 			Expect(messages).To(HaveLen(2))
 
-			log := emitter.Messages[0].Event.(*events.LogMessage)
+			log := emitter.GetMessages()[0].Event.(*events.LogMessage)
 			Expect(log.GetMessage()).To(BeEquivalentTo("line 1"))
 			Expect(log.GetMessageType()).To(Equal(events.LogMessage_ERR))
 			Expect(log.GetAppId()).To(Equal("someId"))
 			Expect(log.GetSourceType()).To(Equal("app"))
 			Expect(log.GetSourceInstance()).To(Equal("0"))
 
-			log = emitter.Messages[1].Event.(*events.LogMessage)
+			log = emitter.GetMessages()[1].Event.(*events.LogMessage)
 			Expect(log.GetMessage()).To(BeEquivalentTo("line 2"))
 			Expect(log.GetMessageType()).To(Equal(events.LogMessage_ERR))
 		})
@@ -250,7 +233,7 @@ var _ = Describe("LogSender", func() {
 			messages := emitter.GetMessages()
 			Expect(messages).To(HaveLen(1))
 
-			log := emitter.Messages[0].Event.(*events.LogMessage)
+			log := emitter.GetMessages()[0].Event.(*events.LogMessage)
 			Expect(log.GetMessageType()).To(Equal(events.LogMessage_ERR))
 			Expect(log.GetMessage()).To(BeEquivalentTo("one"))
 

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/logs/logs.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/logs/logs.go
@@ -16,8 +16,9 @@
 package logs
 
 import (
-	"github.com/cloudfoundry/dropsonde/log_sender"
 	"io"
+
+	"github.com/cloudfoundry/dropsonde/log_sender"
 )
 
 var logSender log_sender.LogSender

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/logs/logs_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/logs/logs_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cloudfoundry/dropsonde/logs"
 
 	"errors"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/metric_sender/fake/fake_metric_sender.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/metric_sender/fake/fake_metric_sender.go
@@ -84,3 +84,12 @@ func (fms *FakeMetricSender) GetContainerMetric(applicationId string) ContainerM
 
 	return fms.containerMetrics[applicationId]
 }
+
+func (fms *FakeMetricSender) Reset() {
+	fms.Lock()
+	defer fms.Unlock()
+
+	fms.counters = make(map[string]uint64)
+	fms.values = make(map[string]Metric)
+	fms.containerMetrics = make(map[string]ContainerMetric)
+}

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/metric_sender/metric_sender_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/metric_sender/metric_sender_test.go
@@ -2,6 +2,7 @@ package metric_sender_test
 
 import (
 	"errors"
+
 	"github.com/cloudfoundry/dropsonde/emitter/fake"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/dropsonde/metric_sender"
@@ -25,8 +26,8 @@ var _ = Describe("MetricSender", func() {
 		err := sender.SendValue("metric-name", 42, "answers")
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(emitter.Messages).To(HaveLen(1))
-		metric := emitter.Messages[0].Event.(*events.ValueMetric)
+		Expect(emitter.GetMessages()).To(HaveLen(1))
+		metric := emitter.GetMessages()[0].Event.(*events.ValueMetric)
 		Expect(metric.GetName()).To(Equal("metric-name"))
 		Expect(metric.GetValue()).To(BeNumerically("==", 42))
 		Expect(metric.GetUnit()).To(Equal("answers"))
@@ -36,7 +37,7 @@ var _ = Describe("MetricSender", func() {
 		emitter.ReturnError = errors.New("some error")
 
 		err := sender.SendValue("stuff", 12, "no answer")
-		Expect(emitter.Messages).To(HaveLen(0))
+		Expect(emitter.GetMessages()).To(HaveLen(0))
 		Expect(err.Error()).To(Equal("some error"))
 	})
 
@@ -44,8 +45,8 @@ var _ = Describe("MetricSender", func() {
 		err := sender.IncrementCounter("counter-strike")
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(emitter.Messages).To(HaveLen(1))
-		counterEvent := emitter.Messages[0].Event.(*events.CounterEvent)
+		Expect(emitter.GetMessages()).To(HaveLen(1))
+		counterEvent := emitter.GetMessages()[0].Event.(*events.CounterEvent)
 		Expect(counterEvent.GetName()).To(Equal("counter-strike"))
 		Expect(counterEvent.GetDelta()).To(Equal(uint64(1)))
 	})
@@ -54,8 +55,8 @@ var _ = Describe("MetricSender", func() {
 		err := sender.AddToCounter("counter-strike", 3)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(emitter.Messages).To(HaveLen(1))
-		counterEvent := emitter.Messages[0].Event.(*events.CounterEvent)
+		Expect(emitter.GetMessages()).To(HaveLen(1))
+		counterEvent := emitter.GetMessages()[0].Event.(*events.CounterEvent)
 		Expect(counterEvent.GetName()).To(Equal("counter-strike"))
 		Expect(counterEvent.GetDelta()).To(Equal(uint64(3)))
 	})
@@ -64,7 +65,7 @@ var _ = Describe("MetricSender", func() {
 		emitter.ReturnError = errors.New("some counter event error")
 
 		err := sender.IncrementCounter("count me in")
-		Expect(emitter.Messages).To(HaveLen(0))
+		Expect(emitter.GetMessages()).To(HaveLen(0))
 		Expect(err.Error()).To(Equal("some counter event error"))
 	})
 
@@ -72,8 +73,8 @@ var _ = Describe("MetricSender", func() {
 		err := sender.SendContainerMetric("some_app_guid", 0, 42.42, 1234, 123412341234)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(emitter.Messages).To(HaveLen(1))
-		containerMetric := emitter.Messages[0].Event.(*events.ContainerMetric)
+		Expect(emitter.GetMessages()).To(HaveLen(1))
+		containerMetric := emitter.GetMessages()[0].Event.(*events.ContainerMetric)
 
 		Expect(containerMetric.GetApplicationId()).To(Equal("some_app_guid"))
 		Expect(containerMetric.GetInstanceIndex()).To(Equal(int32(0)))
@@ -88,7 +89,7 @@ var _ = Describe("MetricSender", func() {
 		emitter.ReturnError = errors.New("some container metric error")
 
 		err := sender.SendContainerMetric("some_app_guid", 0, 42.42, 1234, 123412341234)
-		Expect(emitter.Messages).To(HaveLen(0))
+		Expect(emitter.GetMessages()).To(HaveLen(0))
 		Expect(err.Error()).To(Equal("some container metric error"))
 	})
 })

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/metricbatcher/metricbatcher.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/metricbatcher/metricbatcher.go
@@ -1,0 +1,69 @@
+// package metricbatcher provides a mechanism to batch counter updates into a single event.
+package metricbatcher
+
+import (
+	"github.com/cloudfoundry/dropsonde/metric_sender"
+	"sync"
+	"time"
+)
+
+// MetricBatcher batches counter increment/add calls into periodic, aggregate events.
+type MetricBatcher struct {
+	metrics      map[string]uint64
+	batchTicker  *time.Ticker
+	metricSender metric_sender.MetricSender
+	lock         sync.RWMutex
+}
+
+// New instantiates a running MetricBatcher. Eventswill be emitted once per batchDuration. All
+// updates to a given counter name will be combined into a single event and sent to metricSender.
+func New(metricSender metric_sender.MetricSender, batchDuration time.Duration) *MetricBatcher {
+	mb := &MetricBatcher{
+		metrics:      make(map[string]uint64),
+		batchTicker:  time.NewTicker(batchDuration),
+		metricSender: metricSender,
+	}
+
+	go func() {
+		for {
+			<-mb.batchTicker.C
+			mb.lock.Lock()
+
+			for name, delta := range mb.metrics {
+				metricSender.AddToCounter(name, delta)
+			}
+			mb.unsafeReset()
+
+			mb.lock.Unlock()
+		}
+	}()
+
+	return mb
+}
+
+// BatchIncrementCounter increments the named counter by 1, but does not immediately send a
+// CounterEvent.
+func (mb *MetricBatcher) BatchIncrementCounter(name string) {
+	mb.BatchAddCounter(name, 1)
+}
+
+// BatchAddCounter increments the named counter by the provided delta, but does not
+// immediately send a CounterEvent.
+func (mb *MetricBatcher) BatchAddCounter(name string, delta uint64) {
+	mb.lock.Lock()
+	defer mb.lock.Unlock()
+
+	mb.metrics[name] += delta
+}
+
+// Reset clears the MetricBatcher's internal state, so that no counters are tracked.
+func (mb *MetricBatcher) Reset() {
+	mb.lock.Lock()
+	defer mb.lock.Unlock()
+
+	mb.unsafeReset()
+}
+
+func (mb *MetricBatcher) unsafeReset() {
+	mb.metrics = make(map[string]uint64, len(mb.metrics))
+}

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/metricbatcher/metricbatcher_suite_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/metricbatcher/metricbatcher_suite_test.go
@@ -1,0 +1,13 @@
+package metricbatcher_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestMetricBatcher(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MetricBatcher Suite")
+}

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/metricbatcher/metricbatcher_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/metricbatcher/metricbatcher_test.go
@@ -1,0 +1,117 @@
+package metricbatcher_test
+
+import (
+	"time"
+
+	"github.com/cloudfoundry/dropsonde/metric_sender/fake"
+	"github.com/cloudfoundry/dropsonde/metricbatcher"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MetricBatcher", func() {
+	var (
+		fakeMetricSender *fake.FakeMetricSender
+		metricBatcher    *metricbatcher.MetricBatcher
+	)
+
+	BeforeEach(func() {
+		fakeMetricSender = fake.NewFakeMetricSender()
+		metricBatcher = metricbatcher.New(fakeMetricSender, 50*time.Millisecond)
+	})
+
+	Describe("BatchIncrementCounter", func() {
+		It("batches and then sends a single metric", func() {
+			metricBatcher.BatchIncrementCounter("count")
+			Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(0)) // should not increment.
+
+			metricBatcher.BatchIncrementCounter("count")
+			metricBatcher.BatchIncrementCounter("count")
+
+			time.Sleep(75 * time.Millisecond)
+			Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(3)) // should update counter only when time out
+
+			metricBatcher.BatchIncrementCounter("count")
+			metricBatcher.BatchIncrementCounter("count")
+			Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(3)) // should update counter only when time out
+
+			time.Sleep(75 * time.Millisecond)
+			Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(5)) // should update counter only when time out
+		})
+
+		It("batches and then sends multiple metrics", func() {
+			metricBatcher.BatchIncrementCounter("count1")
+			metricBatcher.BatchIncrementCounter("count2")
+			metricBatcher.BatchIncrementCounter("count2")
+			Expect(fakeMetricSender.GetCounter("count1")).To(BeEquivalentTo(0)) // should not increment.
+			Expect(fakeMetricSender.GetCounter("count2")).To(BeEquivalentTo(0)) // should not increment.
+
+			time.Sleep(75 * time.Millisecond)
+			Expect(fakeMetricSender.GetCounter("count1")).To(BeEquivalentTo(1)) // should update counter only when time out
+			Expect(fakeMetricSender.GetCounter("count2")).To(BeEquivalentTo(2)) // should update counter only when time out
+
+			metricBatcher.BatchIncrementCounter("count1")
+			metricBatcher.BatchIncrementCounter("count2")
+			Expect(fakeMetricSender.GetCounter("count1")).To(BeEquivalentTo(1)) // should update counter only when time out
+			Expect(fakeMetricSender.GetCounter("count2")).To(BeEquivalentTo(2)) // should update counter only when time out
+
+			time.Sleep(75 * time.Millisecond)
+			Expect(fakeMetricSender.GetCounter("count1")).To(BeEquivalentTo(2)) // should update counter only when time out
+			Expect(fakeMetricSender.GetCounter("count2")).To(BeEquivalentTo(3)) // should update counter only when time out
+		})
+	})
+
+	Describe("BatchAddCounter", func() {
+		It("batches and then sends a single metric", func() {
+			metricBatcher.BatchAddCounter("count", 2)
+			Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(0)) // should not increment.
+
+			metricBatcher.BatchAddCounter("count", 2)
+			metricBatcher.BatchAddCounter("count", 3)
+
+			time.Sleep(75 * time.Millisecond)
+			Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(7)) // should update counter only when time out
+
+			metricBatcher.BatchAddCounter("count", 1)
+			metricBatcher.BatchAddCounter("count", 2)
+			Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(7)) // should update counter only when time out
+
+			time.Sleep(75 * time.Millisecond)
+			Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(10)) // should update counter only when time out
+		})
+
+		It("batches and then sends multiple metrics", func() {
+			metricBatcher.BatchAddCounter("count1", 2)
+			metricBatcher.BatchAddCounter("count2", 1)
+			metricBatcher.BatchAddCounter("count2", 2)
+			Expect(fakeMetricSender.GetCounter("count1")).To(BeEquivalentTo(0)) // should not increment.
+			Expect(fakeMetricSender.GetCounter("count2")).To(BeEquivalentTo(0)) // should not increment.
+
+			time.Sleep(75 * time.Millisecond)
+			Expect(fakeMetricSender.GetCounter("count1")).To(BeEquivalentTo(2)) // should update counter only when time out
+			Expect(fakeMetricSender.GetCounter("count2")).To(BeEquivalentTo(3)) // should update counter only when time out
+
+			metricBatcher.BatchAddCounter("count1", 2)
+			metricBatcher.BatchAddCounter("count2", 2)
+			Expect(fakeMetricSender.GetCounter("count1")).To(BeEquivalentTo(2)) // should update counter only when time out
+			Expect(fakeMetricSender.GetCounter("count2")).To(BeEquivalentTo(3)) // should update counter only when time out
+
+			time.Sleep(75 * time.Millisecond)
+			Expect(fakeMetricSender.GetCounter("count1")).To(BeEquivalentTo(4)) // should update counter only when time out
+			Expect(fakeMetricSender.GetCounter("count2")).To(BeEquivalentTo(5)) // should update counter only when time out
+		})
+	})
+
+	Describe("Reset", func() {
+		It("cancels any scheduled counter emission", func() {
+			metricBatcher.BatchAddCounter("count1", 2)
+			metricBatcher.BatchIncrementCounter("count1")
+
+			metricBatcher.Reset()
+
+			Consistently(func() uint64 { return fakeMetricSender.GetCounter("count1") }).Should(BeZero())
+		})
+	})
+
+})

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/metrics/metrics_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/metrics/metrics_test.go
@@ -2,9 +2,11 @@ package metrics_test
 
 import (
 	"github.com/cloudfoundry/dropsonde/metric_sender/fake"
+	"github.com/cloudfoundry/dropsonde/metricbatcher"
 	"github.com/cloudfoundry/dropsonde/metrics"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"time"
 )
 
 var _ = Describe("Metrics", func() {
@@ -12,7 +14,8 @@ var _ = Describe("Metrics", func() {
 
 	BeforeEach(func() {
 		fakeMetricSender = fake.NewFakeMetricSender()
-		metrics.Initialize(fakeMetricSender)
+		metricBatcher := metricbatcher.New(fakeMetricSender, time.Millisecond)
+		metrics.Initialize(fakeMetricSender, metricBatcher)
 	})
 
 	It("delegates SendValue", func() {
@@ -32,6 +35,16 @@ var _ = Describe("Metrics", func() {
 		Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(2))
 	})
 
+	It("delegates BatchIncrementCounter", func() {
+		metrics.BatchIncrementCounter("count")
+		time.Sleep(2 * time.Millisecond)
+		Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(1))
+
+		metrics.BatchIncrementCounter("count")
+		time.Sleep(2 * time.Millisecond)
+		Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(2))
+	})
+
 	It("delegates AddToCounter", func() {
 		metrics.AddToCounter("count", 5)
 
@@ -40,6 +53,16 @@ var _ = Describe("Metrics", func() {
 		metrics.AddToCounter("count", 10)
 
 		Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(15))
+	})
+
+	It("delegates BatchAddCounter", func() {
+		metrics.BatchAddCounter("count", 3)
+		time.Sleep(2 * time.Millisecond)
+		Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(3))
+
+		metrics.BatchAddCounter("count", 7)
+		time.Sleep(2 * time.Millisecond)
+		Expect(fakeMetricSender.GetCounter("count")).To(BeEquivalentTo(10))
 	})
 
 	It("delegates SendContainerMetric", func() {
@@ -51,13 +74,12 @@ var _ = Describe("Metrics", func() {
 		Expect(fakeMetricSender.GetContainerMetric(appGuid).CpuPercentage).To(BeEquivalentTo(42.42))
 		Expect(fakeMetricSender.GetContainerMetric(appGuid).MemoryBytes).To(BeEquivalentTo(1234))
 		Expect(fakeMetricSender.GetContainerMetric(appGuid).DiskBytes).To(BeEquivalentTo(123412341234))
-
 	})
 
 	Context("when Metric Sender is not initialized", func() {
 
 		BeforeEach(func() {
-			metrics.Initialize(nil)
+			metrics.Initialize(nil, nil)
 		})
 
 		It("SendValue is a no-op", func() {

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/runtime_stats/runtime_stats.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/runtime_stats/runtime_stats.go
@@ -1,12 +1,13 @@
 package runtime_stats
 
 import (
-	"github.com/cloudfoundry/dropsonde/emitter"
-	"github.com/cloudfoundry/dropsonde/events"
-	"github.com/gogo/protobuf/proto"
 	"log"
 	"runtime"
 	"time"
+
+	"github.com/cloudfoundry/dropsonde/emitter"
+	"github.com/cloudfoundry/dropsonde/events"
+	"github.com/gogo/protobuf/proto"
 )
 
 type RuntimeStats struct {

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/runtime_stats/runtime_stats_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/runtime_stats/runtime_stats_test.go
@@ -4,14 +4,15 @@ import (
 	"github.com/cloudfoundry/dropsonde/runtime_stats"
 
 	"errors"
+	"log"
+	"runtime"
+	"time"
+
 	"github.com/cloudfoundry/dropsonde/emitter/fake"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/gogo/protobuf/proto"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"log"
-	"runtime"
-	"time"
 )
 
 var _ = Describe("RuntimeStats", func() {

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/signature/signature_suite_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/signature/signature_suite_test.go
@@ -1,13 +1,30 @@
 package signature_test
 
 import (
+	"time"
+
+	"github.com/cloudfoundry/dropsonde/metric_sender"
+	"github.com/cloudfoundry/dropsonde/metricbatcher"
+	"github.com/cloudfoundry/dropsonde/metrics"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"testing"
+
+	"github.com/cloudfoundry/dropsonde/emitter/fake"
 )
 
 func TestUnmarshaller(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Signature Suite")
 }
+
+var fakeEventEmitter = fake.NewFakeEventEmitter("doppler")
+var metricBatcher *metricbatcher.MetricBatcher
+
+var _ = BeforeSuite(func() {
+	sender := metric_sender.NewMetricSender(fakeEventEmitter)
+	metricBatcher = metricbatcher.New(sender, 100*time.Millisecond)
+	metrics.Initialize(sender, metricBatcher)
+})

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/signature/signature_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/signature/signature_test.go
@@ -3,26 +3,31 @@ package signature_test
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+
+	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/dropsonde/signature"
-	"github.com/cloudfoundry/loggregatorlib/cfcomponent/instrumentation/testhelpers"
 	"github.com/cloudfoundry/loggregatorlib/loggertesthelper"
+	"github.com/gogo/protobuf/proto"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("SignatureVerifier", func() {
+var _ = Describe("Verifier", func() {
 	var (
-		inputChan         chan []byte
-		outputChan        chan []byte
-		runComplete       chan struct{}
-		signatureVerifier signature.SignatureVerifier
+		inputChan   chan []byte
+		outputChan  chan []byte
+		runComplete chan struct{}
+
+		signatureVerifier *signature.Verifier
 	)
 
 	BeforeEach(func() {
 		inputChan = make(chan []byte, 10)
 		outputChan = make(chan []byte, 10)
 		runComplete = make(chan struct{})
-		signatureVerifier = signature.NewSignatureVerifier(loggertesthelper.Logger(), "valid-secret")
+
+		signatureVerifier = signature.NewVerifier(loggertesthelper.Logger(), "valid-secret")
 
 		go func() {
 			signatureVerifier.Run(inputChan, outputChan)
@@ -36,18 +41,29 @@ var _ = Describe("SignatureVerifier", func() {
 	})
 
 	It("discards messages less than 32 bytes long", func() {
+		loggertesthelper.TestLoggerSink.Clear()
+
 		message := make([]byte, 1)
 		inputChan <- message
 		Consistently(outputChan).ShouldNot(Receive())
+
+		Expect(loggertesthelper.TestLoggerSink.LogContents()).To(ContainSubstring("missing signature for message"))
 	})
 
 	It("discards messages when verification fails", func() {
+		loggertesthelper.TestLoggerSink.Clear()
+
 		message := make([]byte, 33)
+
 		inputChan <- message
 		Consistently(outputChan).ShouldNot(Receive())
+
+		Expect(loggertesthelper.TestLoggerSink.LogContents()).To(ContainSubstring("invalid signature for message"))
 	})
 
 	It("passes through messages with valid signature", func() {
+		loggertesthelper.TestLoggerSink.Clear()
+
 		message := []byte{1, 2, 3}
 		mac := hmac.New(sha256.New, []byte("valid-secret"))
 		mac.Write(message)
@@ -58,21 +74,34 @@ var _ = Describe("SignatureVerifier", func() {
 		inputChan <- signedMessage
 		outputMessage := <-outputChan
 		Expect(outputMessage).To(Equal(message))
+
+		Expect(loggertesthelper.TestLoggerSink.LogContents()).To(BeEmpty())
 	})
 
 	Context("metrics", func() {
-		It("emits the correct metrics context", func() {
-			Expect(signatureVerifier.Emit().Name).To(Equal("signatureVerifier"))
+
+		BeforeEach(func() {
+			fakeEventEmitter.Reset()
+			metricBatcher.Reset()
 		})
 
 		It("emits a missing signature error counter", func() {
 			inputChan <- []byte{1, 2, 3}
-			testhelpers.EventuallyExpectMetric(signatureVerifier, "missingSignatureErrors", 1)
+			Eventually(fakeEventEmitter.GetMessages).Should(HaveLen(1))
+			Expect(fakeEventEmitter.GetMessages()[0].Event.(*events.CounterEvent)).To(Equal(&events.CounterEvent{
+				Name:  proto.String("signatureVerifier.missingSignatureErrors"),
+				Delta: proto.Uint64(1),
+			}))
 		})
 
 		It("emits an invalid signature error counter", func() {
 			inputChan <- make([]byte, 32)
-			testhelpers.EventuallyExpectMetric(signatureVerifier, "invalidSignatureErrors", 1)
+
+			Eventually(fakeEventEmitter.GetMessages).Should(HaveLen(1))
+			Expect(fakeEventEmitter.GetMessages()[0].Event.(*events.CounterEvent)).To(Equal(&events.CounterEvent{
+				Name:  proto.String("signatureVerifier.invalidSignatureErrors"),
+				Delta: proto.Uint64(1),
+			}))
 		})
 
 		It("emits an valid signature counter", func() {
@@ -83,7 +112,12 @@ var _ = Describe("SignatureVerifier", func() {
 
 			signedMessage := append(signature, message...)
 			inputChan <- signedMessage
-			testhelpers.EventuallyExpectMetric(signatureVerifier, "validSignatures", 1)
+
+			Eventually(fakeEventEmitter.GetMessages).Should(HaveLen(1))
+			Expect(fakeEventEmitter.GetMessages()[0].Event.(*events.CounterEvent)).To(Equal(&events.CounterEvent{
+				Name:  proto.String("signatureVerifier.validSignatures"),
+				Delta: proto.Uint64(1),
+			}))
 		})
 	})
 })

--- a/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/test
+++ b/Godeps/_workspace/src/github.com/cloudfoundry/dropsonde/test
@@ -1,7 +1,0 @@
-set -e
-cd `dirname $0`
-go fmt ./...
-go vet ./...
-GINKGO="ginkgo -r --race --randomizeAllSpecs --failOnPending --skipMeasurements"
-export DROPSONDE_HEARTBEAT_INTERVAL_SECS=0.375
-$GINKGO -cover

--- a/Godeps/_workspace/src/github.com/gogo/protobuf/proto/encode_gogo.go
+++ b/Godeps/_workspace/src/github.com/gogo/protobuf/proto/encode_gogo.go
@@ -40,6 +40,10 @@ import (
 	"reflect"
 )
 
+func NewRequiredNotSetError(field string) *RequiredNotSetError {
+	return &RequiredNotSetError{field}
+}
+
 type Sizer interface {
 	Size() int
 }


### PR DESCRIPTION
Previously locked version of Dropsonde emitted metrics tagged with app ID; this causes instability in the Collector (and too many metrics sent to cloud providers).

[#95428788](https://www.pivotaltracker.com/story/show/95428788)

Signed-off-by: John Tuley <jtuley@pivotal.io>