### PR TITLE
Allow inject custom headers into response

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -112,6 +112,15 @@ var defaultLoggingConfig = LoggingConfig{
 	MetronAddress: "localhost:3457",
 }
 
+type HeaderNameValue struct {
+	Name  string `yaml: "name"`
+	Value string `yaml: "value,omitempty"`
+}
+
+type HTTPRewrite struct {
+	InjectResponseHeaders []HeaderNameValue `inject_response_headers,omitempty`
+}
+
 type Config struct {
 	Status                   StatusConfig      `yaml:"status,omitempty"`
 	Nats                     []NatsConfig      `yaml:"nats,omitempty"`
@@ -188,6 +197,8 @@ type Config struct {
 	DisableKeepAlives   bool `yaml:"disable_keep_alives,omitempty"`
 	MaxIdleConns        int  `yaml:"max_idle_conns,omitempty"`
 	MaxIdleConnsPerHost int  `yaml:"max_idle_conns_per_host,omitempty"`
+
+	HTTPRewrite HTTPRewrite `yaml:"http_rewrite,omitempty"`
 }
 
 var defaultConfig = Config{

--- a/handlers/http_rewrite.go
+++ b/handlers/http_rewrite.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/urfave/negroni"
+
+	"code.cloudfoundry.org/gorouter/config"
+	"code.cloudfoundry.org/gorouter/proxy/utils"
+)
+
+type httpRewriteHandler struct {
+	headerRewriter utils.HeaderRewriter
+}
+
+func NewHTTPRewriteHandler(cfg config.HTTPRewrite) negroni.Handler {
+	headersToInject := http.Header{}
+	for _, hv := range cfg.InjectResponseHeaders {
+		headersToInject.Add(hv.Name, hv.Value)
+	}
+	return &httpRewriteHandler{
+		headerRewriter: &utils.InjectHeaderRewriter{Header: headersToInject},
+	}
+}
+
+func (p *httpRewriteHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	proxyWriter := rw.(utils.ProxyResponseWriter)
+	proxyWriter.AddHeaderRewriter(p.headerRewriter)
+	next(rw, r)
+}

--- a/handlers/http_rewrite_test.go
+++ b/handlers/http_rewrite_test.go
@@ -1,0 +1,77 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"code.cloudfoundry.org/gorouter/config"
+	"code.cloudfoundry.org/gorouter/handlers"
+	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
+
+	"github.com/urfave/negroni"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HTTPRewrite Handler", func() {
+	process := func(cfg config.HTTPRewrite) *httptest.ResponseRecorder {
+		mockedService := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header()["X-Foo"] = []string{"foo"}
+			w.WriteHeader(http.StatusTeapot)
+			w.Write([]byte("I'm a little teapot, short and stout."))
+		})
+
+		n := negroni.New()
+		n.Use(handlers.NewRequestInfo())
+		n.Use(handlers.NewProxyWriter(new(logger_fakes.FakeLogger)))
+		n.Use(handlers.NewHTTPRewriteHandler(cfg))
+		n.UseHandler(mockedService)
+
+		res := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/foo", nil)
+		n.ServeHTTP(res, req)
+		return res
+	}
+
+	It("calls the next handler", func() {
+		res := process(config.HTTPRewrite{})
+		Expect(res.Header()["X-Foo"]).To(ConsistOf("foo"))
+		Expect(res.Body.Bytes()).To(Equal([]byte("I'm a little teapot, short and stout.")))
+	})
+
+	Describe("with AddResponseHeaders", func() {
+		It("does not change the header if already present in response", func() {
+			cfg := config.HTTPRewrite{
+				InjectResponseHeaders: []config.HeaderNameValue{
+					{Name: "X-Foo", Value: "bar"},
+				},
+			}
+			res := process(cfg)
+			Expect(res.Header()["X-Foo"]).To(ConsistOf("foo"))
+		})
+
+		It("injects a header if it is not present and keeps existing ones", func() {
+			cfg := config.HTTPRewrite{
+				InjectResponseHeaders: []config.HeaderNameValue{
+					{Name: "X-Bar", Value: "bar"},
+				},
+			}
+			res := process(cfg)
+			Expect(res.Header()["X-Foo"]).To(ConsistOf("foo"))
+			Expect(res.Header()["X-Bar"]).To(ConsistOf("bar"))
+		})
+
+		It("injects multiple values for same header", func() {
+			cfg := config.HTTPRewrite{
+				InjectResponseHeaders: []config.HeaderNameValue{
+					{Name: "X-Bar", Value: "bar1"},
+					{Name: "X-Bar", Value: "bar2"},
+				},
+			}
+			res := process(cfg)
+			Expect(res.Header()["X-Foo"]).To(ConsistOf("foo"))
+			Expect(res.Header()["X-Bar"]).To(ConsistOf("bar1", "bar2"))
+		})
+	})
+})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"reflect"
 	"strings"
 	"time"
 
