### PR TITLE
Improve performance of registry.Register

### DIFF
--- a/metrics/metricsreporter.go
+++ b/metrics/metricsreporter.go
@@ -84,7 +84,7 @@ func (m *MetricsReporter) CaptureRegistryMessage(msg ComponentTagged) {
 	} else {
 		componentName = "registry_message." + msg.Component()
 	}
-	m.sender.IncrementCounter(componentName)
+	m.batcher.BatchIncrementCounter(componentName)
 }
 
 func (m *MetricsReporter) CaptureUnregistryMessage(msg ComponentTagged) {

--- a/metrics/metricsreporter_test.go
+++ b/metrics/metricsreporter_test.go
@@ -313,8 +313,8 @@ var _ = Describe("MetricsReporter", func() {
 			endpoint.Tags = map[string]string{}
 			metricReporter.CaptureRegistryMessage(endpoint)
 
-			Expect(sender.IncrementCounterCallCount()).To(Equal(1))
-			Expect(sender.IncrementCounterArgsForCall(0)).To(Equal("registry_message"))
+			Expect(batcher.BatchIncrementCounterCallCount()).To(Equal(1))
+			Expect(batcher.BatchIncrementCounterArgsForCall(0)).To(Equal("registry_message"))
 		})
 
 		It("sends number of nats messages received from each component", func() {
@@ -324,9 +324,9 @@ var _ = Describe("MetricsReporter", func() {
 			endpoint.Tags = map[string]string{"component": "route-emitter"}
 			metricReporter.CaptureRegistryMessage(endpoint)
 
-			Expect(sender.IncrementCounterCallCount()).To(Equal(2))
-			Expect(sender.IncrementCounterArgsForCall(0)).To(Equal("registry_message.uaa"))
-			Expect(sender.IncrementCounterArgsForCall(1)).To(Equal("registry_message.route-emitter"))
+			Expect(batcher.BatchIncrementCounterCallCount()).To(Equal(2))
+			Expect(batcher.BatchIncrementCounterArgsForCall(0)).To(Equal("registry_message.uaa"))
+			Expect(batcher.BatchIncrementCounterArgsForCall(1)).To(Equal("registry_message.route-emitter"))
 		})
 
 		It("sends the total routes", func() {

--- a/registry/registry_benchmark_test.go
+++ b/registry/registry_benchmark_test.go
@@ -1,0 +1,83 @@
+package registry_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry/dropsonde"
+	"github.com/cloudfoundry/dropsonde/metric_sender"
+	"github.com/cloudfoundry/dropsonde/metricbatcher"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/uber-go/zap"
+
+	"code.cloudfoundry.org/gorouter/config"
+	"code.cloudfoundry.org/gorouter/logger"
+	"code.cloudfoundry.org/gorouter/metrics"
+	"code.cloudfoundry.org/gorouter/registry"
+	"code.cloudfoundry.org/gorouter/route"
+	"code.cloudfoundry.org/gorouter/test_util"
+	"code.cloudfoundry.org/routing-api/models"
+)
+
+var testLogger = setupLogger()
+var configObj = setupConfig()
+
+var _ = dropsonde.Initialize(configObj.Logging.MetronAddress, configObj.Logging.JobName)
+var sender = metric_sender.NewMetricSender(dropsonde.AutowiredEmitter())
+var batcher = metricbatcher.New(sender, 5*time.Second)
+var reporter = metrics.NewMetricsReporter(sender, batcher)
+
+var fooEndpoint = route.NewEndpoint(
+	"12345", "192.168.1.1", 1234, "id1", "0", map[string]string{}, -1, "",
+	models.ModificationTag{}, "",
+)
+
+func setupLogger() logger.Logger {
+	sink := &test_util.TestZapSink{
+		Buffer: gbytes.NewBuffer(),
+	}
+	testLogger := logger.NewLogger(
+		"test",
+		zap.InfoLevel,
+		zap.Output(zap.MultiWriteSyncer(sink, zap.AddSync(ginkgo.GinkgoWriter))),
+		zap.ErrorOutput(zap.MultiWriteSyncer(sink, zap.AddSync(ginkgo.GinkgoWriter))),
+	)
+	return &test_util.TestZapLogger{
+		Logger:      testLogger,
+		TestZapSink: sink,
+	}
+}
+func setupConfig() *config.Config {
+	configObj := config.DefaultConfig()
+	configObj.PruneStaleDropletsInterval = 50 * time.Millisecond
+	configObj.DropletStaleThreshold = 24 * time.Millisecond
+	configObj.IsolationSegments = []string{"foo", "bar"}
+	return configObj
+}
+func BenchmarkRegisterWith100KRoutes(b *testing.B) {
+	r := registry.NewRouteRegistry(testLogger, configObj, reporter)
+
+	for i := 0; i < 100000; i++ {
+		r.Register(route.Uri(fmt.Sprintf("foo%d.example.com", i)), fooEndpoint)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		r.Register("foo50000.example.com", fooEndpoint)
+	}
+}
+
+func BenchmarkRegisterWithOneRoute(b *testing.B) {
+	r := registry.NewRouteRegistry(testLogger, configObj, reporter)
+
+	r.Register("foo.example.com", fooEndpoint)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		r.Register("foo.example.com", fooEndpoint)
+	}
+}

--- a/registry/registry_benchmark_test.go
+++ b/registry/registry_benchmark_test.go
@@ -38,23 +38,23 @@ func setupLogger() logger.Logger {
 	sink := &test_util.TestZapSink{
 		Buffer: gbytes.NewBuffer(),
 	}
-	testLogger := logger.NewLogger(
+	l := logger.NewLogger(
 		"test",
 		zap.InfoLevel,
 		zap.Output(zap.MultiWriteSyncer(sink, zap.AddSync(ginkgo.GinkgoWriter))),
 		zap.ErrorOutput(zap.MultiWriteSyncer(sink, zap.AddSync(ginkgo.GinkgoWriter))),
 	)
 	return &test_util.TestZapLogger{
-		Logger:      testLogger,
+		Logger:      l,
 		TestZapSink: sink,
 	}
 }
 func setupConfig() *config.Config {
-	configObj := config.DefaultConfig()
-	configObj.PruneStaleDropletsInterval = 50 * time.Millisecond
-	configObj.DropletStaleThreshold = 24 * time.Millisecond
-	configObj.IsolationSegments = []string{"foo", "bar"}
-	return configObj
+	c := config.DefaultConfig()
+	c.PruneStaleDropletsInterval = 50 * time.Millisecond
+	c.DropletStaleThreshold = 24 * time.Millisecond
+	c.IsolationSegments = []string{"foo", "bar"}
+	return c
 }
 func BenchmarkRegisterWith100KRoutes(b *testing.B) {
 	r := registry.NewRouteRegistry(testLogger, configObj, reporter)


### PR DESCRIPTION
The use of IncrementCounter vs BatchIncrement counter causes
registry.Registry to be 6~7x slower

with sender.IncrementCounter:
```
go test -run Benchmark -bench=.
BenchmarkRegisterWith100KRoutes-4         100000             23244 ns/op
BenchmarkRegisterWithOneRoute-4           100000             19677 ns/op
PASS
ok      code.cloudfoundry.org/gorouter/registry 17.593s
```

with batcher.BatchIncrementCounter:
```
go test -run Benchmark -bench=.
BenchmarkRegisterWith100KRoutes-4         300000              3616 ns/op
BenchmarkRegisterWithOneRoute-4           500000              3032 ns/op
PASS
ok      code.cloudfoundry.org/gorouter/registry 8.872s
```

This commit changes the behavior of one of Gorouter's metrics:
Instead of the `registry_message` counter metric being emitted on every
NATS message, it will emit the metric on a set interval.

Thanks for contributing to gorouter. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bin/test`

* [ ] I have run CF Acceptance Tests on bosh lite
