### PR TITLE
As an operator of Cloud Foundry, I want to enable logging of specified headers for all applications.

### DIFF
--- a/access_log/access_log_record.go
+++ b/access_log/access_log_record.go
@@ -71,7 +71,7 @@ func (r *AccessLogRecord) makeRecord() *bytes.Buffer {
 		fmt.Fprintf(b, `app_id:%s`, r.RouteEndpoint.ApplicationId)
 	}
 
-	if r.ExtraHeadersToLog != nil {
+	if r.ExtraHeadersToLog != nil && len(r.ExtraHeadersToLog) > 0 {
 		fmt.Fprintf(b, ` %s`, r.ExtraHeaders())
 	}
 

--- a/access_log/access_log_record.go
+++ b/access_log/access_log_record.go
@@ -106,7 +106,8 @@ func (r *AccessLogRecord) ExtraHeaders() string {
 	for _, header := range r.ExtraHeadersToLog {
 		// X-Something-Cool -> x_something_cool
 		formatted_header_name := strings.Replace(strings.ToLower(header), "-", "_", -1)
-		headerString := fmt.Sprintf("%s:%s", formatted_header_name, r.FormatRequestHeader(header))
+		escaped_header_value := strings.Replace(r.FormatRequestHeader(header), "\"", "\\\"", -1)
+		headerString := fmt.Sprintf("%s:\"%s\"", formatted_header_name, escaped_header_value)
 		extraHeaders = append(extraHeaders, headerString)
 	}
 	return strings.Join(extraHeaders, " ")

--- a/access_log/access_log_record_test.go
+++ b/access_log/access_log_record_test.go
@@ -87,7 +87,9 @@ var _ = Describe("AccessLogRecord", func() {
 					Opaque: "http://example.com/request",
 				},
 				Header: http.Header{
-					"X-Extra-Header": []string{"Cheerio"},
+					"Cache-Control":   []string{"no-cache"},
+					"Accept-Encoding": []string{"gzip, deflate"},
+					"If-Match":        []string{"\"737060cd8c284d8af7ad3082f209582d\""},
 				},
 				RemoteAddr: "FakeRemoteAddr",
 			},
@@ -95,7 +97,7 @@ var _ = Describe("AccessLogRecord", func() {
 				ApplicationId: "FakeApplicationId",
 			},
 			StartedAt:         time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
-			ExtraHeadersToLog: []string{"X-Extra-Header"},
+			ExtraHeadersToLog: []string{"Cache-Control", "Accept-Encoding", "If-Match", "Doesnt-Exist"},
 		}
 
 		recordString := "FakeRequestHost - " +
@@ -111,7 +113,10 @@ var _ = Describe("AccessLogRecord", func() {
 			"vcap_request_id:- " +
 			"response_time:MissingFinishedAt " +
 			"app_id:FakeApplicationId " +
-			"x_extra_header:Cheerio" +
+			"cache_control:\"no-cache\" " +
+			"accept_encoding:\"gzip, deflate\" " +
+			"if_match:\"\\\"737060cd8c284d8af7ad3082f209582d\\\"\" " +
+			"doesnt_exist:\"-\"" +
 			"\n"
 
 		Expect(record.LogMessage()).To(Equal(recordString))

--- a/access_log/access_log_record_test.go
+++ b/access_log/access_log_record_test.go
@@ -111,7 +111,7 @@ var _ = Describe("AccessLogRecord", func() {
 			"vcap_request_id:- " +
 			"response_time:MissingFinishedAt " +
 			"app_id:FakeApplicationId " +
-			"headers:{\"X-Extra-Header\":\"Cheerio\"}" +
+			"x_extra_header:Cheerio" +
 			"\n"
 
 		Expect(record.LogMessage()).To(Equal(recordString))

--- a/access_log/access_log_record_test.go
+++ b/access_log/access_log_record_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 var _ = Describe("AccessLogRecord", func() {
+
 	It("Makes a record with all values", func() {
 		record := CompleteAccessLogRecord()
 
@@ -76,6 +77,45 @@ var _ = Describe("AccessLogRecord", func() {
 		Expect(record.LogMessage()).To(Equal(""))
 	})
 
+	It("Appends extra headers if specified", func() {
+		record := AccessLogRecord{
+			Request: &http.Request{
+				Host:   "FakeRequestHost",
+				Method: "FakeRequestMethod",
+				Proto:  "FakeRequestProto",
+				URL: &url.URL{
+					Opaque: "http://example.com/request",
+				},
+				Header: http.Header{
+					"X-Extra-Header": []string{"Cheerio"},
+				},
+				RemoteAddr: "FakeRemoteAddr",
+			},
+			RouteEndpoint: &route.Endpoint{
+				ApplicationId: "FakeApplicationId",
+			},
+			StartedAt:         time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			ExtraHeadersToLog: []string{"X-Extra-Header"},
+		}
+
+		recordString := "FakeRequestHost - " +
+			"[01/01/2000:00:00:00 +0000] " +
+			"\"FakeRequestMethod http://example.com/request FakeRequestProto\" " +
+			"MissingResponseStatusCode " +
+			"0 " +
+			"0 " +
+			"\"-\" " +
+			"\"-\" " +
+			"FakeRemoteAddr " +
+			"x_forwarded_for:\"-\" " +
+			"vcap_request_id:- " +
+			"response_time:MissingFinishedAt " +
+			"app_id:FakeApplicationId " +
+			"headers:{\"X-Extra-Header\":\"Cheerio\"}" +
+			"\n"
+
+		Expect(record.LogMessage()).To(Equal(recordString))
+	})
 })
 
 func CompleteAccessLogRecord() AccessLogRecord {

--- a/config/config.go
+++ b/config/config.go
@@ -112,6 +112,8 @@ type Config struct {
 	DrainTimeout               time.Duration `yaml:"-"`
 	Ip                         string        `yaml:"-"`
 	RouteServiceEnabled        bool          `yaml:"-"`
+
+	ExtraHeadersToLog []string `yaml:"extra_headers_to_log"`
 }
 
 var defaultConfig = Config{

--- a/example_config/example.yml
+++ b/example_config/example.yml
@@ -26,3 +26,8 @@ publish_active_apps_interval: 0 # 0 means disabled
 secure_cookies: true
 route_service_timeout: 60
 route_service_secret: "tWPE+sWJq+ZnGJpyKkIPYg=="
+
+extra_headers_to_log:
+  - Span-Id
+  - Trace-Id
+  - Cache-Control

--- a/main.go
+++ b/main.go
@@ -185,6 +185,7 @@ func buildProxy(c *config.Config, registry rregistry.RegistryInterface, accessLo
 		RouteServiceTimeout: c.RouteServiceTimeout,
 		Crypto:              crypto,
 		CryptoPrev:          cryptoPrev,
+		ExtraHeadersToLog:   c.ExtraHeadersToLog,
 	}
 	return proxy.NewProxy(args)
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -58,6 +58,7 @@ type ProxyArgs struct {
 	RouteServiceTimeout time.Duration
 	Crypto              secure.Crypto
 	CryptoPrev          secure.Crypto
+	ExtraHeadersToLog   []string
 }
 
 type proxy struct {
@@ -70,6 +71,7 @@ type proxy struct {
 	transport          *http.Transport
 	secureCookies      bool
 	routeServiceConfig *route_service.RouteServiceConfig
+	ExtraHeadersToLog  []string
 }
 
 func NewProxy(args ProxyArgs) Proxy {
@@ -99,6 +101,7 @@ func NewProxy(args ProxyArgs) Proxy {
 		},
 		secureCookies:      args.SecureCookies,
 		routeServiceConfig: routeServiceConfig,
+		ExtraHeadersToLog:  args.ExtraHeadersToLog,
 	}
 
 	return p
@@ -134,8 +137,9 @@ func (p *proxy) lookup(request *http.Request) *route.Pool {
 func (p *proxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
 	startedAt := time.Now()
 	accessLog := access_log.AccessLogRecord{
-		Request:   request,
-		StartedAt: startedAt,
+		Request:           request,
+		StartedAt:         startedAt,
+		ExtraHeadersToLog: p.ExtraHeadersToLog,
 	}
 
 	requestBodyCounter := &countingReadCloser{delegate: request.Body}


### PR DESCRIPTION
This PR implements the use case 

```
As an operator of Cloud Foundry, 
I want to enable logging of specified headers for all applications.
```

It is based on the [discussion](http://cf-dev.70369.x6.nabble.com/cf-dev-Allow-gorouter-to-log-random-headers-tp800p912.html) on the mailing list.

If you specify the following in your gorouter config
```
extra_headers_to_log:
  - Span-Id
  - Trace-Id
  - Cache-Control
```

your access log line will look like

```
FakeRequestHost - [01/01/2000:00:00:00 +0000] "FakeRequestMethod http://example.com/request FakeRequestProto" MissingResponseStatusCode 0 0 "-" "-" FakeRemoteAddr x_forwarded_for:"-" vcap_request_id:- response_time:MissingFinishedAt app_id:FakeApplicationId headers:{"Cache-Control":"private","Span-Id":"3888dcb6-34f4-11e5-a151-feff819cdc9f","Trace-Id":"7b28f886-fe5f-41af-8182-f88c8fec9e1c"}
```