### PR TITLE
Added cache headers to heartbeat response

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -244,7 +244,9 @@ var _ = Describe("Proxy", func() {
 		req.Header.Set("User-Agent", "HTTP-Monitor/1.1")
 		x.WriteRequest(req)
 
-		_, body := x.ReadResponse()
+		resp, body := x.ReadResponse()
+		Ω(resp.Header.Get("Cache-Control")).To(Equal("private, max-age=0"))
+		Ω(resp.Header.Get("Expires")).To(Equal("0"))
 		Ω(body).To(Equal("ok\n"))
 	})
 

--- a/proxy/request_handler.go
+++ b/proxy/request_handler.go
@@ -56,6 +56,8 @@ func (h *RequestHandler) Logger() *steno.Logger {
 }
 
 func (h *RequestHandler) HandleHeartbeat() {
+	h.response.Header().Set("Cache-Control", "private, max-age=0")
+	h.response.Header().Set("Expires", "0")
 	h.logrecord.StatusCode = http.StatusOK
 	h.response.WriteHeader(http.StatusOK)
 	h.response.Write([]byte("ok\n"))


### PR DESCRIPTION
Added "Cache-Control" and "Expires" headers to prevent caching of heartbeat responses.
-------------------------------------------------------------------------------------------------------------------------------

HTTP status code 200 is defined as [cacheable by default](https://tools.ietf.org/html/rfc7231#section-6.1), which means that responses can be reused by a (shared) cache without revalidation "unless otherwise indicated".

That's why the current implementation can cause the following problems:

### 1. Stale response
A heartbeat request is answered with "OK" although the gorouter is not reachable or in a non-"OK" status. This pull request solves this issue by setting the required cache headers.

### 2. Cache pollution
More critical is this behaviour in combination with the fact that host and path of the request are ignored. 
In an environment with a shared cache (e.g. a CDN or caching proxy) this can cause "cache pollution". A curl request like `curl -vv -A "HTTP-Monitor/1.1" http://pivotal.io/platform-as-a-service/pivotal-cloud-foundry` could consequently change the responses for requests with other user agents to a body with a plain "OK". I tested this with some basic configurations in Akamai and Fastly, both CDNs would cache the responses.
This pull request will prevent heartbeats from being cached and will therefore keep the cache valid.