### PR TITLE
Set log level for "prune-suspended" to info

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -201,7 +201,7 @@ func (r *RouteRegistry) pruneStaleDroplets() {
 
 	// suspend pruning if option enabled and if NATS is unavailable
 	if r.suspendPruning() {
-		r.logger.Debug("prune-suspended")
+		r.logger.Info("prune-suspended")
 		r.pruningStatus = DISCONNECTED
 		return
 	} else {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -696,7 +696,8 @@ var _ = Describe("RouteRegistry", func() {
 				Expect(r.NumUris()).To(Equal(totalRoutes))
 				Expect(r.NumEndpoints()).To(Equal(totalRoutes))
 
-				time.Sleep(configObj.PruneStaleDropletsInterval + 50*time.Millisecond)
+				interval := configObj.PruneStaleDropletsInterval + 50*time.Millisecond
+				Eventually(logger, interval).Should(gbytes.Say("prune-suspended"))
 
 				Expect(r.NumUris()).To(Equal(totalRoutes))
 				Expect(r.NumEndpoints()).To(Equal(totalRoutes))


### PR DESCRIPTION
Set the log level for the "prune-suspended" from **debug** to **info**

@jzlwang  indicated that this did not show up in the logs.  I updated it to Info level.

Relates to original PR:  https://github.com/cloudfoundry/gorouter/pull/140 
Tracker item #126051165

