### PR TITLE
Track response metrics by component.

### DIFF
--- a/metrics/metrics_reporter.go
+++ b/metrics/metrics_reporter.go
@@ -40,7 +40,9 @@ func (m *MetricsReporter) CaptureRoutingRequest(b *route.Endpoint, req *http.Req
 }
 
 func (m *MetricsReporter) CaptureRoutingResponse(b *route.Endpoint, res *http.Response, t time.Time, d time.Duration) {
-	dropsondeMetrics.BatchIncrementCounter(getResponseCounterName(res))
+	responseCounterName := getResponseCounterName(res)
+
+	dropsondeMetrics.BatchIncrementCounter(responseCounterName)
 	dropsondeMetrics.BatchIncrementCounter("responses")
 
 	latency := float64(d / time.Millisecond)
@@ -49,6 +51,8 @@ func (m *MetricsReporter) CaptureRoutingResponse(b *route.Endpoint, res *http.Re
 
 	componentName, ok := b.Tags["component"]
 	if ok && len(componentName) > 0 {
+		dropsondeMetrics.BatchIncrementCounter(fmt.Sprintf("responses.%s", componentName))
+		dropsondeMetrics.BatchIncrementCounter(fmt.Sprintf("%s.%s", responseCounterName, componentName))
 		dropsondeMetrics.SendValue(fmt.Sprintf("latency.%s", componentName), latency, unit)
 	}
 }

--- a/metrics/metrics_reporter_test.go
+++ b/metrics/metrics_reporter_test.go
@@ -165,6 +165,22 @@ var _ = Describe("MetricsReporter", func() {
 			Eventually(func() uint64 { return sender.GetCounter("responses.xxx") }).Should(BeEquivalentTo(2))
 		})
 
+		It("increments the response metrics for the given component", func() {
+			response := http.Response{
+				StatusCode: 504,
+			}
+
+			endpoint.Tags["component"] = "CloudController"
+
+			metricsReporter.CaptureRoutingResponse(endpoint, &response, time.Now(), time.Millisecond)
+			Eventually(func() uint64 { return sender.GetCounter("responses.CloudController") }).Should(BeEquivalentTo(1))
+			Eventually(func() uint64 { return sender.GetCounter("responses.5xx.CloudController") }).Should(BeEquivalentTo(1))
+
+			metricsReporter.CaptureRoutingResponse(endpoint, &response, time.Now(), time.Millisecond)
+			Eventually(func() uint64 { return sender.GetCounter("responses.CloudController") }).Should(BeEquivalentTo(2))
+			Eventually(func() uint64 { return sender.GetCounter("responses.5xx.CloudController") }).Should(BeEquivalentTo(2))
+		})
+
 		It("increments the total responses", func() {
 			response2xx := http.Response{
 				StatusCode: 205,


### PR DESCRIPTION
Track response code counts by component, for parity with the `/varz` endpoint.
