### PR TITLE
Add max length check on HTTP method

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -134,6 +134,8 @@ type Config struct {
 	TokenFetcherRetryIntervalInSeconds        int    `yaml:"token_fetcher_retry_interval"`
 	TokenFetcherExpirationBufferTimeInSeconds int64  `yaml:"token_fetcher_expiration_buffer_time"`
 
+	MaxHttpMethodLength int `yaml:"max_http_method_length"`
+
 	PidFile string `yaml:"pid_file"`
 }
 
@@ -159,6 +161,8 @@ var defaultConfig = Config{
 	TokenFetcherMaxRetries:                    3,
 	TokenFetcherRetryIntervalInSeconds:        5,
 	TokenFetcherExpirationBufferTimeInSeconds: 30,
+
+	MaxHttpMethodLength: 64,
 }
 
 func DefaultConfig() *Config {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -265,6 +265,11 @@ token_fetcher_expiration_buffer_time: 40
 			Expect(config.TokenFetcherRetryIntervalInSeconds).To(Equal(5))
 			Expect(config.TokenFetcherExpirationBufferTimeInSeconds).To(Equal(int64(30)))
 		})
+
+		It("sets the default max http method length", func() {
+			Expect(config.MaxHttpMethodLength).To(Equal(64))
+		})
+
 	})
 
 	Describe("Process", func() {

--- a/example_config/example.yml
+++ b/example_config/example.yml
@@ -31,3 +31,5 @@ extra_headers_to_log:
   - Span-Id
   - Trace-Id
   - Cache-Control
+
+max_http_method_length: 64

--- a/main.go
+++ b/main.go
@@ -167,9 +167,10 @@ func buildProxy(logger lager.Logger, c *config.Config, registry rregistry.Regist
 		RouteServiceEnabled:        c.RouteServiceEnabled,
 		RouteServiceTimeout:        c.RouteServiceTimeout,
 		RouteServiceRecommendHttps: c.RouteServiceRecommendHttps,
-		Crypto:            crypto,
-		CryptoPrev:        cryptoPrev,
-		ExtraHeadersToLog: c.ExtraHeadersToLog,
+		Crypto:              crypto,
+		CryptoPrev:          cryptoPrev,
+		ExtraHeadersToLog:   c.ExtraHeadersToLog,
+		MaxHttpMethodLength: c.MaxHttpMethodLength,
 	}
 	return proxy.NewProxy(args)
 }

--- a/proxy/handler/request_handler.go
+++ b/proxy/handler/request_handler.go
@@ -92,6 +92,12 @@ func (h *RequestHandler) HandleUnsupportedProtocol() {
 	conn.Close()
 }
 
+func (h *RequestHandler) HandleInvalidMethod() {
+	h.logger.Info("invalid-http-method")
+	h.writeStatus(http.StatusBadRequest, "invalid http method")
+	h.response.Done()
+}
+
 func (h *RequestHandler) HandleMissingRoute() {
 	h.logger.Info("unknown-route")
 

--- a/proxy/proxy_suite_test.go
+++ b/proxy/proxy_suite_test.go
@@ -91,6 +91,7 @@ var _ = JustBeforeEach(func() {
 		Crypto:                     crypto,
 		CryptoPrev:                 cryptoPrev,
 		RouteServiceRecommendHttps: recommendHttps,
+		MaxHttpMethodLength:        conf.MaxHttpMethodLength,
 	})
 
 	proxyServer, err = net.Listen("tcp", "127.0.0.1:0")

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1272,6 +1272,8 @@ var _ = Describe("Proxy", func() {
 	Context("when using standard and non-standard method in request line", func() {
 		It("responds with a 200", func() {
 			ln := registerHandler(r, "test/path", func(conn *test_util.HttpConn) {
+				_, err := conn.Reader.ReadString('\n')
+				Expect(err).NotTo(HaveOccurred())
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
 			})
 			defer ln.Close()

--- a/proxy/proxy_unit_test.go
+++ b/proxy/proxy_unit_test.go
@@ -52,6 +52,7 @@ var _ = Describe("Proxy Unit tests", func() {
 				RouteServiceTimeout: conf.RouteServiceTimeout,
 				Crypto:              crypto,
 				CryptoPrev:          cryptoPrev,
+				MaxHttpMethodLength: conf.MaxHttpMethodLength,
 			})
 
 			r.Register(route.Uri("some-app"), &route.Endpoint{})

--- a/router/router_drain_test.go
+++ b/router/router_drain_test.go
@@ -206,13 +206,14 @@ var _ = Describe("Router", func() {
 		varz = vvarz.NewVarz(registry)
 		logcounter := schema.NewLogCounter()
 		proxy := proxy.NewProxy(proxy.ProxyArgs{
-			Logger:          logger,
-			EndpointTimeout: config.EndpointTimeout,
-			Ip:              config.Ip,
-			TraceKey:        config.TraceKey,
-			Registry:        registry,
-			Reporter:        varz,
-			AccessLogger:    &access_log.NullAccessLogger{},
+			Logger:              logger,
+			EndpointTimeout:     config.EndpointTimeout,
+			Ip:                  config.Ip,
+			TraceKey:            config.TraceKey,
+			Registry:            registry,
+			Reporter:            varz,
+			AccessLogger:        &access_log.NullAccessLogger{},
+			MaxHttpMethodLength: config.MaxHttpMethodLength,
 		})
 
 		errChan := make(chan error, 2)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -92,13 +92,14 @@ var _ = Describe("Router", func() {
 		varz = vvarz.NewVarz(registry)
 		logcounter := schema.NewLogCounter()
 		proxy := proxy.NewProxy(proxy.ProxyArgs{
-			EndpointTimeout: config.EndpointTimeout,
-			Logger:          logger,
-			Ip:              config.Ip,
-			TraceKey:        config.TraceKey,
-			Registry:        registry,
-			Reporter:        varz,
-			AccessLogger:    &access_log.NullAccessLogger{},
+			EndpointTimeout:     config.EndpointTimeout,
+			Logger:              logger,
+			Ip:                  config.Ip,
+			TraceKey:            config.TraceKey,
+			Registry:            registry,
+			Reporter:            varz,
+			AccessLogger:        &access_log.NullAccessLogger{},
+			MaxHttpMethodLength: config.MaxHttpMethodLength,
 		})
 
 		router, err = NewRouter(logger, config, proxy, mbusClient, registry, varz, logcounter, nil)


### PR DESCRIPTION
Hey @shalako 

Encountered a situation where invalid requests were being sent to `gorouter` and we would like to NOT forward these on.

For example, right now if I sent a request line that has a large http method (or lots of garbage), this will be accepted by `gorouter` and forwarded on to the backend host.

```
FOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO / HTTP/1.1
Host: dora.bosh-lite.com
```

Based on the RFC, we cannot limit to the http methods to the standard
(HEAD, GET, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE) as there could be custom http methods.

In golang 1.6, the http server now validates the http method in the request line, however it just validates that it is a valid token / characters, but does not validate or limit the length.
Request line has no limits that I know of.

This PR is to put a sensible max limit length on the request line's http method (i.e. 64 chars) and if the method is greater than this max, the gorouter will return a 400 Bad Request (invalid http method)

```
HTTP/1.1 400 Bad Request
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
X-Vcap-Request-Id: 0abba867-865f-43a3-55de-787c02f5275f
Date: Fri, 29 Apr 2016 03:56:48 GMT
Content-Length: 37

400 Bad Request: invalid http method
```

I also made this configurable in case there are scenario's where operators would like to reduce or increase.  I also made sure that we cannot set this to lower than the max length of the standard http methods (i.e. CONNECT = length of 7).

I also have changes for cf-release to add to spec, templates, etc.

Please have a review and let me know.

Cheers
