### PR TITLE
Implement listening for traffic on UNIX sockets

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -88,6 +88,7 @@ type Config struct {
 	AccessLog                AccessLog     `yaml:"access_log"`
 	EnableAccessLogStreaming bool          `yaml:"enable_access_log_streaming"`
 	DebugAddr                string        `yaml:"debug_addr"`
+	UnixAddr                 string        `yaml:"unix_addr"`
 	EnablePROXY              bool          `yaml:"enable_proxy"`
 	EnableSSL                bool          `yaml:"enable_ssl"`
 	SSLPort                  uint16        `yaml:"ssl_port"`


### PR DESCRIPTION
So I was stuck on a plane for 12 hours today and, unable to sleep, finally got around implementing #110. 

What's done so far:
- Opt-in HTTP UNIX socket listener (by setting the UnixAddr config to a non-empty value)
- Some refactoring in router.go to reduce code duplication
- Unit-tests for HTTP request, HTTP keep-alive, websocket, PROXY protocol and shutdown
