### PR TITLE
Fixes #106 - Allow HTTP request target in absolute-form

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -124,7 +124,14 @@ func (p *proxy) getStickySession(request *http.Request) string {
 }
 
 func (p *proxy) lookup(request *http.Request) *route.Pool {
-	uri := route.Uri(hostWithoutPort(request) + request.RequestURI)
+	var requestPath string
+	if request.URL.IsAbs() {
+		requestPath = request.URL.Path
+	} else {
+		requestPath = request.RequestURI
+	}
+
+	uri := route.Uri(hostWithoutPort(request) + requestPath)
 	return p.registry.Lookup(uri)
 }
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -150,6 +150,25 @@ var _ = Describe("Proxy", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 	})
 
+	It("responds to HTTP/1.1 with absolute-form request target", func() {
+		ln := registerHandler(r, "test.io", func(conn *test_util.HttpConn) {
+			conn.CheckLine("GET http://test.io/ HTTP/1.1")
+
+			conn.WriteResponse(test_util.NewResponse(http.StatusOK))
+		})
+		defer ln.Close()
+
+		conn := dialProxy(proxyServer)
+
+		conn.WriteLines([]string{
+			"GET http://test.io/ HTTP/1.1",
+			"Host: test.io",
+		})
+
+		resp, _ := conn.ReadResponse()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	})
+
 	It("does not respond to unsupported HTTP versions", func() {
 		conn := dialProxy(proxyServer)
 


### PR DESCRIPTION
If the router recieves a request like
  GET http://my.test.io/my-path HTTP/1.1
  Host: my.test.io

an error message "Requested route ('my.test.io') does not exist." is returned, even though the route my.test.io exists.

This patch provides a test and fix for the issue.