### PR TITLE
Optimize access_log_record.go

### DIFF
--- a/access_log/access_log_record.go
+++ b/access_log/access_log_record.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,6 +22,7 @@ type AccessLogRecord struct {
 	BodyBytesSent        int
 	RequestBytesReceived int
 	ExtraHeadersToLog    []string
+	record               string
 }
 
 func (r *AccessLogRecord) FormatStartedAt() string {
@@ -39,49 +41,56 @@ func (r *AccessLogRecord) ResponseTime() float64 {
 	return float64(r.FinishedAt.UnixNano()-r.StartedAt.UnixNano()) / float64(time.Second)
 }
 
-func (r *AccessLogRecord) makeRecord() *bytes.Buffer {
-	b := &bytes.Buffer{}
-	fmt.Fprintf(b, `%s - `, r.Request.Host)
-	fmt.Fprintf(b, `[%s] `, r.FormatStartedAt())
-	fmt.Fprintf(b, `"%s %s %s" `, r.Request.Method, r.Request.URL.RequestURI(), r.Request.Proto)
-
-	if r.StatusCode == 0 {
-		fmt.Fprintf(b, "MissingResponseStatusCode ")
-	} else {
-		fmt.Fprintf(b, `%d `, r.StatusCode)
+// memoize makeRecord()
+func (r *AccessLogRecord) getRecord() string {
+	if len(r.record) == 0 {
+		r.record = r.makeRecord()
 	}
 
-	fmt.Fprintf(b, `%d `, r.RequestBytesReceived)
-	fmt.Fprintf(b, `%d `, r.BodyBytesSent)
-	fmt.Fprintf(b, `"%s" `, r.FormatRequestHeader("Referer"))
-	fmt.Fprintf(b, `"%s" `, r.FormatRequestHeader("User-Agent"))
-	fmt.Fprintf(b, `%s `, r.Request.RemoteAddr)
-	fmt.Fprintf(b, `x_forwarded_for:"%s" `, r.FormatRequestHeader("X-Forwarded-For"))
-	fmt.Fprintf(b, `x_forwarded_proto:"%s" `, r.FormatRequestHeader("X-Forwarded-Proto"))
-	fmt.Fprintf(b, `vcap_request_id:%s `, r.FormatRequestHeader("X-Vcap-Request-Id"))
+	return r.record
+}
 
-	if r.ResponseTime() < 0 {
-		fmt.Fprintf(b, "response_time:MissingFinishedAt ")
-	} else {
-		fmt.Fprintf(b, `response_time:%.9f `, r.ResponseTime())
+func (r *AccessLogRecord) makeRecord() string {
+	statusCode, responseTime, appId, extraHeaders := "-", "-", "-", ""
+
+	if r.StatusCode != 0 {
+		statusCode = strconv.Itoa(r.StatusCode)
 	}
 
-	if r.RouteEndpoint == nil {
-		fmt.Fprintf(b, "app_id:MissingRouteEndpointApplicationId")
-	} else {
-		fmt.Fprintf(b, `app_id:%s`, r.RouteEndpoint.ApplicationId)
+	if r.ResponseTime() >= 0 {
+		responseTime = strconv.FormatFloat(r.ResponseTime(), 'f', -1, 32)
+	}
+
+	if r.RouteEndpoint != nil {
+		appId = r.RouteEndpoint.ApplicationId
 	}
 
 	if r.ExtraHeadersToLog != nil && len(r.ExtraHeadersToLog) > 0 {
-		fmt.Fprintf(b, ` %s`, r.ExtraHeaders())
+		extraHeaders = r.ExtraHeaders()
 	}
 
-	fmt.Fprint(b, "\n")
-	return b
+	return fmt.Sprintf(`%s - [%s] "%s %s %s" %s %d %d "%s" "%s" %s x_forwarded_for:"%s" x_forwarded_proto:"%s" vcap_request_id:%s response_time:%s app_id:%s%s`+"\n",
+		r.Request.Host,
+		r.FormatStartedAt(),
+		r.Request.Method,
+		r.Request.URL.RequestURI(),
+		r.Request.Proto,
+		statusCode,
+		r.RequestBytesReceived,
+		r.BodyBytesSent,
+		r.FormatRequestHeader("Referer"),
+		r.FormatRequestHeader("User-Agent"),
+		r.Request.RemoteAddr,
+		r.FormatRequestHeader("X-Forwarded-For"),
+		r.FormatRequestHeader("X-Forwarded-Proto"),
+		r.FormatRequestHeader("X-Vcap-Request-Id"),
+		responseTime,
+		appId,
+		extraHeaders)
 }
 
 func (r *AccessLogRecord) WriteTo(w io.Writer) (int64, error) {
-	recordBuffer := r.makeRecord()
+	recordBuffer := bytes.NewBufferString(r.getRecord())
 	return recordBuffer.WriteTo(w)
 }
 
@@ -98,18 +107,18 @@ func (r *AccessLogRecord) LogMessage() string {
 		return ""
 	}
 
-	recordBuffer := r.makeRecord()
-	return recordBuffer.String()
+	return r.getRecord()
 }
 
 func (r *AccessLogRecord) ExtraHeaders() string {
-	extraHeaders := []string{}
+	extraHeaders := make([]string, 0, len(r.ExtraHeadersToLog)*4)
+
 	for _, header := range r.ExtraHeadersToLog {
 		// X-Something-Cool -> x_something_cool
-		formatted_header_name := strings.Replace(strings.ToLower(header), "-", "_", -1)
-		escaped_header_value := strings.Replace(r.FormatRequestHeader(header), "\"", "\\\"", -1)
-		headerString := fmt.Sprintf("%s:\"%s\"", formatted_header_name, escaped_header_value)
-		extraHeaders = append(extraHeaders, headerString)
+		headerName := strings.Replace(strings.ToLower(header), "-", "_", -1)
+		headerValue := strconv.Quote(r.FormatRequestHeader(header))
+		extraHeaders = append(extraHeaders, " ", headerName, ":", headerValue)
 	}
-	return strings.Join(extraHeaders, " ")
+
+	return strings.Join(extraHeaders, "")
 }

--- a/access_log/access_log_record.go
+++ b/access_log/access_log_record.go
@@ -58,7 +58,7 @@ func (r *AccessLogRecord) makeRecord() string {
 	}
 
 	if r.ResponseTime() >= 0 {
-		responseTime = strconv.FormatFloat(r.ResponseTime(), 'f', -1, 32)
+		responseTime = strconv.FormatFloat(r.ResponseTime(), 'f', -1, 64)
 	}
 
 	if r.RouteEndpoint != nil {

--- a/access_log/access_log_record_test.go
+++ b/access_log/access_log_record_test.go
@@ -55,7 +55,7 @@ var _ = Describe("AccessLogRecord", func() {
 			"x_forwarded_for:\"FakeProxy1, FakeProxy2\" " +
 			"x_forwarded_proto:\"FakeOriginalRequestProto\" " +
 			"vcap_request_id:abc-123-xyz-pdq " +
-			"response_time:60.000000000 " +
+			"response_time:60 " +
 			"app_id:FakeApplicationId" +
 			"\n"
 
@@ -83,7 +83,7 @@ var _ = Describe("AccessLogRecord", func() {
 		recordString := "FakeRequestHost - " +
 			"[01/01/2000:00:00:00 +0000] " +
 			"\"FakeRequestMethod http://example.com/request FakeRequestProto\" " +
-			"MissingResponseStatusCode " +
+			"- " +
 			"0 " +
 			"0 " +
 			"\"-\" " +
@@ -92,7 +92,7 @@ var _ = Describe("AccessLogRecord", func() {
 			"x_forwarded_for:\"-\" " +
 			"x_forwarded_proto:\"-\" " +
 			"vcap_request_id:- " +
-			"response_time:MissingFinishedAt " +
+			"response_time:- " +
 			"app_id:FakeApplicationId" +
 			"\n"
 
@@ -130,7 +130,7 @@ var _ = Describe("AccessLogRecord", func() {
 		recordString := "FakeRequestHost - " +
 			"[01/01/2000:00:00:00 +0000] " +
 			"\"FakeRequestMethod http://example.com/request FakeRequestProto\" " +
-			"MissingResponseStatusCode " +
+			"- " +
 			"0 " +
 			"0 " +
 			"\"-\" " +
@@ -139,7 +139,7 @@ var _ = Describe("AccessLogRecord", func() {
 			"x_forwarded_for:\"-\" " +
 			"x_forwarded_proto:\"-\" " +
 			"vcap_request_id:- " +
-			"response_time:MissingFinishedAt " +
+			"response_time:- " +
 			"app_id:FakeApplicationId " +
 			"cache_control:\"no-cache\" " +
 			"accept_encoding:\"gzip, deflate\" " +

--- a/access_log/file_and_loggregator_access_logger_test.go
+++ b/access_log/file_and_loggregator_access_logger_test.go
@@ -79,15 +79,16 @@ var _ = Describe("AccessLog", func() {
 	})
 
 	Measure("Log write speed", func(b Benchmarker) {
-		r := CreateAccessLogRecord()
 		w := nullWriter{}
 
 		b.Time("writeTime", func() {
-			for i := 0; i < 100; i++ {
+			for i := 0; i < 500; i++ {
+				r := CreateAccessLogRecord()
+				r.WriteTo(w)
 				r.WriteTo(w)
 			}
 		})
-	}, 100)
+	}, 500)
 })
 
 func CreateAccessLogRecord() *AccessLogRecord {


### PR DESCRIPTION
Coalesce log line printing in a single Sprintf and memoize the result so that we don't build each log line twice
Three small functional changes:
- Missing values are replaced by `-` instead of the verbose `Missing<name-of-field>` placeholder
- The request duration does not print pointless 0s after the decimal separator
- Extra headers values are properly escaped using strconv.Quote

With the changes to the benchmark included in the PR (github.com/cloudfoundry/gorouter/access_log/file_and_loggregator_access_logger_test.go) we get, without the patch:
```
  Ran 500 samples:
  writeTime:
    Fastest Time: 0.009s
    Slowest Time: 0.046s
    Average Time: 0.011s ± 0.005s
```

and, with the patch:
```
  Ran 500 samples:
  writeTime:
    Fastest Time: 0.004s
    Slowest Time: 0.036s
    Average Time: 0.005s ± 0.003s
```