@@ -129,6 +130,10 @@ func NewProxy(
 	n.Use(handlers.NewHTTPStartStop(dropsonde.DefaultEmitter, logger))
 	n.Use(handlers.NewAccessLog(accessLogger, zipkinHandler.HeadersToLog(), logger))
 	n.Use(handlers.NewReporter(reporter, logger))
+	if !reflect.DeepEqual(cfg.HTTPRewrite, config.HTTPRewrite{}) {
+		logger.Debug("http-rewrite", zap.Object("config", cfg.HTTPRewrite))
+		n.Use(handlers.NewHTTPRewriteHandler(cfg.HTTPRewrite))
+	}
 	n.Use(handlers.NewProxyHealthcheck(cfg.HealthCheckUserAgent, p.heartbeatOK, logger))
 	n.Use(zipkinHandler)
 	n.Use(handlers.NewProtocolCheck(logger))

--- a/proxy/utils/headerrewriter.go
+++ b/proxy/utils/headerrewriter.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"net/http"
+)
+
+type HeaderRewriter interface {
+	RewriteHeader(http.Header)
+}
+
+// InjectHeaderRewriter: Adds headers only if they are not present in the current http.Header
+type InjectHeaderRewriter struct {
+	Header http.Header
+}
+
+func (i *InjectHeaderRewriter) RewriteHeader(header http.Header) {
+	for h, v := range i.Header {
+		if _, ok := header[h]; !ok {
+			header[h] = v
+		}
+	}
+}

--- a/proxy/utils/headerrewriter_test.go
+++ b/proxy/utils/headerrewriter_test.go
@@ -1,0 +1,42 @@
+package utils_test
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/gorouter/proxy/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("InjectHeaderRewriter", func() {
+	It("injects headers if missing in the original Header", func() {
+		header := http.Header{}
+
+		headerToInject := http.Header{}
+		headerToInject.Add("foo", "bar1")
+		headerToInject.Add("foo", "bar2")
+
+		rewriter := utils.InjectHeaderRewriter{headerToInject}
+
+		rewriter.RewriteHeader(header)
+
+		Expect(header).To(HaveKey("Foo"))
+		Expect(header["Foo"]).To(ConsistOf("bar1", "bar2"))
+	})
+
+	It("does not inject headers if present in the original Header", func() {
+		header := http.Header{}
+		header.Add("foo", "original")
+
+		headerToInject := http.Header{}
+		headerToInject.Add("foo", "bar1")
+		headerToInject.Add("foo", "bar2")
+
+		rewriter := utils.InjectHeaderRewriter{headerToInject}
+
+		rewriter.RewriteHeader(header)
+
+		Expect(header).To(HaveKey("Foo"))
+		Expect(header["Foo"]).To(ConsistOf("original"))
+	})
+})

