### PR TITLE
Support for Least connection load balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,23 @@ go tool pprof http://localhost:8080/debug/pprof/profile
 
 ## Load Balancing
 
-The GoRouter is, in simple terms, a reverse proxy that load balances between many backend instances. The implementation currently uses simple round-robin load balancing and will retry a request if the chosen backend does not accept the TCP connection.
+The GoRouter is, in simple terms, a reverse proxy that load balances between many backend instances. The default load balancing algorithm that GoRouter will use is a simple **round-robin** strategy. GoRouter will retry a request if the chosen backend does not accept the TCP connection.
+
+### Round-Robin
+Default load balancing algorithm that gorouter will use or may be explicity set in **gorouter.yml**
+```yaml
+default_balancing_algorithm: round-robin
+```
+
+### Least-Connection
+The GoRouter also supports least connection based routing and this can be enabled in **gorouter.yml**
+```yaml
+default_balancing_algorithm: least-connection
+```
+Least connection based load balancing will select the endpoint with the least number of connections. If multiple endpoints match with the same number of least connections, it will select a random one within those least connections.
+
+_NOTE: GoRouter currently only supports changing the load balancing strategy at the gorouter level and does not yet support a finer-grained level such as route-level. Therefore changing the load balancing algorithm from the default (round-robin) should be proceeded with caution._
+
 
 ## PROXY Protocol
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,6 +20,31 @@ var _ = Describe("Config", func() {
 
 	Describe("Initialize", func() {
 
+		Context("load balance config", func() {
+			It("sets default load balance strategy", func() {
+				Expect(config.LoadBalance).To(Equal(LOAD_BALANCE_RR))
+			})
+
+			It("can override the load balance strategy", func() {
+				cfg := DefaultConfig()
+				var b = []byte(`
+default_balancing_algorithm: least-connection
+`)
+				cfg.Initialize(b)
+				cfg.Process()
+				Expect(cfg.LoadBalance).To(Equal(LOAD_BALANCE_LC))
+			})
+
+			It("does not allow an invalid load balance strategy", func() {
+				cfg := DefaultConfig()
+				var b = []byte(`
+default_balancing_algorithm: foo-bar
+`)
+				cfg.Initialize(b)
+				Expect(cfg.Process).To(Panic())
+			})
+		})
+
 		It("sets status config", func() {
 			var b = []byte(`
 status:

--- a/main.go
+++ b/main.go
@@ -182,6 +182,7 @@ func buildProxy(logger lager.Logger, c *config.Config, registry rregistry.Regist
 		ExtraHeadersToLog:    c.ExtraHeadersToLog,
 		HealthCheckUserAgent: c.HealthCheckUserAgent,
 		EnableZipkin:         c.Tracing.EnableZipkin,
+		DefaultLoadBalance:   c.LoadBalance,
 	}
 	return proxy.NewProxy(args)
 }

--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -57,7 +57,14 @@ func (rt *BackendRoundTripper) RoundTrip(request *http.Request) (*http.Response,
 
 		rt.setupRequest(request, endpoint)
 
+		// increment connection stats
+		rt.iter.PreRequest(endpoint)
+
 		res, err = rt.transport.RoundTrip(request)
+
+		// decrement connection stats
+		rt.iter.PostRequest(endpoint)
+
 		if err == nil || !retryableError(err) {
 			break
 		}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -183,7 +183,7 @@ var _ = Describe("RouteRegistry", func() {
 					Expect(r.NumEndpoints()).To(Equal(1))
 
 					p := r.Lookup("foo.com")
-					Expect(p.Endpoints("").Next().ModificationTag).To(Equal(modTag))
+					Expect(p.Endpoints("", "").Next().ModificationTag).To(Equal(modTag))
 				})
 			})
 
@@ -205,7 +205,7 @@ var _ = Describe("RouteRegistry", func() {
 						Expect(r.NumEndpoints()).To(Equal(1))
 
 						p := r.Lookup("foo.com")
-						Expect(p.Endpoints("").Next().ModificationTag).To(Equal(modTag))
+						Expect(p.Endpoints("", "").Next().ModificationTag).To(Equal(modTag))
 					})
 
 					Context("updating an existing route with an older modification tag", func() {
@@ -225,7 +225,7 @@ var _ = Describe("RouteRegistry", func() {
 							Expect(r.NumEndpoints()).To(Equal(1))
 
 							p := r.Lookup("foo.com")
-							ep := p.Endpoints("").Next()
+							ep := p.Endpoints("", "").Next()
 							Expect(ep.ModificationTag).To(Equal(modTag))
 							Expect(ep).To(Equal(endpoint2))
 						})
@@ -244,7 +244,7 @@ var _ = Describe("RouteRegistry", func() {
 						Expect(r.NumEndpoints()).To(Equal(1))
 
 						p := r.Lookup("foo.com")
-						Expect(p.Endpoints("").Next().ModificationTag).To(Equal(modTag))
+						Expect(p.Endpoints("", "").Next().ModificationTag).To(Equal(modTag))
 					})
 				})
 			})
@@ -349,7 +349,7 @@ var _ = Describe("RouteRegistry", func() {
 			Expect(r.NumUris()).To(Equal(1))
 
 			p1 := r.Lookup("foo/bar")
-			iter := p1.Endpoints("")
+			iter := p1.Endpoints("", "")
 			Expect(iter.Next().CanonicalAddr()).To(Equal("192.168.1.1:1234"))
 
 			p2 := r.Lookup("foo")
@@ -428,7 +428,7 @@ var _ = Describe("RouteRegistry", func() {
 			p2 := r.Lookup("FOO")
 			Expect(p1).To(Equal(p2))
 
-			iter := p1.Endpoints("")
+			iter := p1.Endpoints("", "")
 			Expect(iter.Next().CanonicalAddr()).To(Equal("192.168.1.1:1234"))
 		})
 
@@ -447,7 +447,7 @@ var _ = Describe("RouteRegistry", func() {
 
 			p := r.Lookup("bar")
 			Expect(p).ToNot(BeNil())
-			e := p.Endpoints("").Next()
+			e := p.Endpoints("", "").Next()
 			Expect(e).ToNot(BeNil())
 			Expect(e.CanonicalAddr()).To(MatchRegexp("192.168.1.1:123[4|5]"))
 		})
@@ -461,13 +461,13 @@ var _ = Describe("RouteRegistry", func() {
 
 			p := r.Lookup("foo.wild.card")
 			Expect(p).ToNot(BeNil())
-			e := p.Endpoints("").Next()
+			e := p.Endpoints("", "").Next()
 			Expect(e).ToNot(BeNil())
 			Expect(e.CanonicalAddr()).To(Equal("192.168.1.2:1234"))
 
 			p = r.Lookup("foo.space.wild.card")
 			Expect(p).ToNot(BeNil())
-			e = p.Endpoints("").Next()
+			e = p.Endpoints("", "").Next()
 			Expect(e).ToNot(BeNil())
 			Expect(e.CanonicalAddr()).To(Equal("192.168.1.2:1234"))
 		})
@@ -481,7 +481,7 @@ var _ = Describe("RouteRegistry", func() {
 
 			p := r.Lookup("not.wild.card")
 			Expect(p).ToNot(BeNil())
-			e := p.Endpoints("").Next()
+			e := p.Endpoints("", "").Next()
 			Expect(e).ToNot(BeNil())
 			Expect(e.CanonicalAddr()).To(Equal("192.168.1.1:1234"))
 		})
@@ -499,7 +499,7 @@ var _ = Describe("RouteRegistry", func() {
 				p := r.Lookup("dora.app.com/env?foo=bar")
 
 				Expect(p).ToNot(BeNil())
-				iter := p.Endpoints("")
+				iter := p.Endpoints("", "")
 				Expect(iter.Next().CanonicalAddr()).To(Equal("192.168.1.1:1234"))
 			})
 
@@ -508,7 +508,7 @@ var _ = Describe("RouteRegistry", func() {
 				p := r.Lookup("dora.app.com/env/abc?foo=bar&baz=bing")
 
 				Expect(p).ToNot(BeNil())
-				iter := p.Endpoints("")
+				iter := p.Endpoints("", "")
 				Expect(iter.Next().CanonicalAddr()).To(Equal("192.168.1.1:1234"))
 			})
 		})
@@ -536,7 +536,7 @@ var _ = Describe("RouteRegistry", func() {
 			Expect(r.NumEndpoints()).To(Equal(2))
 
 			p := r.LookupWithInstance("bar", appId, appIndex)
-			e := p.Endpoints("").Next()
+			e := p.Endpoints("", "").Next()
 
 			Expect(e).ToNot(BeNil())
 			Expect(e.CanonicalAddr()).To(MatchRegexp("192.168.1.1:1234"))
@@ -666,7 +666,7 @@ var _ = Describe("RouteRegistry", func() {
 
 			p := r.Lookup("foo")
 			Expect(p).ToNot(BeNil())
-			Expect(p.Endpoints("").Next()).To(Equal(endpoint))
+			Expect(p.Endpoints("", "").Next()).To(Equal(endpoint))
 
 			p = r.Lookup("bar")
 			Expect(p).To(BeNil())

--- a/route/fakes/fake_endpoint_iterator.go
+++ b/route/fakes/fake_endpoint_iterator.go
@@ -17,6 +17,16 @@ type FakeEndpointIterator struct {
 	EndpointFailedStub        func()
 	endpointFailedMutex       sync.RWMutex
 	endpointFailedArgsForCall []struct{}
+	PreRequestStub            func(e *route.Endpoint)
+	preRequestMutex           sync.RWMutex
+	preRequestArgsForCall     []struct {
+		e *route.Endpoint
+	}
+	PostRequestStub        func(e *route.Endpoint)
+	postRequestMutex       sync.RWMutex
+	postRequestArgsForCall []struct {
+		e *route.Endpoint
+	}
 }
 
 func (fake *FakeEndpointIterator) Next() *route.Endpoint {
@@ -56,6 +66,52 @@ func (fake *FakeEndpointIterator) EndpointFailedCallCount() int {
 	fake.endpointFailedMutex.RLock()
 	defer fake.endpointFailedMutex.RUnlock()
 	return len(fake.endpointFailedArgsForCall)
+}
+
+func (fake *FakeEndpointIterator) PreRequest(e *route.Endpoint) {
+	fake.preRequestMutex.Lock()
+	fake.preRequestArgsForCall = append(fake.preRequestArgsForCall, struct {
+		e *route.Endpoint
+	}{e})
+	fake.preRequestMutex.Unlock()
+	if fake.PreRequestStub != nil {
+		fake.PreRequestStub(e)
+	}
+}
+
+func (fake *FakeEndpointIterator) PreRequestCallCount() int {
+	fake.preRequestMutex.RLock()
+	defer fake.preRequestMutex.RUnlock()
+	return len(fake.preRequestArgsForCall)
+}
+
+func (fake *FakeEndpointIterator) PreRequestArgsForCall(i int) *route.Endpoint {
+	fake.preRequestMutex.RLock()
+	defer fake.preRequestMutex.RUnlock()
+	return fake.preRequestArgsForCall[i].e
+}
+
+func (fake *FakeEndpointIterator) PostRequest(e *route.Endpoint) {
+	fake.postRequestMutex.Lock()
+	fake.postRequestArgsForCall = append(fake.postRequestArgsForCall, struct {
+		e *route.Endpoint
+	}{e})
+	fake.postRequestMutex.Unlock()
+	if fake.PostRequestStub != nil {
+		fake.PostRequestStub(e)
+	}
+}
+
+func (fake *FakeEndpointIterator) PostRequestCallCount() int {
+	fake.postRequestMutex.RLock()
+	defer fake.postRequestMutex.RUnlock()
+	return len(fake.postRequestArgsForCall)
+}
+
+func (fake *FakeEndpointIterator) PostRequestArgsForCall(i int) *route.Endpoint {
+	fake.postRequestMutex.RLock()
+	defer fake.postRequestMutex.RUnlock()
+	return fake.postRequestArgsForCall[i].e
 }
 
 var _ route.EndpointIterator = new(FakeEndpointIterator)

--- a/route/leastconnection.go
+++ b/route/leastconnection.go
@@ -1,0 +1,89 @@
+package route
+
+import (
+	"math/rand"
+	"time"
+)
+
+var randomize = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+type LeastConnection struct {
+	pool            *Pool
+	initialEndpoint string
+	lastEndpoint    *Endpoint
+}
+
+func NewLeastConnection(p *Pool, initial string) EndpointIterator {
+	return &LeastConnection{
+		pool:            p,
+		initialEndpoint: initial,
+	}
+}
+
+func (r *LeastConnection) Next() *Endpoint {
+	var e *Endpoint
+	if r.initialEndpoint != "" {
+		e = r.pool.findById(r.initialEndpoint)
+		r.initialEndpoint = ""
+	}
+
+	if e == nil {
+		e = r.next()
+	}
+
+	r.lastEndpoint = e
+	return e
+}
+
+func (r *LeastConnection) PreRequest(e *Endpoint) {
+	e.Stats.NumberConnections.Increment()
+}
+
+func (r *LeastConnection) PostRequest(e *Endpoint) {
+	e.Stats.NumberConnections.Decrement()
+}
+
+func (r *LeastConnection) next() *Endpoint {
+	r.pool.lock.Lock()
+	defer r.pool.lock.Unlock()
+
+	var selected *Endpoint
+
+	// none
+	total := len(r.pool.endpoints)
+	if total == 0 {
+		return nil
+	}
+
+	// single endpoint
+	if total == 1 {
+		return r.pool.endpoints[0].endpoint
+	}
+
+	// more than 1 endpoint
+	// select the least connection endpoint OR
+	// random one within the least connection endpoints
+	randIndices := randomize.Perm(total)
+
+	for i := 0; i < total; i++ {
+		randIdx := randIndices[i]
+		cur := r.pool.endpoints[randIdx].endpoint
+
+		// our first is the least
+		if i == 0 {
+			selected = cur
+			continue
+		}
+
+		if cur.Stats.NumberConnections.Count() < selected.Stats.NumberConnections.Count() {
+			selected = cur
+		}
+	}
+	return selected
+}
+
+func (r *LeastConnection) EndpointFailed() {
+	if r.lastEndpoint != nil {
+		r.pool.endpointFailed(r.lastEndpoint)
+	}
+}

--- a/route/leastconnection_benchmark_test.go
+++ b/route/leastconnection_benchmark_test.go
@@ -1,0 +1,51 @@
+package route_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"code.cloudfoundry.org/gorouter/route"
+	"code.cloudfoundry.org/routing-api/models"
+)
+
+func loadBalance(lb route.EndpointIterator) {
+	e := lb.Next()
+	lb.PreRequest(e)
+	lb.PostRequest(e)
+}
+
+func loadBalanceFor(strategy string, b *testing.B) {
+
+	pool := route.NewPool(2*time.Minute, "")
+	total := 5
+	endpoints := make([]*route.Endpoint, 0)
+	for i := 0; i < total; i++ {
+		ip := fmt.Sprintf("10.0.1.%d", i)
+		e := route.NewEndpoint("", ip, 60000, "", "", nil, -1, "", models.ModificationTag{})
+		endpoints = append(endpoints, e)
+		pool.Put(e)
+	}
+
+	var lb route.EndpointIterator
+	switch strategy {
+	case "round-robin":
+		lb = route.NewRoundRobin(pool, "")
+	case "least-connection":
+		lb = route.NewLeastConnection(pool, "")
+	default:
+		panic("invalid load balancing strategy")
+	}
+
+	for n := 0; n < b.N; n++ {
+		loadBalance(lb)
+	}
+}
+
+func BenchmarkLeastConnection(b *testing.B) {
+	loadBalanceFor("least-connection", b)
+}
+
+func BenchmarkRoundRobin(b *testing.B) {
+	loadBalanceFor("round-robin", b)
+}

--- a/route/leastconnection_test.go
+++ b/route/leastconnection_test.go
@@ -1,0 +1,135 @@
+package route_test
+
+import (
+	"fmt"
+	"time"
+
+	"code.cloudfoundry.org/gorouter/route"
+	"code.cloudfoundry.org/routing-api/models"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LeastConnection", func() {
+	var pool *route.Pool
+
+	BeforeEach(func() {
+		pool = route.NewPool(2*time.Minute, "")
+	})
+
+	Describe("Next", func() {
+
+		Context("when pool is empty", func() {
+			It("does not select an endpoint", func() {
+				iter := route.NewLeastConnection(pool, "")
+				Expect(iter.Next()).To(BeNil())
+			})
+		})
+
+		Context("when pool has endpoints", func() {
+			var (
+				endpoints []*route.Endpoint
+				total     int
+			)
+
+			BeforeEach(func() {
+				total = 5
+				endpoints = make([]*route.Endpoint, 0)
+				for i := 0; i < total; i++ {
+					ip := fmt.Sprintf("10.0.1.%d", i)
+					e := route.NewEndpoint("", ip, 60000, "", "", nil, -1, "", models.ModificationTag{})
+					endpoints = append(endpoints, e)
+					pool.Put(e)
+				}
+				// 10.0.1.0:6000
+				// 10.0.1.1:6000
+				// 10.0.1.2:6000
+				// 10.0.1.3:6000
+				// 10.0.1.4:6000
+			})
+
+			Context("when all endpoints have no statistics", func() {
+				It("selects a random endpoint", func() {
+					iter := route.NewLeastConnection(pool, "")
+					n := iter.Next()
+					Expect(n).NotTo(BeNil())
+				})
+			})
+
+			Context("when all endpoints have zero connections", func() {
+				BeforeEach(func() {
+					// set all to zero
+					setConnectionCount(endpoints, []int{0, 0, 0, 0, 0})
+				})
+
+				It("selects a random endpoint", func() {
+					iter := route.NewLeastConnection(pool, "")
+					n := iter.Next()
+					Expect(n).NotTo(BeNil())
+				})
+			})
+
+			Context("when endpoints have varying number of connections", func() {
+
+				It("selects endpoint with least connection", func() {
+					setConnectionCount(endpoints, []int{0, 1, 1, 1, 1})
+					iter := route.NewLeastConnection(pool, "")
+					Expect(iter.Next()).To(Equal(endpoints[0]))
+
+					setConnectionCount(endpoints, []int{1, 0, 1, 1, 1})
+					Expect(iter.Next()).To(Equal(endpoints[1]))
+
+					setConnectionCount(endpoints, []int{1, 1, 0, 1, 1})
+					Expect(iter.Next()).To(Equal(endpoints[2]))
+
+					setConnectionCount(endpoints, []int{1, 1, 1, 0, 1})
+					Expect(iter.Next()).To(Equal(endpoints[3]))
+
+					setConnectionCount(endpoints, []int{1, 1, 1, 1, 0})
+					Expect(iter.Next()).To(Equal(endpoints[4]))
+
+					setConnectionCount(endpoints, []int{1, 4, 15, 8, 3})
+					Expect(iter.Next()).To(Equal(endpoints[0]))
+
+					setConnectionCount(endpoints, []int{5, 4, 15, 8, 3})
+					Expect(iter.Next()).To(Equal(endpoints[4]))
+
+					setConnectionCount(endpoints, []int{5, 4, 15, 8, 7})
+					Expect(iter.Next()).To(Equal(endpoints[1]))
+
+					setConnectionCount(endpoints, []int{5, 5, 15, 2, 7})
+					Expect(iter.Next()).To(Equal(endpoints[3]))
+				})
+
+				It("selects random endpoint from all with least connection", func() {
+					iter := route.NewLeastConnection(pool, "")
+
+					setConnectionCount(endpoints, []int{1, 0, 0, 0, 0})
+					okRandoms := []string{
+						"10.0.1.1:60000",
+						"10.0.1.2:60000",
+						"10.0.1.3:60000",
+						"10.0.1.4:60000",
+					}
+					Expect(okRandoms).Should(ContainElement(iter.Next().CanonicalAddr()))
+
+					setConnectionCount(endpoints, []int{10, 10, 15, 10, 11})
+					okRandoms = []string{
+						"10.0.1.0:60000",
+						"10.0.1.1:60000",
+						"10.0.1.3:60000",
+					}
+					Expect(okRandoms).Should(ContainElement(iter.Next().CanonicalAddr()))
+				})
+			})
+		})
+	})
+})
+
+func setConnectionCount(endpoints []*route.Endpoint, counts []int) {
+	for i := 0; i < len(endpoints); i++ {
+		endpoints[i].Stats = &route.Stats{
+			NumberConnections: route.NewCounter(int64(counts[i])),
+		}
+	}
+}

--- a/route/pool.go
+++ b/route/pool.go
@@ -28,13 +28,6 @@ type EndpointIterator interface {
 	EndpointFailed()
 }
 
-type endpointIterator struct {
-	pool *Pool
-
-	initialEndpoint string
-	lastEndpoint    *Endpoint
-}
-
 type endpointElem struct {
 	endpoint *Endpoint
 	index    int
@@ -197,7 +190,8 @@ func (p *Pool) removeEndpoint(e *endpointElem) {
 }
 
 func (p *Pool) Endpoints(initial string) EndpointIterator {
-	return newEndpointIterator(p, initial)
+	// default to round robin
+	return NewRoundRobin(p, initial)
 }
 
 func (p *Pool) next() *Endpoint {
@@ -301,35 +295,6 @@ func (p *Pool) MarshalJSON() ([]byte, error) {
 	p.lock.Unlock()
 
 	return json.Marshal(endpoints)
-}
-
-func newEndpointIterator(p *Pool, initial string) EndpointIterator {
-	return &endpointIterator{
-		pool:            p,
-		initialEndpoint: initial,
-	}
-}
-
-func (i *endpointIterator) Next() *Endpoint {
-	var e *Endpoint
-	if i.initialEndpoint != "" {
-		e = i.pool.findById(i.initialEndpoint)
-		i.initialEndpoint = ""
-	}
-
-	if e == nil {
-		e = i.pool.next()
-	}
-
-	i.lastEndpoint = e
-
-	return e
-}
-
-func (i *endpointIterator) EndpointFailed() {
-	if i.lastEndpoint != nil {
-		i.pool.endpointFailed(i.lastEndpoint)
-	}
 }
 
 func (e *endpointElem) failed() {

--- a/route/pool.go
+++ b/route/pool.go
@@ -3,14 +3,41 @@ package route
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"code.cloudfoundry.org/gorouter/config"
 	"code.cloudfoundry.org/routing-api/models"
 )
 
-var random = rand.New(rand.NewSource(time.Now().UnixNano()))
+type Counter struct {
+	value int64
+}
+
+func NewCounter(initial int64) *Counter {
+	return &Counter{initial}
+}
+
+func (c *Counter) Increment() {
+	atomic.AddInt64(&c.value, 1)
+}
+func (c *Counter) Decrement() {
+	atomic.AddInt64(&c.value, -1)
+}
+func (c *Counter) Count() int64 {
+	return atomic.LoadInt64(&c.value)
+}
+
+type Stats struct {
+	NumberConnections *Counter
+}
+
+func NewStats() *Stats {
+	return &Stats{
+		NumberConnections: &Counter{},
+	}
+}
 
 type Endpoint struct {
 	ApplicationId        string
@@ -21,11 +48,15 @@ type Endpoint struct {
 	RouteServiceUrl      string
 	PrivateInstanceIndex string
 	ModificationTag      models.ModificationTag
+	Stats                *Stats
 }
 
+//go:generate counterfeiter -o fakes/fake_endpoint_iterator.go . EndpointIterator
 type EndpointIterator interface {
 	Next() *Endpoint
 	EndpointFailed()
+	PreRequest(e *Endpoint)
+	PostRequest(e *Endpoint)
 }
 
 type endpointElem struct {
@@ -58,6 +89,7 @@ func NewEndpoint(appId, host string, port uint16, privateInstanceId string, priv
 		staleThreshold:       time.Duration(staleThresholdInSeconds) * time.Second,
 		RouteServiceUrl:      routeServiceUrl,
 		ModificationTag:      modificationTag,
+		Stats:                NewStats(),
 	}
 }
 
@@ -189,55 +221,12 @@ func (p *Pool) removeEndpoint(e *endpointElem) {
 	delete(p.index, e.endpoint.PrivateInstanceId)
 }
 
-func (p *Pool) Endpoints(initial string) EndpointIterator {
-	// default to round robin
-	return NewRoundRobin(p, initial)
-}
-
-func (p *Pool) next() *Endpoint {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	last := len(p.endpoints)
-	if last == 0 {
-		return nil
-	}
-
-	if p.nextIdx == -1 {
-		p.nextIdx = random.Intn(last)
-	} else if p.nextIdx >= last {
-		p.nextIdx = 0
-	}
-
-	startIdx := p.nextIdx
-	curIdx := startIdx
-	for {
-		e := p.endpoints[curIdx]
-
-		curIdx++
-		if curIdx == last {
-			curIdx = 0
-		}
-
-		if e.failedAt != nil {
-			curTime := time.Now()
-			if curTime.Sub(*e.failedAt) > p.retryAfterFailure {
-				// exipired failure window
-				e.failedAt = nil
-			}
-		}
-
-		if e.failedAt == nil {
-			p.nextIdx = curIdx
-			return e.endpoint
-		}
-
-		if curIdx == startIdx {
-			// all endpoints are marked failed so reset everything to available
-			for _, e2 := range p.endpoints {
-				e2.failedAt = nil
-			}
-		}
+func (p *Pool) Endpoints(defaultLoadBalance, initial string) EndpointIterator {
+	switch defaultLoadBalance {
+	case config.LOAD_BALANCE_LC:
+		return NewLeastConnection(p, initial)
+	default:
+		return NewRoundRobin(p, initial)
 	}
 }
 
@@ -336,6 +325,7 @@ func (e *Endpoint) ToLogData() interface{} {
 		e.RouteServiceUrl,
 	}
 }
+
 func (e *Endpoint) modificationTagSameOrNewer(other *Endpoint) bool {
 	return e.ModificationTag == other.ModificationTag || e.ModificationTag.SucceededBy(&other.ModificationTag)
 }

--- a/route/roundrobin.go
+++ b/route/roundrobin.go
@@ -1,0 +1,37 @@
+package route
+
+type RoundRobin struct {
+	pool *Pool
+
+	initialEndpoint string
+	lastEndpoint    *Endpoint
+}
+
+func NewRoundRobin(p *Pool, initial string) EndpointIterator {
+	return &RoundRobin{
+		pool:            p,
+		initialEndpoint: initial,
+	}
+}
+
+func (r *RoundRobin) Next() *Endpoint {
+	var e *Endpoint
+	if r.initialEndpoint != "" {
+		e = r.pool.findById(r.initialEndpoint)
+		r.initialEndpoint = ""
+	}
+
+	if e == nil {
+		e = r.pool.next()
+	}
+
+	r.lastEndpoint = e
+
+	return e
+}
+
+func (r *RoundRobin) EndpointFailed() {
+	if r.lastEndpoint != nil {
+		r.pool.endpointFailed(r.lastEndpoint)
+	}
+}

--- a/route/roundrobin_test.go
+++ b/route/roundrobin_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("EndpointIterator", func() {
+var _ = Describe("RoundRobin", func() {
 	var pool *route.Pool
 	var modTag models.ModificationTag
 
@@ -31,7 +31,7 @@ var _ = Describe("EndpointIterator", func() {
 
 			counts := make([]int, len(endpoints))
 
-			iter := pool.Endpoints("")
+			iter := route.NewRoundRobin(pool, "")
 
 			loops := 50
 			for i := 0; i < len(endpoints)*loops; i += 1 {
@@ -50,7 +50,7 @@ var _ = Describe("EndpointIterator", func() {
 		})
 
 		It("returns nil when no endpoints exist", func() {
-			iter := pool.Endpoints("")
+			iter := route.NewRoundRobin(pool, "")
 			e := iter.Next()
 			Expect(e).To(BeNil())
 		})
@@ -63,7 +63,7 @@ var _ = Describe("EndpointIterator", func() {
 			pool.Put(route.NewEndpoint("", "1.2.3.4", 1237, "d", "", nil, -1, "", modTag))
 
 			for i := 0; i < 10; i++ {
-				iter := pool.Endpoints(b.PrivateInstanceId)
+				iter := route.NewRoundRobin(pool, b.PrivateInstanceId)
 				e := iter.Next()
 				Expect(e).ToNot(BeNil())
 				Expect(e.PrivateInstanceId).To(Equal(b.PrivateInstanceId))
@@ -78,7 +78,7 @@ var _ = Describe("EndpointIterator", func() {
 			pool.Put(route.NewEndpoint("", "1.2.3.4", 1237, "d", "", nil, -1, "", modTag))
 
 			for i := 0; i < 10; i++ {
-				iter := pool.Endpoints(b.CanonicalAddr())
+				iter := route.NewRoundRobin(pool, b.CanonicalAddr())
 				e := iter.Next()
 				Expect(e).ToNot(BeNil())
 				Expect(e.CanonicalAddr()).To(Equal(b.CanonicalAddr()))
@@ -92,12 +92,12 @@ var _ = Describe("EndpointIterator", func() {
 			pool.Put(endpointFoo)
 			pool.Put(endpointBar)
 
-			iter := pool.Endpoints(endpointFoo.PrivateInstanceId)
+			iter := route.NewRoundRobin(pool, endpointFoo.PrivateInstanceId)
 			foundEndpoint := iter.Next()
 			Expect(foundEndpoint).ToNot(BeNil())
 			Expect(foundEndpoint).To(Equal(endpointFoo))
 
-			iter = pool.Endpoints(endpointBar.PrivateInstanceId)
+			iter = route.NewRoundRobin(pool, endpointBar.PrivateInstanceId)
 			foundEndpoint = iter.Next()
 			Expect(foundEndpoint).ToNot(BeNil())
 			Expect(foundEndpoint).To(Equal(endpointBar))
@@ -107,7 +107,7 @@ var _ = Describe("EndpointIterator", func() {
 			eFoo := route.NewEndpoint("", "1.2.3.4", 1234, "foo", "", nil, -1, "", modTag)
 			pool.Put(eFoo)
 
-			iter := pool.Endpoints("bogus")
+			iter := route.NewRoundRobin(pool, "bogus")
 			e := iter.Next()
 			Expect(e).ToNot(BeNil())
 			Expect(e).To(Equal(eFoo))
@@ -117,7 +117,7 @@ var _ = Describe("EndpointIterator", func() {
 			endpointFoo := route.NewEndpoint("", "1.2.3.4", 1234, "foo", "", nil, -1, "", modTag)
 			pool.Put(endpointFoo)
 
-			iter := pool.Endpoints(endpointFoo.PrivateInstanceId)
+			iter := route.NewRoundRobin(pool, endpointFoo.PrivateInstanceId)
 			foundEndpoint := iter.Next()
 			Expect(foundEndpoint).ToNot(BeNil())
 			Expect(foundEndpoint).To(Equal(endpointFoo))
@@ -125,11 +125,11 @@ var _ = Describe("EndpointIterator", func() {
 			endpointBar := route.NewEndpoint("", "1.2.3.4", 1234, "bar", "", nil, -1, "", modTag)
 			pool.Put(endpointBar)
 
-			iter = pool.Endpoints("foo")
+			iter = route.NewRoundRobin(pool, "foo")
 			foundEndpoint = iter.Next()
 			Expect(foundEndpoint).ToNot(Equal(endpointFoo))
 
-			iter = pool.Endpoints("bar")
+			iter = route.NewRoundRobin(pool, "bar")
 			Expect(foundEndpoint).To(Equal(endpointBar))
 		})
 	})
@@ -141,7 +141,7 @@ var _ = Describe("EndpointIterator", func() {
 			pool.Put(e1)
 			pool.Put(e2)
 
-			iter := pool.Endpoints("")
+			iter := route.NewRoundRobin(pool, "")
 			n := iter.Next()
 			Expect(n).ToNot(BeNil())
 
@@ -161,7 +161,7 @@ var _ = Describe("EndpointIterator", func() {
 			pool.Put(e1)
 			pool.Put(e2)
 
-			iter := pool.Endpoints("")
+			iter := route.NewRoundRobin(pool, "")
 			n1 := iter.Next()
 			iter.EndpointFailed()
 			n2 := iter.Next()
@@ -181,7 +181,7 @@ var _ = Describe("EndpointIterator", func() {
 			pool.Put(e1)
 			pool.Put(e2)
 
-			iter := pool.Endpoints("")
+			iter := route.NewRoundRobin(pool, "")
 			n1 := iter.Next()
 			n2 := iter.Next()
 			Expect(n1).ToNot(Equal(n2))


### PR DESCRIPTION
This PR will provide support for gorouter to use an alternate load balancing algorithm vs the default round-robin approach.

For more information, please see: https://docs.google.com/document/d/1EKzq7Bh0_7e8iwT8ikjlLMvq7prEyuBFysWCLSolBnY/edit?usp=sharing

This will be configured at the gorouter level, and could be changed by an operator in the deployment manifest (router.default_balancing_algorithm) which would update the gorouter.yml config.

**gorouter.yml**
```yaml
default_balancing_algorithm: least-connection
```

**Refactor:**
- refactored out the default round-robin algorithm
- added least-connection algorithm

**Support for least-connection load balancing algorithm**
- will select endpoint with the least number of connections
- if multiple endpoints match with the same number of least connections, will
  select a random one within those least connections
- currently scoped at gorouter level and can replace the default round-robin
- adds connection tracking stats

_NOTE: This currently only supports changing the load balancing strategy at the gorouter level and not at a finer-grained level such as route-level._  


# Testing:

## Manual functional tests
Outside of the unit tests, I did some tests using an app that I could control the response times:
https://github.com/markstgodard/sloth
Using this I did some tests where I could have one app slow than the other (i.e. 100ms, 2s, etc.) and compare and contrast the results between LC and RR.
Note, this was intentionally testing a scenario where one app was consistently laggier, however it illustrates that LC was working in that it was not straight RR-ing.

Please see this gist with more info: https://gist.github.com/markstgodard/8174efa110fdd824607b94d0ef441a48

## routing perf tests
I also used the https://github.com/cf-routing/routing-perf-release and was able to test this on bosh-lite by doings runs where I used RR vs LC.
I did 75 runs of the routing-perf release http_performance_tests errand.
30 times with RR, 45 times w/ LC.   Nothing really conclusive regarding if LC is slower than RR in the case where there is a single route and endpoint.  Sometimes slower, sometimes faster. Could just be related to bosh-lite.

I documented my results here: https://docs.google.com/spreadsheets/d/1WWh144qa8Cjt390vj5HtsM9sgb0tKjkF-n85xLnQP3k/edit?usp=sharing


Also I have NOT yet submitted a PR for the manifest changes to add `default_balancing_algorithm`. Between runs I manually modified the `gorouter.yml` to add the 
```yaml
default_balancing_algorithm: least-connection
```
Note, valid values are "least-connection" or "round-robin", or if absent defaults to round-robin.


NOTE: Since I refactored some stuff in `route` package the scripts/test failed in `go vet` since its running on a per file basis.  I talked to Shash in Slack about it.
I also submitted a separate PR to address this issue. So this PR will not pass the go vet tests as is. 
See other PR: https://github.com/cloudfoundry/gorouter/pull/146


Please feel free to ping me on Slack or a hangout if you need to discuss, since this is a larger PR.

Cheers
