### PR TITLE
Optional suspend route pruning if NATS unavailable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -99,13 +99,14 @@ type Config struct {
 	CipherString string `yaml:"cipher_suites"`
 	CipherSuites []uint16
 
-	PublishStartMessageIntervalInSeconds int `yaml:"publish_start_message_interval"`
-	PruneStaleDropletsIntervalInSeconds  int `yaml:"prune_stale_droplets_interval"`
-	DropletStaleThresholdInSeconds       int `yaml:"droplet_stale_threshold"`
-	PublishActiveAppsIntervalInSeconds   int `yaml:"publish_active_apps_interval"`
-	StartResponseDelayIntervalInSeconds  int `yaml:"start_response_delay_interval"`
-	EndpointTimeoutInSeconds             int `yaml:"endpoint_timeout"`
-	RouteServiceTimeoutInSeconds         int `yaml:"route_services_timeout"`
+	PublishStartMessageIntervalInSeconds int  `yaml:"publish_start_message_interval"`
+	SuspendPruningIfNatsUnavailable      bool `yaml:"suspend_pruning_if_nats_unavailable"`
+	PruneStaleDropletsIntervalInSeconds  int  `yaml:"prune_stale_droplets_interval"`
+	DropletStaleThresholdInSeconds       int  `yaml:"droplet_stale_threshold"`
+	PublishActiveAppsIntervalInSeconds   int  `yaml:"publish_active_apps_interval"`
+	StartResponseDelayIntervalInSeconds  int  `yaml:"start_response_delay_interval"`
+	EndpointTimeoutInSeconds             int  `yaml:"endpoint_timeout"`
+	RouteServiceTimeoutInSeconds         int  `yaml:"route_services_timeout"`
 
 	DrainWaitInSeconds    int  `yaml:"drain_wait,omitempty"`
 	DrainTimeoutInSeconds int  `yaml:"drain_timeout,omitempty"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -73,6 +73,20 @@ nats:
 			Expect(config.Nats[0].Pass).To(Equal("pass"))
 		})
 
+		Context("Suspend Pruning option", func() {
+			It("sets default suspend_pruning_if_nats_unavailable", func() {
+				Expect(config.SuspendPruningIfNatsUnavailable).To(BeFalse())
+			})
+
+			It("sets default suspend_pruning_if_nats_unavailable", func() {
+				var b = []byte(`
+suspend_pruning_if_nats_unavailable: true
+`)
+				config.Initialize(b)
+				Expect(config.SuspendPruningIfNatsUnavailable).To(BeTrue())
+			})
+		})
+
 		It("sets default logging configs", func() {
 			Expect(config.Logging.File).To(Equal(""))
 			Expect(config.Logging.Syslog).To(Equal(""))

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,6 +1,9 @@
 package registry_test
 
 import (
+	"fmt"
+	"net"
+
 	"github.com/cloudfoundry-incubator/routing-api/models"
 	. "github.com/cloudfoundry/gorouter/registry"
 	. "github.com/onsi/ginkgo"
@@ -622,6 +625,7 @@ var _ = Describe("RouteRegistry", func() {
 				configObj.PruneStaleDropletsInterval = 50 * time.Millisecond
 				configObj.DropletStaleThreshold = 100 * time.Millisecond
 				reporter = new(fakes.FakeRouteRegistryReporter)
+
 				r = NewRouteRegistry(logger, configObj, reporter)
 			})
 
@@ -638,6 +642,51 @@ var _ = Describe("RouteRegistry", func() {
 				Expect(logger).ToNot(gbytes.Say(`prune.*"log_level":0.*foo.com/bar`))
 			})
 		})
+
+		Context("when suspend pruning is triggered (i.e. nats offline)", func() {
+			var totalRoutes int
+
+			BeforeEach(func() {
+				totalRoutes = 1000
+				Expect(r.NumUris()).To(Equal(0))
+				Expect(r.NumEndpoints()).To(Equal(0))
+
+				// add endpoints
+				for i := 0; i < totalRoutes; i++ {
+					e := route.NewEndpoint("12345", "192.168.1.1", uint16(1024+i), "id1", nil, -1, "", modTag)
+					r.Register(route.Uri(fmt.Sprintf("foo-%d", i)), e)
+				}
+
+				r.StartPruningCycle()
+				r.SuspendPruning(func() bool { return true })
+				time.Sleep(configObj.PruneStaleDropletsInterval + 10*time.Millisecond)
+			})
+
+			It("does not remove any routes", func() {
+				Expect(r.NumUris()).To(Equal(totalRoutes))
+				Expect(r.NumEndpoints()).To(Equal(totalRoutes))
+
+				time.Sleep(configObj.PruneStaleDropletsInterval + 50*time.Millisecond)
+
+				Expect(r.NumUris()).To(Equal(totalRoutes))
+				Expect(r.NumEndpoints()).To(Equal(totalRoutes))
+			})
+
+			Context("when suspend pruning is turned off (i.e. nats back online)", func() {
+				It("marks all routes as updated and does not remove routes", func() {
+					Expect(r.NumUris()).To(Equal(totalRoutes))
+					Expect(r.NumEndpoints()).To(Equal(totalRoutes))
+
+					r.SuspendPruning(func() bool { return false })
+
+					time.Sleep(configObj.PruneStaleDropletsInterval + 10*time.Millisecond)
+
+					Expect(r.NumUris()).To(Equal(totalRoutes))
+					Expect(r.NumEndpoints()).To(Equal(totalRoutes))
+				})
+			})
+		})
+
 	})
 
 	Context("Varz data", func() {
@@ -687,3 +736,13 @@ var _ = Describe("RouteRegistry", func() {
 		Expect(string(marshalled)).To(Equal(`{}`))
 	})
 })
+
+func portListening(addr string) bool {
+	var ok bool
+	conn, err := net.Dial("tcp", addr)
+	if err == nil {
+		ok = true
+		defer conn.Close()
+	}
+	return ok
+}


### PR DESCRIPTION
Currently, in the event that a NATS cluster goes down or becomes unavailable, gorouter will continue to prune routes. More importantly, gorouter will actually attempt to reconnect to all configured NATS servers and if exceeds the NATS client MaxReconnect attempts, it will exit and monit will keep restarting gorouter. In this catastrophic scenario, gorouter will not retain any routing info and apps will not be routable.

This approach favors consistency over availability, however if an operator would prefer to keep apps routable in the event of a NATS cluster outage, this PR provides that option.

The PR does the following:
- Opt-in config **suspend_pruning_if_nats_unavailable** to suspend route pruning if we cannot connect to NATS
- Set max reconnect in NATS client to -1 (no limit) when suspend prune enabled
- if pruning was suspended at any point and when NATS becomes available, the routes 'updated' timestamp will be marked with a current timestamp, so that it "resets the clock" for routes and avoids gorouter from pruning all the routes once NATS comes back online
- Default behavior will remain as pruning routes and not override max reconnect (current behavior)

_NOTE: This strategy favors availability over consistency and there is a possibility of routing to an incorrect endpoint in the case of port re-use. To be used with caution._

Once this PR is merged, I can update cf-release spec, templates to include **router.suspend_pruning_if_nats_unavailable** with the default value being **false**.




**Acceptance:**
- enable "suspend_pruning_if_nats_unavailable" setting to true (can change by hand in gorouter.yml or via manifest change)
- restart gorouter
- start watching the gorouter routing table
i.e.
```
while true; do clear && curl -s http://router:router@IP_ADDRESS_OF_GOROUTER:8080/routes | jq . && sleep 3; done
```
- bring down all NATS instances one by one
- gorouter.log should indicate "prune-suspended"
- wait for period of time until prune stale droplet threshold exceeded (or longer)
- routes should still be showing up in watch of routing table
- bring back nats instances
- routes should remain showing up in watch of routing table