--- a/proxy/utils/responsewriter_test.go
+++ b/proxy/utils/responsewriter_test.go
@@ -1,0 +1,188 @@
+package utils
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type fakeResponseWriter struct {
+	header                http.Header
+	headerCalled          bool
+	flushCalled           bool
+	writeCalled           bool
+	writeHeaderCalled     bool
+	writeHeaderStatusCode int
+}
+
+func newFakeResponseWriter() *fakeResponseWriter {
+	return &fakeResponseWriter{
+		header: http.Header{},
+	}
+}
+
+func (f *fakeResponseWriter) Header() http.Header {
+	f.headerCalled = true
+	return f.header
+}
+
+func (f *fakeResponseWriter) Write(b []byte) (int, error) {
+	f.writeCalled = true
+	return len(b), nil
+}
+
+func (f *fakeResponseWriter) WriteHeader(statusCode int) {
+	f.writeHeaderCalled = true
+	f.writeHeaderStatusCode = statusCode
+}
+
+func (f *fakeResponseWriter) Flush() {
+	f.flushCalled = true
+}
+
+type fakeCloseNotifierResponseWriter struct {
+	fakeResponseWriter
+	c <-chan bool
+}
+
+func (f *fakeCloseNotifierResponseWriter) CloseNotify() <-chan bool {
+	return f.c
+}
+
+type fakeHijackerResponseWriter struct {
+	fakeResponseWriter
+	hijackCalled bool
+}
+
+func (f *fakeHijackerResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	f.hijackCalled = true
+	return nil, nil, errors.New("Not Implemented")
+}
+
+var _ = Describe("ProxyWriter", func() {
+	var (
+		closeNotifier chan bool
+		fake          *fakeResponseWriter
+		proxy         *proxyResponseWriter
+	)
+
+	BeforeEach(func() {
+		fake = newFakeResponseWriter()
+		proxy = NewProxyResponseWriter(fake)
+	})
+
+	It("delegates the call to Header", func() {
+		proxy.Header()
+		Expect(fake.headerCalled).To(BeTrue())
+	})
+
+	It("delegates the call to Flush", func() {
+		proxy.Flush()
+		Expect(fake.flushCalled).To(BeTrue())
+	})
+
+	It("delegates CloseNotify() if the writer is a http.CloseNotifier", func() {
+		closeNotifier = make(chan bool, 1)
+		fake := &fakeCloseNotifierResponseWriter{
+			fakeResponseWriter: *newFakeResponseWriter(),
+			c:                  closeNotifier,
+		}
+		proxy = NewProxyResponseWriter(fake)
+
+		closeNotifier <- true
+		Expect(proxy.CloseNotify()).To(Receive())
+	})
+
+	It("returns a channel if the writer is not http.CloseNotifier", func() {
+		Expect(proxy.CloseNotify()).To(BeAssignableToTypeOf(make(<-chan bool)))
+	})
+
+	It("delegates Hijack() if the writer is a http.Hijacker", func() {
+		fake := &fakeHijackerResponseWriter{
+			fakeResponseWriter: *newFakeResponseWriter(),
+		}
+		proxy = NewProxyResponseWriter(fake)
+		proxy.Hijack()
+		Expect(fake.hijackCalled).To(BeTrue())
+	})
+
+	It("Hijack() returns error if the writer is not http.Hijacker", func() {
+		_, _, err := proxy.Hijack()
+		Expect(err).To(MatchError("response writer cannot hijack"))
+	})
+
+	It("delegates the call to WriteHeader", func() {
+		proxy.WriteHeader(http.StatusOK)
+		Expect(fake.writeHeaderCalled).To(BeTrue())
+		Expect(fake.writeHeaderStatusCode).To(Equal(http.StatusOK))
+	})
+
+	It("WriteHeader sets Content-Type to empty if not set", func() {
+		proxy.WriteHeader(http.StatusOK)
+		Expect(fake.writeHeaderCalled).To(BeTrue())
+		Expect(fake.writeHeaderStatusCode).To(Equal(http.StatusOK))
+		Expect(fake.Header()).To(HaveKey("Content-Type"))
+		Expect(fake.Header()["Content-Type"]).To(HaveLen(0))
+	})
+
+	It("WriteHeader returns if Done() has been called", func() {
+		proxy.Done()
+		proxy.WriteHeader(http.StatusOK)
+		Expect(fake.writeHeaderCalled).To(BeFalse())
+		Expect(fake.Header()).ToNot(HaveKey("Content-Type"))
+	})
+
+	It("WriteHeader sets the status once", func() {
+		Expect(proxy.Status()).To(Equal(0))
+		proxy.WriteHeader(http.StatusTeapot)
+		Expect(proxy.Status()).To(Equal(http.StatusTeapot))
+		proxy.WriteHeader(http.StatusOK)
+		Expect(proxy.Status()).To(Equal(http.StatusTeapot))
+	})
+
+	It("delegates the call to Write", func() {
+		l, err := proxy.Write([]byte("foo"))
+		Expect(l).To(BeNumerically("==", 3))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fake.writeCalled).To(BeTrue())
+	})
+
+	It("Write returns if Done() has been called", func() {
+		proxy.Done()
+		l, err := proxy.Write([]byte("foo"))
+		Expect(l).To(BeNumerically("==", 0))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fake.writeCalled).To(BeFalse())
+	})
+
+	It("Write calls WriteHeader with http.StatusOK if it has not been set", func() {
+		proxy.Write([]byte("foo"))
+		Expect(fake.writeCalled).To(BeTrue())
+		Expect(fake.writeHeaderCalled).To(BeTrue())
+		Expect(fake.writeHeaderStatusCode).To(Equal(http.StatusOK))
+	})
+
+	It("Write does not call WriteHeader it has been already set", func() {
+		proxy.SetStatus(http.StatusTeapot)
+		proxy.Write([]byte("foo"))
+		Expect(fake.writeCalled).To(BeTrue())
+		Expect(fake.writeHeaderCalled).To(BeFalse())
+	})
+
+	It("Write does not call WriteHeader it has been already set", func() {
+		proxy.SetStatus(http.StatusTeapot)
+		proxy.Write([]byte("foo"))
+		Expect(fake.writeCalled).To(BeTrue())
+		Expect(fake.writeHeaderCalled).To(BeFalse())
+	})
+
+	It("Write keeps track of the size", func() {
+		proxy.Write([]byte("foo"))
+		proxy.Write([]byte("foo"))
+		Expect(proxy.Size()).To(BeNumerically("==", 6))
+	})
+})


