### PR TITLE
Allow inject HSTS header to response

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -139,6 +139,8 @@ type Config struct {
 	IsolationSegments        []string          `yaml:"isolation_segments,omitempty"`
 	RoutingTableShardingMode string            `yaml:"routing_table_sharding_mode,omitempty"`
 
+	StrictTransportSecurityHeader string `yaml:"strict_transport_security_header,omitempty"`
+
 	CipherString                      string             `yaml:"cipher_suites,omitempty"`
 	CipherSuites                      []uint16           `yaml:"-"`
 	MinTLSVersionString               string             `yaml:"min_tls_version,omitempty"`

--- a/handlers/inject_header.go
+++ b/handlers/inject_header.go
@@ -1,0 +1,27 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/urfave/negroni"
+
+	"code.cloudfoundry.org/gorouter/proxy/utils"
+)
+
+type injectHeaderHandler struct {
+	headerName  string
+	headerValue string
+}
+
+func NewInjectHeaderHandler(headerName, headerValue string) negroni.Handler {
+	return &injectHeaderHandler{
+		headerName:  headerName,
+		headerValue: headerValue,
+	}
+}
+
+func (p *injectHeaderHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	proxyWriter := rw.(utils.ProxyResponseWriter)
+	proxyWriter.InjectHeader(p.headerName, p.headerValue)
+	next(rw, r)
+}

--- a/handlers/inject_header_test.go
+++ b/handlers/inject_header_test.go
@@ -1,0 +1,57 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"code.cloudfoundry.org/gorouter/handlers"
+	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
+
+	"github.com/urfave/negroni"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("InjectHeaderHandler", func() {
+	processAndGetHeaders := func(listHandlers ...negroni.Handler) http.Header {
+		mockedService := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header()["X-Foo"] = []string{"foo"}
+			w.Write([]byte("some body"))
+		})
+
+		n := negroni.New()
+		n.Use(handlers.NewRequestInfo())
+		n.Use(handlers.NewProxyWriter(new(logger_fakes.FakeLogger)))
+		for _, h := range listHandlers {
+			n.Use(h)
+		}
+		n.UseHandler(mockedService)
+
+		res := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/foo", nil)
+		n.ServeHTTP(res, req)
+		return res.Header()
+	}
+
+	It("dones not change the header if already present in response", func() {
+		headers := processAndGetHeaders(handlers.NewInjectHeaderHandler("X-Foo", "bar"))
+		Expect(headers["X-Foo"]).To(Equal([]string{"foo"}))
+	})
+
+	It("injects a header if it is not present and keeps existing ones", func() {
+		headers := processAndGetHeaders(handlers.NewInjectHeaderHandler("X-Bar", "bar"))
+		Expect(headers["X-Bar"]).To(Equal([]string{"bar"}))
+		Expect(headers["X-Foo"]).To(Equal([]string{"foo"}))
+	})
+
+	It("injects multiple values for same header", func() {
+		headers := processAndGetHeaders(
+			handlers.NewInjectHeaderHandler("X-Bar", "bar1"),
+			handlers.NewInjectHeaderHandler("X-Bar", "bar2"),
+		)
+		Expect(headers["X-Bar"]).To(HaveLen(2))
+		Expect(headers["X-Bar"]).To(ContainElement("bar1"))
+		Expect(headers["X-Bar"]).To(ContainElement("bar2"))
+	})
+})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -129,6 +129,9 @@ func NewProxy(
 	n.Use(handlers.NewHTTPStartStop(dropsonde.DefaultEmitter, logger))
 	n.Use(handlers.NewAccessLog(accessLogger, zipkinHandler.HeadersToLog(), logger))
 	n.Use(handlers.NewReporter(reporter, logger))
+	if cfg.StrictTransportSecurityHeader != "" {
+		n.Use(handlers.NewInjectHeaderHandler("Strict-Transport-Security", cfg.StrictTransportSecurityHeader))
+	}
 	n.Use(handlers.NewProxyHealthcheck(cfg.HealthCheckUserAgent, p.heartbeatOK, logger))
 	n.Use(zipkinHandler)
 	n.Use(handlers.NewProtocolCheck(logger))

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -612,6 +612,70 @@ var _ = Describe("Proxy", func() {
 		})
 	})
 
