### PR TITLE
add query parameter to Opaque on //

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -192,13 +192,13 @@ func (p *proxy) setupProxyRequest(target *http.Request) {
 
 	target.URL.Scheme = "http"
 	target.URL.Host = target.Host
-	target.URL.RawQuery = ""
 	target.URL.ForceQuery = false
 	target.URL.Opaque = target.RequestURI
 
 	if strings.HasPrefix(target.RequestURI, "//") {
-		target.URL.Opaque = "//" + target.Host + target.URL.Path
+		target.URL.Opaque = "//" + target.Host + target.URL.Path + target.URL.Query().Encode()
 	}
+	target.URL.RawQuery = ""
 
 	handler.SetRequestXRequestStart(target)
 	target.Header.Del(router_http.CfAppInstance)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -251,14 +251,14 @@ var _ = Describe("Proxy", func() {
 
 		It("handles double slashes in an absolute-form request target correctly", func() {
 			ln := test_util.RegisterHandler(r, "test.io", func(conn *test_util.HttpConn) {
-				conn.CheckLine("GET http://test.io//something.io HTTP/1.1")
+				conn.CheckLine("GET http://test.io//something.io?q=something HTTP/1.1")
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
 			})
 			defer ln.Close()
 
 			conn := dialProxy(proxyServer)
 			conn.WriteLines([]string{
-				"GET http://test.io//something.io HTTP/1.1",
+				"GET http://test.io//something.io?q=something HTTP/1.1",
 				"Host: test.io",
 			})
 


### PR DESCRIPTION
path beginning with // it must set the query parameter to opaque.
Otherwise the parameter will get lost in the process.

Thanks for contributing to gorouter. To speed up the process of reviewing your pull request please provide us with:

A short explanation of the proposed change:
Setting the query parameter in the URL.Opaque inside Director of Reverseproxy so that those will not getting lost in the process.

An explanation of the use cases your change solves
Someone hits gorouter with test.io//something?q=something than target of that should receive the complete information including the query parameter so that service can decide how to handle that.

Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
start gorouter, start a test service, register that service and than call it.

Expected result after the change
curl 'my_first_url.localhost.routing.cf-app.com:8081/internal/status?q=hi' ends up at test service with q=hi

Current result before the change
curl 'my_first_url.localhost.routing.cf-app.com:8081/internal/status?q=hi' ends ends up at test service without q=hi


* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [X] I have run all the unit tests using `bin/test`

* [ ] I have run CF Acceptance Tests on bosh lite