### PR DESCRIPTION
What?
-----

We want to be able to inject the HSTS header, Strict-Transport-Security
into the response of the gorouter[1]

To do so here we add the posibility to inject custom headers in any response from the
go router. The header would be injected only if the backend
does not return those headers.

We allow some new configuration as in the router as:

    http_rewrite:
      inject_response_headers:
      - name: X-A-Header
        value: the-value
      - name: X-A-Header
        value: other-value
      - name: X-Other-Header
        value: some value

Scope
------

We only implement add the headers if they are not set in the backend. Other operations  (append, override, delete) can be easily added if desired.

Implementation details
-----------------------------

This commit adds the basis to implement any rewrite logic on
the headers. We extend ProxyResponseWriter to allow register
new HeaderRewriters.

We add for the time being a InjectHeaderRewriter, that would only
add headers if they don't already exist. Similar HeaderRewriters
can be implemented for delete, append, etc.

A new Handler HTTPRewrite is inserted if there is any `http_rewrite`
configuration. This handler would initialise once HeaderRewriter
during the setup of the server, and attach it to each
ProxyResponseWriter in each request.

[1] https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security

Use case
--------

In our organisation there is a requirement of any application to use HTTPS and set HSTS headers. We want every application to respond with these headers. The tenant can always override them if they need to.

How to review/test
----------------------

 - Code review, there are tests
 - Set the right config as aboce. Check that gorouter returns the header as desired.
 - A fork of routing-release with the right parameter is in: TBD


Expected result after the change
-------

Header added if the `strict_transport_security_header` is configured and the app does not return such header.

Current result before the change
------------

Nothing happens :)

Links to any other associated PRs
-------

PR for routing release: TBD

Checklist
--------
* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bin/test`
      - The tests fail for me in master anyway. There are some problems with `go vet` in `main.go` (router variable overrides package) 

* [ ] I have run CF Acceptance Tests on bosh lite