+	Describe("HSTS", func() {
+		mockedHandler := func(host string, addHeader bool) net.Listener {
+			return test_util.RegisterHandler(r, host, func(conn *test_util.HttpConn) {
+				_, err := http.ReadRequest(conn.Reader)
+				Expect(err).NotTo(HaveOccurred())
+
+				resp := test_util.NewResponse(http.StatusOK)
+				if addHeader {
+					resp.Header.Set("Strict-Transport-Security", "foobar")
+				}
+				conn.WriteResponse(resp)
+				conn.Close()
+			})
+		}
+
+		processAndGetHeader := func(host string) string {
+			conn := dialProxy(proxyServer)
+
+			req := test_util.NewRequest("GET", host, "/", nil)
+			conn.WriteRequest(req)
+
+			resp, _ := conn.ReadResponse()
+			return resp.Header.Get("Strict-Transport-Security")
+		}
+
+		It("does not add Strict-Transport-Security if not configured", func() {
+			ln := mockedHandler("hsts-test", false)
+			defer ln.Close()
+
+			header := processAndGetHeader("hsts-test")
+			Expect(header).To(BeEmpty())
+		})
+
+		Context("when strict_transport_security_header is set", func() {
+			BeforeEach(func() {
+				conf.StrictTransportSecurityHeader = "max-age=1234"
+			})
+
+			It("adds Strict-Transport-Security if it doesn't already exist in the response", func() {
+				ln := mockedHandler("hsts-test", false)
+				defer ln.Close()
+
+				header := processAndGetHeader("hsts-test")
+				Expect(header).To(Equal("max-age=1234"))
+			})
+
+			It("does not add Strict-Transport-Security if it already exists in the response", func() {
+				ln := mockedHandler("hsts-test", true)
+				defer ln.Close()
+
+				header := processAndGetHeader("hsts-test")
+				Expect(header).To(Equal("foobar"))
+			})
+
+			It("adds Strict-Transport-Security for unknown routes", func() {
+				ln := mockedHandler("hsts-test", false)
+				defer ln.Close()
+
+				header := processAndGetHeader("other-host")
+				Expect(header).To(Equal("max-age=1234"))
+			})
+		})
+	})
+
 	Describe("Backend Connection Handling", func() {
 		Context("when max conn per backend is set to > 0 ", func() {
 			BeforeEach(func() {


### PR DESCRIPTION
What?
-----

We want to be able to inject the HSTS header, Strict-Transport-Security
into the response of the gorouter[1]

A new option strict_transport_security_header is added and can be
set to any free string to be inserted in this header, the
operator must set the right format.

The header would be injected only if configured and if the backend
does not return that header.

The implementation extends ProxyResponseWriter to allow inject
any the header, and we add a new custom handler. This would make
it easier to add similar features later.

[1] https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security

Use case
--------

In our organisation there is a requirement of any application to use HTTPS and set HSTS headers. We want every application to respond with these headers. The tenant can always override them if they need to.

How to review/test
----------------------

 - Code review, there are tests
 - Set the right config `strict_transport_security_header` with the right value. Check that gorouter returns the header as desired.
 - A fork of routing-release with the right parameter is in: https://github.com/alphagov/paas-routing-release/tree/add_hsts_header and https://github.com/cloudfoundry/routing-release/pull/126


Expected result after the change
-------

Header added if the `strict_transport_security_header` is configured and the app does not return such header.

Current result before the change
------------

Nothing happens :)

Links to any other associated PRs
-------

PR for routing release: https://github.com/cloudfoundry/routing-release/pull/126


Checklist
--------
* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bin/test`
      - The tests fail for me in master anyway. There are some problems with `go vet` in `main.go` (router variable overrides package) 

* [x] I have run CF Acceptance Tests on bosh lite
