### PR TITLE
Allow specify headers to remove in response and config struct change

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -118,7 +118,11 @@ type HeaderNameValue struct {
 }
 
 type HTTPRewrite struct {
-	InjectResponseHeaders []HeaderNameValue `yaml:"inject_response_headers,omitempty"`
+	Responses HTTPRewriteResponses `yaml:"responses,omitempty"`
+}
+
+type HTTPRewriteResponses struct {
+	AddHeadersIfNotPresent []HeaderNameValue `yaml:"add_headers_if_not_present,omitempty"`
 }
 
 type Config struct {

--- a/config/config.go
+++ b/config/config.go
@@ -123,6 +123,7 @@ type HTTPRewrite struct {
 
 type HTTPRewriteResponses struct {
 	AddHeadersIfNotPresent []HeaderNameValue `yaml:"add_headers_if_not_present,omitempty"`
+	RemoveHeaders          []HeaderNameValue `yaml:"remove_headers,omitempty"`
 }
 
 type Config struct {

--- a/handlers/http_rewrite.go
+++ b/handlers/http_rewrite.go
@@ -10,21 +10,28 @@ import (
 )
 
 type httpRewriteHandler struct {
-	headerRewriter utils.HeaderRewriter
+	responseHeaderRewriter utils.HeaderRewriter
+}
+
+func headerNameValuesToHTTPHeader(headerNameValues []config.HeaderNameValue) http.Header {
+	h := http.Header{}
+	for _, hv := range headerNameValues {
+		h.Add(hv.Name, hv.Value)
+	}
+	return h
 }
 
 func NewHTTPRewriteHandler(cfg config.HTTPRewrite) negroni.Handler {
-	headersToInject := http.Header{}
-	for _, hv := range cfg.InjectResponseHeaders {
-		headersToInject.Add(hv.Name, hv.Value)
-	}
+	addHeadersIfNotPresent := headerNameValuesToHTTPHeader(
+		cfg.Responses.AddHeadersIfNotPresent,
+	)
 	return &httpRewriteHandler{
-		headerRewriter: &utils.InjectHeaderRewriter{Header: headersToInject},
+		responseHeaderRewriter: &utils.AddHeaderIfNotPresentRewriter{Header: addHeadersIfNotPresent},
 	}
 }
 
 func (p *httpRewriteHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	proxyWriter := rw.(utils.ProxyResponseWriter)
-	proxyWriter.AddHeaderRewriter(p.headerRewriter)
+	proxyWriter.AddHeaderRewriter(p.responseHeaderRewriter)
 	next(rw, r)
 }

--- a/handlers/http_rewrite_test.go
+++ b/handlers/http_rewrite_test.go
@@ -80,4 +80,49 @@ var _ = Describe("HTTPRewrite Handler", func() {
 			Expect(res.Header()["X-Bar"]).To(ConsistOf("bar1", "bar2"))
 		})
 	})
+
+	Describe("with Responses.RemoveHeaders", func() {
+		It("does not remove headers that have same name", func() {
+			cfg := config.HTTPRewrite{
+				Responses: config.HTTPRewriteResponses{
+					RemoveHeaders: []config.HeaderNameValue{
+						{Name: "X-Bar"},
+					},
+				},
+			}
+			res := process(cfg)
+			Expect(res.Header()).To(HaveKey("X-Foo"))
+			Expect(res.Header()["X-Foo"]).To(ConsistOf("foo"))
+		})
+
+		It("removes headers that have same name", func() {
+			cfg := config.HTTPRewrite{
+				Responses: config.HTTPRewriteResponses{
+					RemoveHeaders: []config.HeaderNameValue{
+						{Name: "X-Foo"},
+					},
+				},
+			}
+			res := process(cfg)
+			Expect(res.Header()).ToNot(HaveKey("X-Foo"))
+		})
+	})
+
+	Describe("with Responses.RemoveHeaders and Responses.InjectHeadersIfNotPresent", func() {
+		It("removes and adds the header", func() {
+			cfg := config.HTTPRewrite{
+				Responses: config.HTTPRewriteResponses{
+					RemoveHeaders: []config.HeaderNameValue{
+						{Name: "X-Foo"},
+					},
+					AddHeadersIfNotPresent: []config.HeaderNameValue{
+						{Name: "X-Foo", Value: "bar"},
+					},
+				},
+			}
+			res := process(cfg)
+			Expect(res.Header()).To(HaveKey("X-Foo"))
+			Expect(res.Header()["X-Foo"]).To(ConsistOf("bar"))
+		})
+	})
 })

