### PR TITLE
Make gorouter status host configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,12 +20,14 @@ const LOAD_BALANCE_LC string = "least-connection"
 var LoadBalancingStrategies = []string{LOAD_BALANCE_RR, LOAD_BALANCE_LC}
 
 type StatusConfig struct {
+	Host string `yaml:"host"`
 	Port uint16 `yaml:"port"`
 	User string `yaml:"user"`
 	Pass string `yaml:"pass"`
 }
 
 var defaultStatusConfig = StatusConfig{
+	Host: "0.0.0.0",
 	Port: 8082,
 	User: "",
 	Pass: "",

--- a/router/router.go
+++ b/router/router.go
@@ -90,7 +90,7 @@ func NewRouter(logger lager.Logger, cfg *config.Config, p proxy.Proxy, mbusClien
 
 	var host string
 	if cfg.Status.Port != 0 {
-		host = fmt.Sprintf(":%d", cfg.Status.Port)
+		host = fmt.Sprintf("%s:%d", cfg.Status.Host, cfg.Status.Port)
 	}
 
 	varz := &health.Varz{


### PR DESCRIPTION
Allows the gorouter status endpoint network interface to be configurable.

This is related to the PR here.
https://github.com/cloudfoundry-incubator/routing-release/pull/55
