### PR TITLE
Support disabling access logging to file and syslog

### DIFF
--- a/access_log/create_running_access_logger.go
+++ b/access_log/create_running_access_logger.go
@@ -7,20 +7,20 @@ import (
 	"github.com/cloudfoundry/gorouter/config"
 	"github.com/pivotal-golang/lager"
 
-	"os"
 	"io"
+	"os"
 )
 
 func CreateRunningAccessLogger(logger lager.Logger, config *config.Config) (AccessLogger, error) {
 
-	if config.AccessLog == "" && !config.Logging.LoggregatorEnabled {
+	if (config.AccessLog == "" || !config.Logging.AccessLoggingEnabled) && !config.Logging.LoggregatorEnabled {
 		return &NullAccessLogger{}, nil
 	}
 
 	var err error
 	var file *os.File
 	var writers []io.Writer
-	if config.AccessLog != "" {
+	if config.AccessLog != "" && config.Logging.AccessLoggingEnabled {
 		file, err = os.OpenFile(config.AccessLog, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
 		if err != nil {
 			logger.Error(fmt.Sprintf("Error creating accesslog file, %s", config.AccessLog), err)

--- a/access_log/create_running_access_logger_test.go
+++ b/access_log/create_running_access_logger_test.go
@@ -23,10 +23,25 @@ var _ = Describe("AccessLog", func() {
 		Expect(CreateRunningAccessLogger(logger, config)).To(BeAssignableToTypeOf(&NullAccessLogger{}))
 	})
 
+	It("creates null access loger if access log disabled, no access log location, and loggregator is disabled", func() {
+		config := config.DefaultConfig()
+		config.Logging.AccessLoggingEnabled = false
+
+		Expect(CreateRunningAccessLogger(logger, config)).To(BeAssignableToTypeOf(&NullAccessLogger{}))
+	})
+
+	It("creates null access loger if access log disabled when there is an access log location and loggregator is disabled", func() {
+		config := config.DefaultConfig()
+		config.AccessLog = "/dev/null"
+		config.Logging.AccessLoggingEnabled = false
+
+		Expect(CreateRunningAccessLogger(logger, config)).To(BeAssignableToTypeOf(&NullAccessLogger{}))
+	})
+
 	It("creates an access log when loggegrator is enabled", func() {
 		config := config.DefaultConfig()
 		config.Logging.LoggregatorEnabled = true
-		config.AccessLog = ""
+		config.Logging.AccessLoggingEnabled = false
 
 		accessLogger, _ := CreateRunningAccessLogger(logger, config)
 		Expect(accessLogger.(*FileAndLoggregatorAccessLogger).FileWriter()).To(BeNil())
@@ -34,7 +49,7 @@ var _ = Describe("AccessLog", func() {
 
 	})
 
-	It("creates an access log if an access log is specified", func() {
+	It("creates an access log if an access log is specified and access logging enabled", func() {
 		config := config.DefaultConfig()
 		config.AccessLog = "/dev/null"
 

--- a/config/config.go
+++ b/config/config.go
@@ -55,19 +55,21 @@ type OAuthConfig struct {
 }
 
 type LoggingConfig struct {
-	File               string `yaml:"file"`
-	Syslog             string `yaml:"syslog"`
-	Level              string `yaml:"level"`
-	LoggregatorEnabled bool   `yaml:"loggregator_enabled"`
-	MetronAddress      string `yaml:"metron_address"`
+	File                 string `yaml:"file"`
+	Syslog               string `yaml:"syslog"`
+	Level                string `yaml:"level"`
+	LoggregatorEnabled   bool   `yaml:"loggregator_enabled"`
+	AccessLoggingEnabled bool   `yaml:"access_logging_enabled"`
+	MetronAddress        string `yaml:"metron_address"`
 
 	// This field is populated by the `Process` function.
 	JobName string `yaml:"-"`
 }
 
 var defaultLoggingConfig = LoggingConfig{
-	Level:         "debug",
-	MetronAddress: "localhost:3457",
+	Level:                "debug",
+	MetronAddress:        "localhost:3457",
+	AccessLoggingEnabled: true,
 }
 
 type Config struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -87,6 +87,7 @@ logging:
   syslog: syslog
   level: debug2
   loggregator_enabled: true
+  access_logging_enabled: false
 `)
 			config.Initialize(b)
 
@@ -94,6 +95,7 @@ logging:
 			Expect(config.Logging.Syslog).To(Equal("syslog"))
 			Expect(config.Logging.Level).To(Equal("debug2"))
 			Expect(config.Logging.LoggregatorEnabled).To(Equal(true))
+			Expect(config.Logging.AccessLoggingEnabled).To(Equal(false))
 			Expect(config.Logging.JobName).To(Equal("gorouter"))
 		})
 


### PR DESCRIPTION
PR for https://github.com/cloudfoundry/gorouter/issues/117

I didn't notice before that gorouter already supported disabling loggregator logging.  Anyway I'd be fine changing this to `syslog_access_logging_enabled` if so desired.