### PR TITLE
Return the current maximum number of instances in X-CF-APP-INSTANCE-MAX

### DIFF
--- a/common/http/headers.go
+++ b/common/http/headers.go
@@ -9,6 +9,7 @@ const (
 	VcapTraceHeader       = "X-Vcap-Trace"
 	CfInstanceIdHeader    = "X-CF-InstanceID"
 	CfAppInstance         = "X-CF-APP-INSTANCE"
+	CfAppInstanceMax      = "X-CF-APP-INSTANCE-MAX"
 	CfRouterError         = "X-Cf-RouterError"
 )
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1230,7 +1230,7 @@ var _ = Describe("Proxy", func() {
 					Expect(req.Header.Get(router_http.CfAppInstance)).To(BeEmpty())
 
 					resp := test_util.NewResponse(http.StatusOK)
-					resp.Body = ioutil.NopCloser(strings.NewReader("Hellow World: App2"))
+					resp.Body = ioutil.NopCloser(strings.NewReader("Hello World: App2"))
 					conn.WriteResponse(resp)
 
 					conn.Close()
@@ -1250,13 +1250,51 @@ var _ = Describe("Proxy", func() {
 					Eventually(done).Should(Receive())
 					_, b := conn.ReadResponse()
 					return b
-				}).Should(Equal("Hellow World: App2"))
+				}).Should(Equal("Hello World: App2"))
+			})
+
+			It("includes the number of running instances in the response headers", func() {
+				done := make(chan struct{})
+				// app handlers for app.vcap.me
+				ln := test_util.RegisterHandler(r, "app.vcap.me", func(conn *test_util.HttpConn) {
+					Fail("Instance should not have received request")
+				}, test_util.RegisterConfig{AppId: "app-1-id", InstanceIndex: "5"})
+				defer ln.Close()
+
+				ln = test_util.RegisterHandler(r, "app.vcap.me", func(conn *test_util.HttpConn) {
+					Fail("Instance should not have received request")
+				}, test_util.RegisterConfig{AppId: "app-2-id", InstanceIndex: "7"})
+				defer ln.Close()
+
+				ln = test_util.RegisterHandler(r, "app.vcap.me", func(conn *test_util.HttpConn) {
+					_, err := http.ReadRequest(conn.Reader)
+					Expect(err).NotTo(HaveOccurred())
+
+					resp := test_util.NewResponse(http.StatusOK)
+					conn.WriteResponse(resp)
+					conn.Close()
+
+					done <- struct{}{}
+				}, test_util.RegisterConfig{AppId: "app-2-id", InstanceIndex: "3"})
+				defer ln.Close()
+
+				conn := dialProxy(proxyServer)
+
+				req := test_util.NewRequest("GET", "app.vcap.me", "/yadda", nil)
+				req.Header.Set(router_http.CfAppInstance, "app-2-id:3")
+
+				conn.WriteRequest(req)
+
+				Eventually(done).Should(Receive())
+				resp, _ := conn.ReadResponse()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(resp.Header.Get(router_http.CfAppInstanceMax)).To(Equal("7"))
 			})
 
 			It("returns a 404 if it cannot find the specified instance", func() {
 				ln := test_util.RegisterHandler(r, "app.vcap.me", func(conn *test_util.HttpConn) {
 					Fail("App should not have received request")
-				}, test_util.RegisterConfig{AppId: "app-1-id"})
+				}, test_util.RegisterConfig{AppId: "app-1-id", InstanceIndex: "3"})
 				defer ln.Close()
 
 				conn := dialProxy(proxyServer)
