### PR TITLE
Add go-proxyproto 100ms timeout for Proxy Protocol Header

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -39,7 +39,8 @@ import (
 var DrainTimeout = errors.New("router: Drain timeout")
 
 const (
-	emitInterval = 1 * time.Second
+	emitInterval               = 1 * time.Second
+	proxyProtocolHeaderTimeout = 100 * time.Millisecond
 )
 
 var noDeadline = time.Time{}
@@ -292,7 +293,10 @@ func (r *Router) serveHTTPS(server *http.Server, errChan chan error) error {
 
 		r.tlsListener = tlsListener
 		if r.config.EnablePROXY {
-			r.tlsListener = &proxyproto.Listener{tlsListener}
+			r.tlsListener = &proxyproto.Listener{
+				Listener:           tlsListener,
+				ProxyHeaderTimeout: proxyProtocolHeaderTimeout,
+			}
 		}
 
 		r.logger.Info(fmt.Sprintf("Listening on %s", r.tlsListener.Addr()))
@@ -319,7 +323,10 @@ func (r *Router) serveHTTP(server *http.Server, errChan chan error) error {
 
 	r.listener = listener
 	if r.config.EnablePROXY {
-		r.listener = &proxyproto.Listener{listener}
+		r.listener = &proxyproto.Listener{
+			Listener:           listener,
+			ProxyHeaderTimeout: proxyProtocolHeaderTimeout,
+		}
 	}
 
 	r.logger.Info(fmt.Sprintf("Listening on %s", r.listener.Addr()))


### PR DESCRIPTION
# What 

As described in #141, currently the Proxy Protocol implementation has a bug that might cause go router stop accepting connections when using Proxy Protocol and a client connects without sending data. 

Solutions are upgrade to Golang 1.6 used a patched version of upstream go-proxyproto  which allows define a timeout to receive the Proxy Header.

This PR configure a 100ms timeout to receive the Proxy Header Protocol. 

# Consequences 

This PR:
 * hardcodes the timeout 100ms
 * assumes that 100ms is enough time to receive the Proxy Header from the proxy. 
     * That is very likely the case, as the proxy will send the header immediately after stablish the connection, and hopefully there is not such latency between the proxy and the gorouter!!!
     * In the worse case scenario, if it timeouts after 100ms, the connection will be drop as invalid HTTP request
 * If a client connects and does not send data, gorouter will still be block for 100ms and not accepting connections. This might degrade the performance if there is are clients constantly connecting and not sending data.

# Dependencies and additional work

**IMPORTANT:** 

This code depends on https://github.com/armon/go-proxyproto/commit/3daa90aec0039a806299b9078f4422fee950f33c and **it is not compatible with previous versions of the library**

Once this PR is merged, https://github.com/cloudfoundry-incubator/routing-release must be updated  with the submodule references for github.com/cloudfoundry/gorouter and https://github.com/armon/go-proxyproto

I will not do a PR on routing-release as it needs to be updated by whoever merges this.

# How to test

We included the [test added](https://github.com/cloudfoundry/gorouter/pull/126#issuecomment-231470118) by @shashwathi to check that multiple connections can be established.

Thx



(our project story https://www.pivotaltracker.com/story/show/126483997)