### PR TITLE
Do not set VCAP_ID stickyness cookie if value already provided by backend. 

### DIFF
--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -310,6 +310,13 @@ func setupStickySession(
 			break
 		}
 	}
+	
+	for _, v := range response.Cookies() {
+		if v.Name == VcapCookieId {
+			sticky = false
+			break
+		}
+	}	
 
 	if sticky {
 		// right now secure attribute would as equal to the JSESSION ID cookie (if present),


### PR DESCRIPTION
…kend.

Thanks for contributing to gorouter. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Do not set VCAP_ID stickyness cookie if value already provided by backend. 
GoRoute would set the VCAP_ID Cookie ignoring an already present Set-Cookie Header from the backend, which results in a dublicate Set-Cookie Header.
This is important to allow the backend to change the routing of a sticky session to a different instance.

* An explanation of the use cases your change solves
Rerouting indication from the backend where overwritten by gorouter. gorouter schould not set the 
VCAP_ID Cookie twice if it is already present in the backend response.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests using `bin/test`

* [ ] I have run CF Acceptance Tests on bosh lite
