### PR TITLE
Allow forcing X-Forwarded-Proto Header

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,18 @@ echo -e "PROXY TCP4 1.2.3.4 [GOROUTER IP] 12345 [GOROUTER PORT]\r\nGET / HTTP/1.
 
 You should see in the access logs on the GoRouter that the `X-Forwarded-For` header is `1.2.3.4`. You can read more about the PROXY Protocol [here](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt). 
 
+## SSL termination & X-Forwarded-Proto
+
+If you terminate SSL before passing traffic to gorouter it will incorrectly set the `X-Forwarded-Proto` header to `http` instead of `https`, which results in applications incorrectly detecting they are using an insecure connection.
+
+To force the `X-Forwarded-Proto` header to `https` you can configure your cf-release manifest as follows:
+
+```
+properties:
+  router:
+    force_forwarded_proto_https: true
+```
+
 ## HTTP/2 Support
 
 The GoRouter does not currently support proxying HTTP/2 connections, even over TLS. Connections made using HTTP/1.1, either by TLS or cleartext, will be proxied to backends over cleartext.

--- a/config/config.go
+++ b/config/config.go
@@ -100,6 +100,7 @@ type Config struct {
 	SSLKeyPath               string        `yaml:"ssl_key_path"`
 	SSLCertificate           tls.Certificate
 	SkipSSLValidation        bool `yaml:"skip_ssl_validation"`
+	ForceForwardedProtoHttps bool `yaml:"force_forwarded_proto_https"`
 
 	CipherString string `yaml:"cipher_suites"`
 	CipherSuites []uint16

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -355,6 +355,12 @@ enable_proxy: true
 
 			Expect(config.Tracing.EnableZipkin).To(BeFalse())
 		})
+
+		It("sets the proxy forwarded proto header", func() {
+			var b = []byte("force_forwarded_proto_https: true")
+			config.Initialize(b)
+			Expect(config.ForceForwardedProtoHttps).To(Equal(true))
+		})
 	})
 
 	Describe("Process", func() {

--- a/main.go
+++ b/main.go
@@ -182,6 +182,7 @@ func buildProxy(logger lager.Logger, c *config.Config, registry rregistry.Regist
 		ExtraHeadersToLog:    &c.ExtraHeadersToLog,
 		HealthCheckUserAgent: c.HealthCheckUserAgent,
 		EnableZipkin:         c.Tracing.EnableZipkin,
+		ForceForwardedProtoHttps: c.ForceForwardedProtoHttps,
 	}
 	return proxy.NewProxy(args)
 }

--- a/proxy/proxy_suite_test.go
+++ b/proxy/proxy_suite_test.go
@@ -94,6 +94,7 @@ var _ = JustBeforeEach(func() {
 		HealthCheckUserAgent:       "HTTP-Monitor/1.1",
 		EnableZipkin:               conf.Tracing.EnableZipkin,
 		ExtraHeadersToLog:          &conf.ExtraHeadersToLog,
+		ForceForwardedProtoHttps:   conf.ForceForwardedProtoHttps,
 	})
 
 	proxyServer, err = net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
There are situations where it's not possible to determine the
appropriate value for this header from the incoming connection (for
example when running behind an Amazon ELB in TCP mode where SSL
termination is handled by the ELB). This therefore adds a config option
to allow specifying a value that should be unconditionally added to all
downstream requests.