### PR TITLE
Cleanup go vet and scripts so runs on all packages

### DIFF
--- a/common/component_test.go
+++ b/common/component_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Component", func() {
 			_, err = mbusClient.Subscribe("subject", func(msg *nats.Msg) {
 				defer GinkgoRecover()
 				data := make(map[string]interface{})
-				err := json.Unmarshal(msg.Data, &data)
+				err = json.Unmarshal(msg.Data, &data)
 				Expect(err).ToNot(HaveOccurred())
 
 				for _, key := range members {
@@ -239,7 +239,7 @@ var _ = Describe("Component", func() {
 			_, err = mbusClient.Subscribe("vcap.component.announce", func(msg *nats.Msg) {
 				defer GinkgoRecover()
 				data := make(map[string]interface{})
-				err := json.Unmarshal(msg.Data, &data)
+				err = json.Unmarshal(msg.Data, &data)
 				Expect(err).ToNot(HaveOccurred())
 
 				for _, key := range members {

--- a/proxy/route_service_test.go
+++ b/proxy/route_service_test.go
@@ -45,8 +45,8 @@ var _ = Describe("Route Services", func() {
 		forwardedUrl = "https://my_host.com/resource+9-9_9?query=123&query$2=345#page1..5"
 
 		routeServiceHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			metadataHeader := r.Header.Get(route_service.RouteServiceMetadata)
-			signatureHeader := r.Header.Get(route_service.RouteServiceSignature)
+			metadataHeader = r.Header.Get(route_service.RouteServiceMetadata)
+			signatureHeader = r.Header.Get(route_service.RouteServiceSignature)
 
 			crypto, err := secure.NewAesGCM([]byte(cryptoKey))
 			Expect(err).ToNot(HaveOccurred())
@@ -111,8 +111,8 @@ var _ = Describe("Route Services", func() {
 				furl := "http://my_host.com/resource+9-9_9?query=123&query$2=345#page1..5"
 				recommendHttps = false
 				routeServiceHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					metadataHeader := r.Header.Get(route_service.RouteServiceMetadata)
-					signatureHeader := r.Header.Get(route_service.RouteServiceSignature)
+					metadataHeader = r.Header.Get(route_service.RouteServiceMetadata)
+					signatureHeader = r.Header.Get(route_service.RouteServiceSignature)
 
 					crypto, err := secure.NewAesGCM([]byte(cryptoKey))
 					Expect(err).ToNot(HaveOccurred())

--- a/proxy/session_affinity_test.go
+++ b/proxy/session_affinity_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Session Affinity", func() {
 			req = test_util.NewRequest("GET", host, "/", nil)
 			req.AddCookie(cookie)
 
-			jSessionIdCookie := &http.Cookie{
+			jSessionIdCookie = &http.Cookie{
 				Name:  proxy.StickyCookieKey,
 				Value: "xxx",
 			}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -169,7 +169,6 @@ var _ = Describe("RouteRegistry", func() {
 		Context("Modification Tags", func() {
 			var (
 				endpoint *route.Endpoint
-				modTag   models.ModificationTag
 			)
 
 			BeforeEach(func() {
@@ -390,7 +389,6 @@ var _ = Describe("RouteRegistry", func() {
 		Context("with modification tags", func() {
 			var (
 				endpoint *route.Endpoint
-				modTag   models.ModificationTag
 			)
 
 			BeforeEach(func() {

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -118,9 +118,6 @@ var _ = Describe("Pool", func() {
 		})
 
 		Context("with modification tags", func() {
-
-			var modTag models.ModificationTag
-
 			BeforeEach(func() {
 				modTag = models.ModificationTag{Guid: "abc"}
 				endpoint1 := route.NewEndpoint("", "1.2.3.4", 5678, "", "", nil, -1, "", modTag)

--- a/scripts/test
+++ b/scripts/test
@@ -28,9 +28,5 @@ ginkgo -r -failOnPending -randomizeAllSpecs -race "$@"
 # Installing dependencies needed by go vet
 go install .
 
-go tool vet -v -all -shadow=true main.go
-
-for file in $(find {access_log,common,config,metrics,proxy,registry,route,route_fetcher,route_service,router,stats,varz} \( -name "*.go" -not -iname "*test.go" \))
-do
-    go tool vet -v -all -shadow=true $file
-done
+go vet ./...
+go tool vet --shadow .


### PR DESCRIPTION
- run go vet on each package vs. per file
- cleanup script so we are not maintaining a list of dirs to run
  against.
- fix issues of variable shadowing in tests

_Note, I was submitting a different PR and this is the only thing failing when I run `./scripts/test` because when running go vet per file in a package seems to not work correctly._

cc @shashwathi @crhino 