@@ -1268,6 +1306,7 @@ var _ = Describe("Proxy", func() {
 				resp, _ := conn.ReadResponse()
 				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 				Expect(resp.Header.Get("X-Cf-RouterError")).To(Equal("unknown_route"))
+				Expect(resp.Header.Get(router_http.CfAppInstanceMax)).To(Equal("3"))
 			})
 		})
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -179,19 +180,22 @@ func (r *RouteRegistry) endpointInRouterShard(endpoint *route.Endpoint) bool {
 }
 
 func (r *RouteRegistry) LookupWithInstance(uri route.Uri, appID string, appIndex string) *route.Pool {
-	uri = uri.RouteKey()
 	p := r.Lookup(uri)
-
 	if p == nil {
 		return nil
 	}
 
-	var surgicalPool *route.Pool
+	surgicalPool := route.NewPool(0, p.Host(), p.ContextPath())
 
 	p.Each(func(e *route.Endpoint) {
-		if (e.ApplicationId == appID) && (e.PrivateInstanceIndex == appIndex) {
-			surgicalPool = route.NewPool(0, p.Host(), p.ContextPath())
-			surgicalPool.Put(e)
+		if e.ApplicationId == appID {
+			idx, err := strconv.Atoi(e.PrivateInstanceIndex)
+			if idx > surgicalPool.MaxIdx && err == nil {
+				surgicalPool.MaxIdx = idx
+			}
+			if e.PrivateInstanceIndex == appIndex {
+				surgicalPool.Put(e)
+			}
 		}
 	})
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -894,11 +894,11 @@ var _ = Describe("RouteRegistry", func() {
 				appIndex = "94"
 			})
 
-			It("returns a nil pool", func() {
+			It("returns an empty pool", func() {
 				Expect(r.NumUris()).To(Equal(1))
 				Expect(r.NumEndpoints()).To(Equal(2))
 				p := r.LookupWithInstance("bar.com/foo", appId, appIndex)
-				Expect(p).To(BeNil())
+				Expect(p.IsEmpty()).To(BeTrue())
 			})
 		})
 
@@ -908,11 +908,11 @@ var _ = Describe("RouteRegistry", func() {
 				appIndex = "0"
 			})
 
-			It("returns a nil pool ", func() {
+			It("returns an empty pool ", func() {
 				Expect(r.NumUris()).To(Equal(1))
 				Expect(r.NumEndpoints()).To(Equal(2))
 				p := r.LookupWithInstance("bar.com/foo", appId, appIndex)
-				Expect(p).To(BeNil())
+				Expect(p.IsEmpty()).To(BeTrue())
 			})
 		})
 	})

--- a/route/pool.go
+++ b/route/pool.go
@@ -94,6 +94,8 @@ type Pool struct {
 	nextIdx           int
 	overloaded        bool
 
+	MaxIdx int
+
 	random *rand.Rand
 }
 
@@ -137,6 +139,7 @@ func NewPool(retryAfterFailure time.Duration, host, contextPath string) *Pool {
 		index:             make(map[string]*endpointElem),
 		retryAfterFailure: retryAfterFailure,
 		nextIdx:           -1,
+		MaxIdx:            -1,
 		host:              host,
 		contextPath:       contextPath,
 		random:            rand.New(rand.NewSource(time.Now().UnixNano())),

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -46,6 +46,11 @@ var _ = Describe("Pool", func() {
 		pool = route.NewPool(2*time.Minute, "", "")
 		modTag = models.ModificationTag{}
 	})
+
+	It("has the expected MaxIdx", func() {
+		Expect(pool.MaxIdx).To(Equal(-1))
+	})
+
 	Context("PoolsMatch", func() {
 		It("returns true if the hosts and paths on both pools are the same", func() {
 			p1 := route.NewPool(2*time.Minute, "foo.com", "/path")


### PR DESCRIPTION
Fixes https://github.com/cloudfoundry/gorouter/issues/197

To test, send a request using app instance routing and check that the response contains the `X-CF-APP-INSTANCE-MAX` header. The header is added as long as the `X-CF-APP-INSTANCE` request header is syntactically correct and it contains a valid app GUID.

Note: the implementation is less than elegant since it adds a field to the Pool to avoid changing interfaces and function signatures all over the place. Suggestions on how to improve it are welcome.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bin/test`

* [ ] I have run CF Acceptance Tests on bosh lite
