### PR TITLE
Graceful drain

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,6 +94,7 @@ type Config struct {
 	EndpointTimeoutInSeconds             int `yaml:"endpoint_timeout"`
 	RouteServiceTimeoutInSeconds         int `yaml:"route_services_timeout"`
 
+	DrainWaitInSeconds    int  `yaml:"drain_wait,omitempty"`
 	DrainTimeoutInSeconds int  `yaml:"drain_timeout,omitempty"`
 	SecureCookies         bool `yaml:"secure_cookies"`
 
@@ -109,6 +110,7 @@ type Config struct {
 	StartResponseDelayInterval time.Duration `yaml:"-"`
 	EndpointTimeout            time.Duration `yaml:"-"`
 	RouteServiceTimeout        time.Duration `yaml:"-"`
+	DrainWait                  time.Duration `yaml:"-"`
 	DrainTimeout               time.Duration `yaml:"-"`
 	Ip                         string        `yaml:"-"`
 	RouteServiceEnabled        bool          `yaml:"-"`
@@ -165,11 +167,14 @@ func (c *Config) Process() {
 		log.Warnf("DropletStaleThreshold (%s) cannot be less than StartResponseDelayInterval (%s); setting both equal to StartResponseDelayInterval and continuing", c.DropletStaleThreshold, c.StartResponseDelayInterval)
 	}
 
-	drain := c.DrainTimeoutInSeconds
-	if drain == 0 {
-		drain = c.EndpointTimeoutInSeconds
+	c.DrainTimeout = c.EndpointTimeout
+	if c.DrainTimeoutInSeconds > 0 {
+		c.DrainTimeout = time.Duration(c.DrainTimeoutInSeconds) * time.Second
 	}
-	c.DrainTimeout = time.Duration(drain) * time.Second
+
+	if c.DrainWaitInSeconds > 0 {
+		c.DrainWait = time.Duration(c.DrainWaitInSeconds) * time.Second
+	}
 
 	c.Ip, err = localip.LocalIP()
 	if err != nil {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -38,6 +38,8 @@ type AfterRoundTrip func(rsp *http.Response, endpoint *route.Endpoint, err error
 
 type Proxy interface {
 	ServeHTTP(responseWriter http.ResponseWriter, request *http.Request)
+	// Drain signals Proxy that the gorouter is about to shutdown
+	Drain()
 }
 
 type ProxyArgs struct {
@@ -65,6 +67,7 @@ type proxy struct {
 	accessLogger       access_log.AccessLogger
 	transport          *http.Transport
 	secureCookies      bool
+	heartbeatOK        int32
 	routeServiceConfig *route_service.RouteServiceConfig
 	ExtraHeadersToLog  []string
 }
@@ -95,6 +98,7 @@ func NewProxy(args ProxyArgs) Proxy {
 			TLSClientConfig:    args.TLSConfig,
 		},
 		secureCookies:      args.SecureCookies,
+		heartbeatOK:        1, // 1->true, 0->false
 		routeServiceConfig: routeServiceConfig,
 		ExtraHeadersToLog:  args.ExtraHeadersToLog,
 	}
@@ -129,6 +133,11 @@ func (p *proxy) lookup(request *http.Request) *route.Pool {
 	return p.registry.Lookup(uri)
 }
 
+// Drain stops sending successful heartbeats back to the loadbalancer
+func (p *proxy) Drain() {
+	atomic.StoreInt32(&(p.heartbeatOK), 0)
+}
+
 func (p *proxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
 	startedAt := time.Now()
 	accessLog := access_log.AccessLogRecord{
@@ -154,7 +163,7 @@ func (p *proxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.Requ
 	}
 
 	if isLoadBalancerHeartbeat(request) {
-		handler.HandleHeartbeat()
+		handler.HandleHeartbeat(atomic.LoadInt32(&p.heartbeatOK) != 0)
 		return
 	}
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -174,7 +174,24 @@ var _ = Describe("Proxy", func() {
 		resp, body := conn.ReadResponse()
 		Expect(resp.Header.Get("Cache-Control")).To(Equal("private, max-age=0"))
 		Expect(resp.Header.Get("Expires")).To(Equal("0"))
+		Expect(resp.Status).To(Equal("200 OK"))
 		Expect(body).To(Equal("ok\n"))
+	})
+
+	It("responds with failure to load balancer check after StopHeartbeat() has been called", func() {
+		p.Drain()
+
+		conn := dialProxy(proxyServer)
+
+		req := test_util.NewRequest("GET", "", "/", nil)
+		req.Header.Set("User-Agent", "HTTP-Monitor/1.1")
+		conn.WriteRequest(req)
+
+		resp, body := conn.ReadResponse()
+		Expect(resp.Header.Get("Cache-Control")).To(Equal("private, max-age=0"))
+		Expect(resp.Header.Get("Expires")).To(Equal("0"))
+		Expect(resp.Status).NotTo(Equal("200 OK"))
+		Expect(body).NotTo(Equal("ok\n"))
 	})
 
 	It("responds to unknown host with 404", func() {

--- a/proxy/request_handler.go
+++ b/proxy/request_handler.go
@@ -13,9 +13,9 @@ import (
 	"github.com/cloudfoundry/gorouter/access_log"
 	"github.com/cloudfoundry/gorouter/common"
 	router_http "github.com/cloudfoundry/gorouter/common/http"
+	"github.com/cloudfoundry/gorouter/metrics"
 	"github.com/cloudfoundry/gorouter/route"
 	steno "github.com/cloudfoundry/gosteno"
-"github.com/cloudfoundry/gorouter/metrics"
 )
 
 type RequestHandler struct {
@@ -55,12 +55,17 @@ func (h *RequestHandler) Logger() *steno.Logger {
 	return h.StenoLogger
 }
 
-func (h *RequestHandler) HandleHeartbeat() {
+func (h *RequestHandler) HandleHeartbeat(ok bool) {
 	h.response.Header().Set("Cache-Control", "private, max-age=0")
 	h.response.Header().Set("Expires", "0")
-	h.logrecord.StatusCode = http.StatusOK
-	h.response.WriteHeader(http.StatusOK)
-	h.response.Write([]byte("ok\n"))
+	if ok {
+		h.logrecord.StatusCode = http.StatusOK
+		h.response.WriteHeader(http.StatusOK)
+		h.response.Write([]byte("ok\n"))
+	} else {
+		h.logrecord.StatusCode = http.StatusServiceUnavailable
+		h.response.WriteHeader(http.StatusServiceUnavailable)
+	}
 	h.request.Close = true
 }
 

--- a/router/router.go
+++ b/router/router.go
@@ -195,15 +195,15 @@ func (r *Router) OnErrOrSignal(signals <-chan os.Signal, errChan chan error) {
 }
 
 func (r *Router) DrainAndStop() {
-	drainTimeout := r.config.DrainTimeout
 	r.logger.Infod(
 		map[string]interface{}{
-			"timeout": (drainTimeout).String(),
+			"wait":    (r.config.DrainWait).String(),
+			"timeout": (r.config.DrainTimeout).String(),
 		},
 		"gorouter.draining",
 	)
 
-	r.Drain(drainTimeout)
+	r.Drain(r.config.DrainWait, r.config.DrainTimeout)
 
 	r.Stop()
 }
@@ -260,7 +260,11 @@ func (r *Router) serveHTTP(server *http.Server, errChan chan error) error {
 	return nil
 }
 
-func (r *Router) Drain(drainTimeout time.Duration) error {
+func (r *Router) Drain(drainWait, drainTimeout time.Duration) error {
+	r.proxy.Drain()
+
+	<-time.After(drainWait)
+
 	r.stopListening()
 
 	drained := make(chan struct{})

--- a/router/router_drain_test.go
+++ b/router/router_drain_test.go
@@ -262,7 +262,7 @@ var _ = Describe("Router", func() {
 			<-blocker
 			go func() {
 				defer GinkgoRecover()
-				err := router.Drain(drainTimeout)
+				err := router.Drain(0, drainTimeout)
 				Expect(err).ToNot(HaveOccurred())
 				resultCh <- true
 			}()
@@ -312,7 +312,7 @@ var _ = Describe("Router", func() {
 
 			go func() {
 				defer GinkgoRecover()
-				err := router.Drain(500 * time.Millisecond)
+				err := router.Drain(0, 500*time.Millisecond)
 				resultCh <- err
 			}()
 
@@ -371,7 +371,7 @@ var _ = Describe("Router", func() {
 				<-blocker
 				go func() {
 					defer GinkgoRecover()
-					err := router.Drain(drainTimeout)
+					err := router.Drain(0, drainTimeout)
 					Expect(err).ToNot(HaveOccurred())
 					resultCh <- true
 				}()


### PR DESCRIPTION
During Drain() stop responding to heartbeats and wait a configurable amount of time before stopping listening.
Abruptly shutting down the listener may cause latency or lost requests for requests reaching the gorouter after it stops listening.
The drain_wait configuration specifies how long it takes for the downstream SLB to mark this gorouter as down.This will ensure that new traffic is steered away from this gorouter before the listener is stopped.
If unspecified drain_wait is 0 to avoid changing the current behavior. The cf-release enabling bits are in https://github.com/cloudfoundry/cf-release/pull/866.