--- a/handlers/http_rewrite_test.go
+++ b/handlers/http_rewrite_test.go
@@ -40,21 +40,25 @@ var _ = Describe("HTTPRewrite Handler", func() {
 		Expect(res.Body.Bytes()).To(Equal([]byte("I'm a little teapot, short and stout.")))
 	})
 
-	Describe("with AddResponseHeaders", func() {
+	Describe("with Responses.InjectHeadersIfNotPresent", func() {
 		It("does not change the header if already present in response", func() {
 			cfg := config.HTTPRewrite{
-				InjectResponseHeaders: []config.HeaderNameValue{
-					{Name: "X-Foo", Value: "bar"},
+				Responses: config.HTTPRewriteResponses{
+					AddHeadersIfNotPresent: []config.HeaderNameValue{
+						{Name: "X-Foo", Value: "bar"},
+					},
 				},
 			}
 			res := process(cfg)
 			Expect(res.Header()["X-Foo"]).To(ConsistOf("foo"))
 		})
 
-		It("injects a header if it is not present and keeps existing ones", func() {
+		It("adds a header if it is not present and keeps existing ones", func() {
 			cfg := config.HTTPRewrite{
-				InjectResponseHeaders: []config.HeaderNameValue{
-					{Name: "X-Bar", Value: "bar"},
+				Responses: config.HTTPRewriteResponses{
+					AddHeadersIfNotPresent: []config.HeaderNameValue{
+						{Name: "X-Bar", Value: "bar"},
+					},
 				},
 			}
 			res := process(cfg)
@@ -62,11 +66,13 @@ var _ = Describe("HTTPRewrite Handler", func() {
 			Expect(res.Header()["X-Bar"]).To(ConsistOf("bar"))
 		})
 
-		It("injects multiple values for same header", func() {
+		It("adds multiple values for same header", func() {
 			cfg := config.HTTPRewrite{
-				InjectResponseHeaders: []config.HeaderNameValue{
-					{Name: "X-Bar", Value: "bar1"},
-					{Name: "X-Bar", Value: "bar2"},
+				Responses: config.HTTPRewriteResponses{
+					AddHeadersIfNotPresent: []config.HeaderNameValue{
+						{Name: "X-Bar", Value: "bar1"},
+						{Name: "X-Bar", Value: "bar2"},
+					},
 				},
 			}
 			res := process(cfg)

--- a/handlers/http_rewrite_test.go
+++ b/handlers/http_rewrite_test.go
@@ -79,6 +79,21 @@ var _ = Describe("HTTPRewrite Handler", func() {
 			Expect(res.Header()["X-Foo"]).To(ConsistOf("foo"))
 			Expect(res.Header()["X-Bar"]).To(ConsistOf("bar1", "bar2"))
 		})
+
+		It("canonicalizes the header names to be case-insentive", func() {
+			cfg := config.HTTPRewrite{
+				Responses: config.HTTPRewriteResponses{
+					AddHeadersIfNotPresent: []config.HeaderNameValue{
+						{Name: "x-FoO", Value: "bar"},
+						{Name: "x-BaR", Value: "bar1"},
+						{Name: "X-bAr", Value: "bar2"},
+					},
+				},
+			}
+			res := process(cfg)
+			Expect(res.Header()["X-Foo"]).To(ConsistOf("foo"))
+			Expect(res.Header()["X-Bar"]).To(ConsistOf("bar1", "bar2"))
+		})
 	})
 
 	Describe("with Responses.RemoveHeaders", func() {
@@ -100,6 +115,18 @@ var _ = Describe("HTTPRewrite Handler", func() {
 				Responses: config.HTTPRewriteResponses{
 					RemoveHeaders: []config.HeaderNameValue{
 						{Name: "X-Foo"},
+					},
+				},
+			}
+			res := process(cfg)
+			Expect(res.Header()).ToNot(HaveKey("X-Foo"))
+		})
+
+		It("canonicalizes the header names to be case-insentive", func() {
+			cfg := config.HTTPRewrite{
+				Responses: config.HTTPRewriteResponses{
+					RemoveHeaders: []config.HeaderNameValue{
+						{Name: "x-FoO"},
 					},
 				},
 			}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -646,11 +646,13 @@ var _ = Describe("Proxy", func() {
 			Expect(testLogger).NotTo(gbytes.Say("http-rewrite"))
 		})
 
-		Context("when inject response header is set", func() {
+		Context("when add response header is set", func() {
 			BeforeEach(func() {
 				conf.HTTPRewrite = config.HTTPRewrite{
-					InjectResponseHeaders: []config.HeaderNameValue{
-						{Name: "X-Foo", Value: "bar"},
+					Responses: config.HTTPRewriteResponses{
+						AddHeadersIfNotPresent: []config.HeaderNameValue{
+							{Name: "X-Foo", Value: "bar"},
+						},
 					},
 				}
 			})

--- a/proxy/utils/headerrewriter.go
+++ b/proxy/utils/headerrewriter.go
@@ -20,3 +20,14 @@ func (i *AddHeaderIfNotPresentRewriter) RewriteHeader(header http.Header) {
 		}
 	}
 }
+
+// RemoveHeaderRewriter: Removes any value associated to a header
+type RemoveHeaderRewriter struct {
+	Header http.Header
+}
+
+func (i *RemoveHeaderRewriter) RewriteHeader(header http.Header) {
+	for h, _ := range i.Header {
+		header.Del(h)
+	}
+}

--- a/proxy/utils/headerrewriter.go
+++ b/proxy/utils/headerrewriter.go
@@ -8,12 +8,12 @@ type HeaderRewriter interface {
 	RewriteHeader(http.Header)
 }
 
-// InjectHeaderRewriter: Adds headers only if they are not present in the current http.Header
-type InjectHeaderRewriter struct {
+// AddHeaderIfNotPresentRewriter: Adds headers only if they are not present in the current http.Header
+type AddHeaderIfNotPresentRewriter struct {
 	Header http.Header
 }
 
-func (i *InjectHeaderRewriter) RewriteHeader(header http.Header) {
+func (i *AddHeaderIfNotPresentRewriter) RewriteHeader(header http.Header) {
 	for h, v := range i.Header {
 		if _, ok := header[h]; !ok {
 			header[h] = v

--- a/proxy/utils/headerrewriter.go
+++ b/proxy/utils/headerrewriter.go
@@ -8,7 +8,9 @@ type HeaderRewriter interface {
 	RewriteHeader(http.Header)
 }
 
-// AddHeaderIfNotPresentRewriter: Adds headers only if they are not present in the current http.Header
+// AddHeaderIfNotPresentRewriter: Adds headers only if they are not present
+// in the current http.Header.
+// The http.Header must be built using the method Add() to canonalize the keys
 type AddHeaderIfNotPresentRewriter struct {
 	Header http.Header
 }
@@ -22,6 +24,7 @@ func (i *AddHeaderIfNotPresentRewriter) RewriteHeader(header http.Header) {
 }
 
 // RemoveHeaderRewriter: Removes any value associated to a header
+// The http.Header must be built using the method Add() to canonalize the keys
 type RemoveHeaderRewriter struct {
 	Header http.Header
 }

--- a/proxy/utils/headerrewriter_test.go
+++ b/proxy/utils/headerrewriter_test.go
@@ -40,3 +40,27 @@ var _ = Describe("AddHeaderIfNotPresentRewriter", func() {
 		Expect(header["Foo"]).To(ConsistOf("original"))
 	})
 })
+
+var _ = Describe("RemoveHeaderRewriter", func() {
+	It("remove headers with same name and only those", func() {
+		header := http.Header{}
+		header.Add("foo1", "bar1")
+		header.Add("foo1", "bar2")
+		header.Add("foo2", "bar1")
+		header.Add("foo3", "bar1")
+		header.Add("foo3", "bar2")
+
+		headerToRemove := http.Header{}
+		headerToRemove.Add("foo1", "")
+		headerToRemove.Add("foo2", "")
+
+		rewriter := utils.RemoveHeaderRewriter{Header: headerToRemove}
+
+		rewriter.RewriteHeader(header)
+
+		Expect(header).ToNot(HaveKey("Foo1"))
+		Expect(header).ToNot(HaveKey("Foo2"))
+		Expect(header).To(HaveKey("Foo3"))
+		Expect(header["Foo3"]).To(ConsistOf("bar1", "bar2"))
+	})
+})

--- a/proxy/utils/headerrewriter_test.go
+++ b/proxy/utils/headerrewriter_test.go
@@ -39,6 +39,21 @@ var _ = Describe("AddHeaderIfNotPresentRewriter", func() {
 		Expect(header).To(HaveKey("Foo"))
 		Expect(header["Foo"]).To(ConsistOf("original"))
 	})
+
+	It("headers match based with the canonicalized case-insentive key", func() {
+		header := http.Header{}
+		header.Add("FOO", "original")
+
+		headerToAdd := http.Header{}
+		headerToAdd.Add("fOo", "bar1")
+
+		rewriter := utils.AddHeaderIfNotPresentRewriter{Header: headerToAdd}
+
+		rewriter.RewriteHeader(header)
+
+		Expect(header.Get("fOo")).To(Equal("original"))
+		Expect(header.Get("Foo")).To(Equal("original"))
+	})
 })
 
 var _ = Describe("RemoveHeaderRewriter", func() {
@@ -62,5 +77,29 @@ var _ = Describe("RemoveHeaderRewriter", func() {
 		Expect(header).ToNot(HaveKey("Foo2"))
 		Expect(header).To(HaveKey("Foo3"))
 		Expect(header["Foo3"]).To(ConsistOf("bar1", "bar2"))
+	})
+
+	It("headers match based with the canonicalized case-insentive key", func() {
+		header := http.Header{}
+		header.Add("X-Foo", "foo")
+		header.Add("x-BAR", "bar")
+		header.Add("x-foobar", "foobar")
+
+		headerToRemove := http.Header{}
+		headerToRemove.Add("X-fOo", "")
+		headerToRemove.Add("x-bar", "")
+		headerToRemove.Add("x-FoObAr", "")
+
+		rewriter := utils.RemoveHeaderRewriter{Header: headerToRemove}
+
+		Expect(header.Get("X-Foo")).ToNot(BeEmpty())
+		Expect(header.Get("X-Bar")).ToNot(BeEmpty())
+		Expect(header.Get("x-foobar")).ToNot(BeEmpty())
+
+		rewriter.RewriteHeader(header)
+
+		Expect(header.Get("X-Foo")).To(BeEmpty())
+		Expect(header.Get("X-Bar")).To(BeEmpty())
+		Expect(header.Get("x-foobar")).To(BeEmpty())
 	})
 })

--- a/proxy/utils/headerrewriter_test.go
+++ b/proxy/utils/headerrewriter_test.go
@@ -8,15 +8,15 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("InjectHeaderRewriter", func() {
-	It("injects headers if missing in the original Header", func() {
+var _ = Describe("AddHeaderIfNotPresentRewriter", func() {
+	It("adds headers if missing in the original Header", func() {
 		header := http.Header{}
 
-		headerToInject := http.Header{}
-		headerToInject.Add("foo", "bar1")
-		headerToInject.Add("foo", "bar2")
+		headerToAdd := http.Header{}
+		headerToAdd.Add("foo", "bar1")
+		headerToAdd.Add("foo", "bar2")
 
-		rewriter := utils.InjectHeaderRewriter{Header: headerToInject}
+		rewriter := utils.AddHeaderIfNotPresentRewriter{Header: headerToAdd}
 
 		rewriter.RewriteHeader(header)
 
@@ -24,15 +24,15 @@ var _ = Describe("InjectHeaderRewriter", func() {
 		Expect(header["Foo"]).To(ConsistOf("bar1", "bar2"))
 	})
 
-	It("does not inject headers if present in the original Header", func() {
+	It("does not add headers if present in the original Header", func() {
 		header := http.Header{}
 		header.Add("foo", "original")
 
-		headerToInject := http.Header{}
-		headerToInject.Add("foo", "bar1")
-		headerToInject.Add("foo", "bar2")
+		headerToAdd := http.Header{}
+		headerToAdd.Add("foo", "bar1")
+		headerToAdd.Add("foo", "bar2")
 
-		rewriter := utils.InjectHeaderRewriter{Header: headerToInject}
+		rewriter := utils.AddHeaderIfNotPresentRewriter{Header: headerToAdd}
 
 		rewriter.RewriteHeader(header)
 


### PR DESCRIPTION
What?
----

 - Fixes the configuration syntax for `router.http_rewrite.responses.add_headers_if_not_present`  to match https://github.com/cloudfoundry/routing-release/pull/128#issuecomment-436753733
 - Implements https://github.com/cloudfoundry/routing-release/issues/129: Operator can specify headers that should be deleted from gorouter responses

An explanation of the use cases your change solves
----

See https://github.com/cloudfoundry/routing-release/issues/129

Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
----

Configure with:

```
http_rewrite:
  responses:
    remove_headers:
    - name: X-Vcap-Request-Id
```

Expected result after the change
----

After configuring a manifest property with `X-Vcap-Request-Id` and deploying, responses should not include `X-Vcap-Request-Id`


Current result before the change
----

Currently gorouter returns the HTTP header `X-Vcap-Request-Id`


Links to any other associated PRs
---

https://github.com/cloudfoundry/gorouter/pull/232

Checklist
-----
* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bin/test`

* [ ] I have run CF Acceptance Tests on bosh lite