### PR TITLE
Fix for sticky session bug in gorouter

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -75,14 +75,15 @@ func (r *RouteRegistry) Register(uri route.Uri, endpoint *route.Endpoint) {
 
 	r.Lock()
 
-	uri = uri.RouteKey()
+	routekey := uri.RouteKey()
 
-	pool := r.byUri.Find(uri)
+	pool := r.byUri.Find(routekey)
 	if pool == nil {
 		contextPath := parseContextPath(uri)
 		pool = route.NewPool(r.dropletStaleThreshold/4, contextPath)
-		r.byUri.Insert(uri, pool)
-		r.logger.Debug("uri-added", lager.Data{"uri": uri})
+		r.byUri.Insert(routekey, pool)
+		r.logger.Debug("uri-added", lager.Data{
+			"uri": uri, "routekey": routekey})
 	}
 
 	endpointAdded := pool.Put(endpoint)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -271,5 +271,10 @@ func parseContextPath(uri route.Uri) string {
 	if len(split) > 1 {
 		contextPath += split[1]
 	}
+
+	if idx := strings.Index(string(contextPath), "?"); idx >= 0 {
+		contextPath = contextPath[0:idx]
+	}
+
 	return contextPath
 }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -139,6 +139,19 @@ var _ = Describe("RouteRegistry", func() {
 				Expect(p).ToNot(BeNil())
 
 			})
+
+			It("remembers the context path properly with case (RFC 3986, Section 6.2.2.1)", func() {
+				m1 := route.NewEndpoint("", "192.168.1.1", 1234, "", nil, -1, "", modTag)
+
+				r.Register("dora.app.com/app/UP/we/Go", m1)
+
+				Expect(r.NumUris()).To(Equal(1))
+				Expect(r.NumEndpoints()).To(Equal(1))
+
+				p := r.Lookup("dora.app.com/app/UP/we/Go")
+				Expect(p).ToNot(BeNil())
+				Expect(p.ContextPath()).To(Equal("/app/UP/we/Go"))
+			})
 		})
 
 		Context("wildcard routes", func() {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -141,7 +141,7 @@ var _ = Describe("RouteRegistry", func() {
 			})
 
 			It("remembers the context path properly with case (RFC 3986, Section 6.2.2.1)", func() {
-				m1 := route.NewEndpoint("", "192.168.1.1", 1234, "", nil, -1, "", modTag)
+				m1 := route.NewEndpoint("", "192.168.1.1", 1234, "", "", nil, -1, "", modTag)
 
 				r.Register("dora.app.com/app/UP/we/Go", m1)
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -130,14 +130,14 @@ var _ = Describe("RouteRegistry", func() {
 				m1 := route.NewEndpoint("", "192.168.1.1", 1234, "", "", nil, -1, "", modTag)
 
 				// discards query string
-				r.Register("dora.app.com?foo=bar", m1)
+				r.Register("dora.app.com/snarf?foo=bar", m1)
 
 				Expect(r.NumUris()).To(Equal(1))
 				Expect(r.NumEndpoints()).To(Equal(1))
 
-				p := r.Lookup("dora.app.com")
+				p := r.Lookup("dora.app.com/snarf")
 				Expect(p).ToNot(BeNil())
-
+				Expect(p.ContextPath()).To(Equal("/snarf"))
 			})
 
 			It("remembers the context path properly with case (RFC 3986, Section 6.2.2.1)", func() {


### PR DESCRIPTION
A customer reported that session stickiness did not work when used
together with routing based on context paths.

On investigation this was found to be an issue in gorouter, with it
mishandling applications paths containing upper-case characters, for
example `app/UP`.

The context path is extracted from the incoming uri after the actual
uri was processed by `RouteKey()`, which translates the **entire** uri
to lower case, instead of only schema and host, the only parts which
are actually case-insensitive as per RFC 3986, Section 6.2.2.1.

This modified, all-lowercase context path is then returned to the
browser via the `VCAP_ID` cookie. As the path information in the
cookie (`app/up` for our example) does not match the actual path
(`app/UP`) the browser ignores the cookie, does not send it back, and
the session does not stick.

The new test added to `registry_test.go` will show the faulty
behaviour and fail before the fix is applied.

The fix shown in the PR keeps the route key information in a separate
variable instead of overwriting the incoming uri.

This change as is not only fixes the issue in question, but also
ensures that the used route key itself is not changed at all compared
to before the change. This avoids possible issues with unstated
assumptions of other parts of the system, i.e. expecting an
all-lowercase key.

If such an assumption does not exist then an alternate fix would be to
rewrite the `RouteKey()` method to only (properly) treat host and schema
as case-insensitive, while keeping the path as is. This will also
retain the untranslated path, and further modify the routekey.
