### PR TITLE
Prune TLS endpoints when Dial fails

### DIFF
--- a/handlers/lookup_test.go
+++ b/handlers/lookup_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Lookup", func() {
 		var pool *route.Pool
 
 		BeforeEach(func() {
-			pool = route.NewPool(&route.PoolOpts{
+			pool = route.NewPool(new(logger_fakes.FakeLogger), &route.PoolOpts{
 				RetryAfterFailure:  2 * time.Minute,
 				Host:               "example.com",
 				ContextPath:        "/",
@@ -109,7 +109,7 @@ var _ = Describe("Lookup", func() {
 	Context("when there is a pool that matches the request, and it has endpoints", func() {
 		Context("when conn limit is set to unlimited", func() {
 			BeforeEach(func() {
-				pool := route.NewPool(&route.PoolOpts{
+				pool := route.NewPool(new(logger_fakes.FakeLogger), &route.PoolOpts{
 					RetryAfterFailure:  2 * time.Minute,
 					Host:               "example.com",
 					ContextPath:        "/",
@@ -141,7 +141,7 @@ var _ = Describe("Lookup", func() {
 
 		Context("when conn limit is reached for an endpoint", func() {
 			BeforeEach(func() {
-				pool := route.NewPool(&route.PoolOpts{
+				pool := route.NewPool(new(logger_fakes.FakeLogger), &route.PoolOpts{
 					RetryAfterFailure:  2 * time.Minute,
 					Host:               "example.com",
 					ContextPath:        "/",
@@ -168,7 +168,7 @@ var _ = Describe("Lookup", func() {
 		Context("when conn limit is reached for all requested endpoints", func() {
 			var testEndpoint *route.Endpoint
 			BeforeEach(func() {
-				pool := route.NewPool(&route.PoolOpts{
+				pool := route.NewPool(new(logger_fakes.FakeLogger), &route.PoolOpts{
 					RetryAfterFailure:  2 * time.Minute,
 					Host:               "example.com",
 					ContextPath:        "/",
@@ -199,7 +199,7 @@ var _ = Describe("Lookup", func() {
 
 		Context("when a specific instance is requested", func() {
 			BeforeEach(func() {
-				pool := route.NewPool(&route.PoolOpts{
+				pool := route.NewPool(new(logger_fakes.FakeLogger), &route.PoolOpts{
 					RetryAfterFailure:  2 * time.Minute,
 					Host:               "example.com",
 					ContextPath:        "/",
@@ -226,7 +226,7 @@ var _ = Describe("Lookup", func() {
 
 		Context("when an invalid instance header is requested", func() {
 			BeforeEach(func() {
-				pool := route.NewPool(&route.PoolOpts{
+				pool := route.NewPool(new(logger_fakes.FakeLogger), &route.PoolOpts{
 					RetryAfterFailure:  2 * time.Minute,
 					Host:               "example.com",
 					ContextPath:        "/",
@@ -253,7 +253,7 @@ var _ = Describe("Lookup", func() {
 
 		Context("when given an incomplete app instance header", func() {
 			BeforeEach(func() {
-				pool := route.NewPool(&route.PoolOpts{
+				pool := route.NewPool(new(logger_fakes.FakeLogger), &route.PoolOpts{
 					RetryAfterFailure:  2 * time.Minute,
 					Host:               "example.com",
 					ContextPath:        "/",
@@ -279,7 +279,7 @@ var _ = Describe("Lookup", func() {
 
 		Context("when only the app id is given", func() {
 			BeforeEach(func() {
-				pool := route.NewPool(&route.PoolOpts{
+				pool := route.NewPool(new(logger_fakes.FakeLogger), &route.PoolOpts{
 					RetryAfterFailure:  2 * time.Minute,
 					Host:               "example.com",
 					ContextPath:        "/",
@@ -309,7 +309,7 @@ var _ = Describe("Lookup", func() {
 				handler.Use(handlers.NewLookup(reg, rep, logger))
 				handler.UseHandler(nextHandler)
 
-				pool := route.NewPool(&route.PoolOpts{
+				pool := route.NewPool(new(logger_fakes.FakeLogger), &route.PoolOpts{
 					RetryAfterFailure:  2 * time.Minute,
 					Host:               "example.com",
 					ContextPath:        "/",

--- a/handlers/routeservice_test.go
+++ b/handlers/routeservice_test.go
@@ -77,12 +77,14 @@ var _ = Describe("Route Service Handler", func() {
 
 		reqChan = make(chan *http.Request, 1)
 
-		routePool = route.NewPool(&route.PoolOpts{
-			RetryAfterFailure:  1 * time.Second,
-			Host:               "my_host.com",
-			ContextPath:        "/resource+9-9_9",
-			MaxConnsPerBackend: 0,
-		})
+		routePool = route.NewPool(
+			new(logger_fakes.FakeLogger),
+			&route.PoolOpts{
+				RetryAfterFailure:  1 * time.Second,
+				Host:               "my_host.com",
+				ContextPath:        "/resource+9-9_9",
+				MaxConnsPerBackend: 0,
+			})
 
 		fakeLogger = new(logger_fakes.FakeLogger)
 		reg = &fakeRegistry.FakeRegistry{}
@@ -217,7 +219,7 @@ var _ = Describe("Route Service Handler", func() {
 
 			Context("when the route service has a route in the route registry", func() {
 				BeforeEach(func() {
-					rsPool := route.NewPool(&route.PoolOpts{
+					rsPool := route.NewPool(new(logger_fakes.FakeLogger), &route.PoolOpts{
 						RetryAfterFailure:  2 * time.Minute,
 						Host:               "route-service.com",
 						ContextPath:        "/",
@@ -360,7 +362,7 @@ var _ = Describe("Route Service Handler", func() {
 					req.Header.Set(routeservice.HeaderKeySignature, reqArgs.Signature)
 					req.Header.Set(routeservice.HeaderKeyMetadata, reqArgs.Metadata)
 
-					rsPool := route.NewPool(&route.PoolOpts{
+					rsPool := route.NewPool(new(logger_fakes.FakeLogger), &route.PoolOpts{
 						RetryAfterFailure:  2 * time.Minute,
 						Host:               "my_host.com",
 						ContextPath:        "/original_path",

--- a/proxy/fails/classifier_group.go
+++ b/proxy/fails/classifier_group.go
@@ -19,6 +19,10 @@ var PrunableClassifiers = ClassifierGroup{
 	AttemptedTLSWithNonTLSBackend,
 }
 
+var UnavailableClassifiers = ClassifierGroup{
+	Dial,
+}
+
 // Classify returns true on errors that are retryable
 func (cg ClassifierGroup) Classify(err error) bool {
 	for _, classifier := range cg {

--- a/proxy/modifyresponse_unit_test.go
+++ b/proxy/modifyresponse_unit_test.go
@@ -7,7 +7,9 @@ import (
 
 	router_http "code.cloudfoundry.org/gorouter/common/http"
 	"code.cloudfoundry.org/gorouter/handlers"
+	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
 	"code.cloudfoundry.org/gorouter/route"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -35,7 +37,7 @@ var _ = Describe("modifyResponse", func() {
 		reqInfo, err = handlers.ContextRequestInfo(modifiedReq)
 		Expect(err).ToNot(HaveOccurred())
 		reqInfo.RouteEndpoint = route.NewEndpoint(&route.EndpointOpts{Host: "1.2.3.4", Port: 5678})
-		reqInfo.RoutePool = route.NewPool(&route.PoolOpts{
+		reqInfo.RoutePool = route.NewPool(new(logger_fakes.FakeLogger), &route.PoolOpts{
 			RetryAfterFailure:  0,
 			Host:               "foo.com",
 			ContextPath:        "context-path",

--- a/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/proxy/round_tripper/proxy_round_tripper_test.go
@@ -14,6 +14,7 @@ import (
 	"code.cloudfoundry.org/gorouter/common/uuid"
 	sharedfakes "code.cloudfoundry.org/gorouter/fakes"
 	"code.cloudfoundry.org/gorouter/handlers"
+	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
 	"code.cloudfoundry.org/gorouter/metrics/fakes"
 	errorClassifierFakes "code.cloudfoundry.org/gorouter/proxy/fails/fakes"
 	"code.cloudfoundry.org/gorouter/proxy/handler"
@@ -79,7 +80,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 		)
 
 		BeforeEach(func() {
-			routePool = route.NewPool(&route.PoolOpts{
+			routePool = route.NewPool(new(logger_fakes.FakeLogger), &route.PoolOpts{
 				RetryAfterFailure:  1 * time.Second,
 				Host:               "myapp.com",
 				ContextPath:        "",

--- a/registry/container/trie_test.go
+++ b/registry/container/trie_test.go
@@ -3,35 +3,36 @@ package container_test
 import (
 	"code.cloudfoundry.org/gorouter/route"
 
+	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
 	"code.cloudfoundry.org/gorouter/registry/container"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Trie", func() {
-
 	var (
 		r         *container.Trie
 		p, p1, p2 *route.Pool
+		logger    *logger_fakes.FakeLogger
 	)
 
 	BeforeEach(func() {
 		r = container.NewTrie()
-		p = route.NewPool(&route.PoolOpts{
+		p = route.NewPool(logger, &route.PoolOpts{
 			RetryAfterFailure:  42,
 			Host:               "",
 			ContextPath:        "",
 			MaxConnsPerBackend: 0,
 		})
 
-		p1 = route.NewPool(&route.PoolOpts{
+		p1 = route.NewPool(logger, &route.PoolOpts{
 			RetryAfterFailure:  42,
 			Host:               "",
 			ContextPath:        "",
 			MaxConnsPerBackend: 0,
 		})
 
-		p2 = route.NewPool(&route.PoolOpts{
+		p2 = route.NewPool(logger, &route.PoolOpts{
 			RetryAfterFailure:  42,
 			Host:               "",
 			ContextPath:        "",
@@ -124,8 +125,8 @@ var _ = Describe("Trie", func() {
 		})
 
 		It("adds a child node", func() {
-			rootPool := route.NewPool(&route.PoolOpts{RetryAfterFailure: 0, Host: "", ContextPath: ""})
-			childPool := route.NewPool(&route.PoolOpts{RetryAfterFailure: 0, Host: "", ContextPath: ""})
+			rootPool := route.NewPool(logger, &route.PoolOpts{RetryAfterFailure: 0, Host: "", ContextPath: ""})
+			childPool := route.NewPool(logger, &route.PoolOpts{RetryAfterFailure: 0, Host: "", ContextPath: ""})
 
 			_ = r.Insert("example", rootPool)
 
@@ -258,8 +259,8 @@ var _ = Describe("Trie", func() {
 
 			e1 := route.NewEndpoint(&route.EndpointOpts{Port: 1234})
 			e2 := route.NewEndpoint(&route.EndpointOpts{Port: 4321})
-			p3 := route.NewPool(&route.PoolOpts{RetryAfterFailure: 42, Host: "", ContextPath: ""})
-			p4 := route.NewPool(&route.PoolOpts{RetryAfterFailure: 42, Host: "", ContextPath: ""})
+			p3 := route.NewPool(logger, &route.PoolOpts{RetryAfterFailure: 42, Host: "", ContextPath: ""})
+			p4 := route.NewPool(logger, &route.PoolOpts{RetryAfterFailure: 42, Host: "", ContextPath: ""})
 			p1.Put(e1)
 			p2.Put(e2)
 			r.Insert("/foo", p1)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -94,7 +94,7 @@ func (r *RouteRegistry) Register(uri route.Uri, endpoint *route.Endpoint) {
 	pool := r.byURI.Find(routekey)
 	if pool == nil {
 		host, contextPath := splitHostAndContextPath(uri)
-		pool = route.NewPool(&route.PoolOpts{
+		pool = route.NewPool(r.logger, &route.PoolOpts{
 			RetryAfterFailure:  r.dropletStaleThreshold / 4,
 			Host:               host,
 			ContextPath:        contextPath,
@@ -203,7 +203,7 @@ func (r *RouteRegistry) LookupWithInstance(uri route.Uri, appID string, appIndex
 
 	p.Each(func(e *route.Endpoint) {
 		if (e.ApplicationId == appID) && (e.PrivateInstanceIndex == appIndex) {
-			surgicalPool = route.NewPool(&route.PoolOpts{
+			surgicalPool = route.NewPool(r.logger, &route.PoolOpts{
 				RetryAfterFailure:  0,
 				Host:               p.Host(),
 				ContextPath:        p.ContextPath(),

--- a/route/leastconnection_benchmark_test.go
+++ b/route/leastconnection_benchmark_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
+
 	"code.cloudfoundry.org/gorouter/route"
 )
 
@@ -15,13 +17,14 @@ func loadBalance(lb route.EndpointIterator) {
 }
 
 func loadBalanceFor(strategy string, b *testing.B) {
-
-	pool := route.NewPool(&route.PoolOpts{
-		RetryAfterFailure:  2 * time.Minute,
-		Host:               "",
-		ContextPath:        "",
-		MaxConnsPerBackend: 0,
-	})
+	pool := route.NewPool(
+		new(logger_fakes.FakeLogger),
+		&route.PoolOpts{
+			RetryAfterFailure:  2 * time.Minute,
+			Host:               "",
+			ContextPath:        "",
+			MaxConnsPerBackend: 0,
+		})
 
 	total := 5
 	endpoints := make([]*route.Endpoint, 0)

--- a/route/leastconnection_test.go
+++ b/route/leastconnection_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
 	"code.cloudfoundry.org/gorouter/route"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,6 +15,7 @@ var _ = Describe("LeastConnection", func() {
 
 	BeforeEach(func() {
 		pool = route.NewPool(
+			new(logger_fakes.FakeLogger),
 			&route.PoolOpts{
 				RetryAfterFailure:  2 * time.Minute,
 				Host:               "",
@@ -133,12 +135,14 @@ var _ = Describe("LeastConnection", func() {
 				)
 
 				BeforeEach(func() {
-					pool = route.NewPool(&route.PoolOpts{
-						RetryAfterFailure:  2 * time.Minute,
-						Host:               "",
-						ContextPath:        "",
-						MaxConnsPerBackend: 2,
-					})
+					pool = route.NewPool(
+						new(logger_fakes.FakeLogger),
+						&route.PoolOpts{
+							RetryAfterFailure:  2 * time.Minute,
+							Host:               "",
+							ContextPath:        "",
+							MaxConnsPerBackend: 2,
+						})
 
 					epOne = route.NewEndpoint(&route.EndpointOpts{Host: "5.5.5.5", Port: 5555, PrivateInstanceId: "private-label-1"})
 					pool.Put(epOne)

--- a/route/roundrobin_test.go
+++ b/route/roundrobin_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"time"
 
+	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
 	"code.cloudfoundry.org/gorouter/route"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,12 +15,14 @@ var _ = Describe("RoundRobin", func() {
 	var pool *route.Pool
 
 	BeforeEach(func() {
-		pool = route.NewPool(&route.PoolOpts{
-			RetryAfterFailure:  2 * time.Minute,
-			Host:               "",
-			ContextPath:        "",
-			MaxConnsPerBackend: 0,
-		})
+		pool = route.NewPool(
+			new(logger_fakes.FakeLogger),
+			&route.PoolOpts{
+				RetryAfterFailure:  2 * time.Minute,
+				Host:               "",
+				ContextPath:        "",
+				MaxConnsPerBackend: 0,
+			})
 	})
 
 	Describe("Next", func() {
@@ -143,12 +146,14 @@ var _ = Describe("RoundRobin", func() {
 			)
 
 			BeforeEach(func() {
-				pool = route.NewPool(&route.PoolOpts{
-					RetryAfterFailure:  2 * time.Minute,
-					Host:               "",
-					ContextPath:        "",
-					MaxConnsPerBackend: 2,
-				})
+				pool = route.NewPool(
+					new(logger_fakes.FakeLogger),
+					&route.PoolOpts{
+						RetryAfterFailure:  2 * time.Minute,
+						Host:               "",
+						ContextPath:        "",
+						MaxConnsPerBackend: 2,
+					})
 
 				epOne = route.NewEndpoint(&route.EndpointOpts{Host: "5.5.5.5", Port: 5555, PrivateInstanceId: "private-label-1"})
 				pool.Put(epOne)
@@ -261,12 +266,14 @@ var _ = Describe("RoundRobin", func() {
 		})
 
 		It("resets failed endpoints after exceeding failure duration", func() {
-			pool = route.NewPool(&route.PoolOpts{
-				RetryAfterFailure:  50 * time.Millisecond,
-				Host:               "",
-				ContextPath:        "",
-				MaxConnsPerBackend: 0,
-			})
+			pool = route.NewPool(
+				new(logger_fakes.FakeLogger),
+				&route.PoolOpts{
+					RetryAfterFailure:  50 * time.Millisecond,
+					Host:               "",
+					ContextPath:        "",
+					MaxConnsPerBackend: 0,
+				})
 
 			e1 := route.NewEndpoint(&route.EndpointOpts{Host: "1.2.3.4", Port: 1234})
 			e2 := route.NewEndpoint(&route.EndpointOpts{Host: "5.6.7.8", Port: 5678})


### PR DESCRIPTION
[#158847588]

Hi, this PR implements what was decided with [Change TLS route pruning behavior on dial error](https://github.com/cloudfoundry/gorouter/blob/master/docs/decisions/0002-change-tls-route-pruning-behavior-on-dial-error.md). Let me know what you think and what's missing (including test coverage and logging info). 

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `master` branch
* [x] I have run all the unit tests using `bin/test`
* [ ] I have run CF Acceptance Tests on bosh lite
