### PR TITLE
Allow inject HSTS header to response

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -139,6 +139,8 @@ type Config struct {
 	IsolationSegments        []string          `yaml:"isolation_segments,omitempty"`
 	RoutingTableShardingMode string            `yaml:"routing_table_sharding_mode,omitempty"`
 
+	StrictTransportSecurityHeader string `yaml:"strict_transport_security_header,omitempty"`
+
 	CipherString                      string             `yaml:"cipher_suites,omitempty"`
 	CipherSuites                      []uint16           `yaml:"-"`
 	MinTLSVersionString               string             `yaml:"min_tls_version,omitempty"`

--- a/handlers/inject_header.go
+++ b/handlers/inject_header.go
@@ -1,0 +1,27 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/urfave/negroni"
+
+	"code.cloudfoundry.org/gorouter/proxy/utils"
+)
+
+type injectHeaderHandler struct {
+	headerName  string
+	headerValue string
+}
+
+func NewInjectHeaderHandler(headerName, headerValue string) negroni.Handler {
+	return &injectHeaderHandler{
+		headerName:  headerName,
+		headerValue: headerValue,
+	}
+}
+
+func (p *injectHeaderHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	proxyWriter := rw.(utils.ProxyResponseWriter)
+	proxyWriter.InjectHeader(p.headerName, p.headerValue)
+	next(rw, r)
+}

--- a/handlers/inject_header_test.go
+++ b/handlers/inject_header_test.go
@@ -1,0 +1,57 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"code.cloudfoundry.org/gorouter/handlers"
+	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
+
+	"github.com/urfave/negroni"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("InjectHeaderHandler", func() {
+	processAndGetHeaders := func(listHandlers ...negroni.Handler) http.Header {
+		mockedService := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header()["X-Foo"] = []string{"foo"}
+			w.Write([]byte("some body"))
+		})
+
+		n := negroni.New()
+		n.Use(handlers.NewRequestInfo())
+		n.Use(handlers.NewProxyWriter(new(logger_fakes.FakeLogger)))
+		for _, h := range listHandlers {
+			n.Use(h)
+		}
+		n.UseHandler(mockedService)
+
+		res := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/foo", nil)
+		n.ServeHTTP(res, req)
+		return res.Header()
+	}
+
+	It("dones not change the header if already present in response", func() {
+		headers := processAndGetHeaders(handlers.NewInjectHeaderHandler("X-Foo", "bar"))
+		Expect(headers["X-Foo"]).To(Equal([]string{"foo"}))
+	})
+
+	It("injects a header if it is not present and keeps existing ones", func() {
+		headers := processAndGetHeaders(handlers.NewInjectHeaderHandler("X-Bar", "bar"))
+		Expect(headers["X-Bar"]).To(Equal([]string{"bar"}))
+		Expect(headers["X-Foo"]).To(Equal([]string{"foo"}))
+	})
+
+	It("injects multiple values for same header", func() {
+		headers := processAndGetHeaders(
+			handlers.NewInjectHeaderHandler("X-Bar", "bar1"),
+			handlers.NewInjectHeaderHandler("X-Bar", "bar2"),
+		)
+		Expect(headers["X-Bar"]).To(HaveLen(2))
+		Expect(headers["X-Bar"]).To(ContainElement("bar1"))
+		Expect(headers["X-Bar"]).To(ContainElement("bar2"))
+	})
+})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -145,6 +145,9 @@ func NewProxy(
 		SanitizeForwardedProto:   p.sanitizeForwardedProto,
 		Logger:                   logger,
 	})
+	if cfg.StrictTransportSecurityHeader != "" {
+		n.Use(handlers.NewInjectHeaderHandler("Strict-Transport-Security", cfg.StrictTransportSecurityHeader))
+	}
 	n.Use(routeServiceHandler)
 	n.Use(p)
 	n.UseHandler(rproxy)


### PR DESCRIPTION
Thanks for contributing to gorouter. To speed up the process of reviewing your pull request please provide us with:

What?
-----

We want to be able to inject the HSTS header, Strict-Transport-Security
into the response of the gorouter[1]

A new option strict_transport_security_header is added and can be
set to any free string to be inserted in this header, the
operator must set the right format.

The header would be injected only if configured and if the backend
does not return that header.

The implementation extends ProxyResponseWriter to allow inject
any the header, and we add a new custom handler. This would make
it easier to add similar features later.

[1] https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security

Use case
--------

In our use case we want every application to have the right HSTS
headers configured by default, as it is a requirement in our
organisation for any service.

The tenants can always override this header.

How to test/review?
-------------------

Tests where added.

To test it, you must set the `strict_transport_security_header`
config and test it by checking that the gorouter  returns
the header for any proxied HTTP request.

A fork of the routing-release with this option has been
added in: https://github.com/keymon/routing-release/tree/add_hsts_header
and will be

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests using `bin/test`

* [ ] I have run CF Acceptance Tests on bosh lite