### PR TITLE
Add tags as part of the return JSON of routes endpoint

### DIFF
--- a/route/pool.go
+++ b/route/pool.go
@@ -290,14 +290,16 @@ func (e *endpointElem) failed() {
 
 func (e *Endpoint) MarshalJSON() ([]byte, error) {
 	var jsonObj struct {
-		Address         string `json:"address"`
-		TTL             int    `json:"ttl"`
-		RouteServiceUrl string `json:"route_service_url,omitempty"`
+		Address         string            `json:"address"`
+		TTL             int               `json:"ttl"`
+		RouteServiceUrl string            `json:"route_service_url,omitempty"`
+		Tags            map[string]string `json:"tags"`
 	}
 
 	jsonObj.Address = e.addr
 	jsonObj.RouteServiceUrl = e.RouteServiceUrl
 	jsonObj.TTL = int(e.staleThreshold.Seconds())
+	jsonObj.Tags = e.Tags
 	return json.Marshal(jsonObj)
 }
 

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -379,6 +379,6 @@ var _ = Describe("Pool", func() {
 		json, err := pool.MarshalJSON()
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(string(json)).To(Equal(`[{"address":"1.2.3.4:5678","ttl":-1,"route_service_url":"https://my-rs.com"},{"address":"5.6.7.8:5678","ttl":-1}]`))
+		Expect(string(json)).To(Equal(`[{"address":"1.2.3.4:5678","ttl":-1,"route_service_url":"https://my-rs.com","tags":{}},{"address":"5.6.7.8:5678","ttl":-1,"tags":{}}]`))
 	})
 })


### PR DESCRIPTION
The foundation behind this change is that I am trying to use gorouter independently for dynamic route registration, and I would tags to identity difference kinds of services, to classify them based on tags and put them into various buckets.