### PR TITLE
http keep-alive connections to backends outlast the route-registration interval

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -199,7 +199,7 @@ type Config struct {
 	PidFile     string `yaml:"pid_file,omitempty"`
 	LoadBalance string `yaml:"balancing_algorithm,omitempty"`
 
-	DisableKeepAlives   bool `yaml:"disable_keep_alives,omitempty"`
+	DisableKeepAlives   bool `yaml:"disable_keep_alives"`
 	MaxIdleConns        int  `yaml:"max_idle_conns,omitempty"`
 	MaxIdleConnsPerHost int  `yaml:"max_idle_conns_per_host,omitempty"`
 

--- a/integration/backend_keepalive_test.go
+++ b/integration/backend_keepalive_test.go
@@ -1,0 +1,200 @@
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("KeepAlive (HTTP Persistent Connections) to backends", func() {
+	var (
+		testState *testState
+
+		testAppRoute string
+		testApp      *StateTrackingTestApp
+	)
+
+	BeforeEach(func() {
+		testState = NewTestState()
+
+		testApp = NewUnstartedTestApp(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer GinkgoRecover()
+			_, err := ioutil.ReadAll(r.Body)
+			Expect(err).NotTo(HaveOccurred())
+			w.WriteHeader(200)
+		}))
+		testAppRoute = "potato.potato"
+	})
+
+	AfterEach(func() {
+		if testState != nil {
+			testState.StopAndCleanup()
+		}
+		testApp.Close()
+	})
+
+	doRequest := func() {
+		assertRequestSucceeds(testState.client,
+			testState.newRequest(fmt.Sprintf("http://%s", testAppRoute)))
+	}
+
+	Context("when KeepAlives are disabled", func() {
+		BeforeEach(func() {
+			testState.cfg.DisableKeepAlives = true
+
+			testState.StartGorouter()
+			testApp.Start()
+			testState.register(testApp.Server, testAppRoute)
+			Expect(testApp.GetConnStates()).To(BeEmpty())
+		})
+
+		Specify("connections to backends are closed after each request", func() {
+			doRequest()
+
+			By("checking that the connection is closed after the first request")
+			connStates := testApp.GetConnStates()
+			Expect(connStates).To(HaveLen(3))
+			Expect(connStates[0].State).To(Equal("new"))
+			Expect(connStates[1].State).To(Equal("active"))
+			Expect(connStates[2].State).To(Equal("closed"))
+
+			By("doing a second request")
+			doRequest()
+
+			By("checking that the connection is not re-used")
+			connStates = testApp.GetConnStates()
+			Expect(connStates).To(HaveLen(6))
+			Expect(connStates[0].State).To(Equal("new"))
+			Expect(connStates[1].State).To(Equal("active"))
+			Expect(connStates[2].State).To(Equal("closed"))
+			Expect(connStates[3].State).To(Equal("new"))
+			Expect(connStates[4].State).To(Equal("active"))
+			Expect(connStates[5].State).To(Equal("closed"))
+
+			By("checking that different connections are used for each request")
+			Expect(connStates[0].ConnPtr).NotTo(Equal(connStates[3].ConnPtr))
+		})
+	})
+
+	Context("when KeepAlives are enabled", func() {
+		BeforeEach(func() {
+			testState.cfg.DisableKeepAlives = false
+			testState.StartGorouter()
+		})
+
+		Context("when connecting to a non-TLS backend", func() {
+			BeforeEach(func() {
+				testApp.Start()
+				testState.register(testApp.Server, testAppRoute)
+			})
+
+			Specify("connections to backends are persisted after requests finish", func() {
+				doRequest()
+				assertConnectionIsReused(testApp.GetConnStates(), "new", "active", "idle")
+
+				doRequest()
+				assertConnectionIsReused(testApp.GetConnStates(), "new", "active", "idle", "active", "idle")
+
+				By("re-registering the route")
+				testState.register(testApp.Server, testAppRoute)
+
+				By("doing a third request")
+				doRequest()
+
+				By("checking that the same connection is *still* being re-used on the backend")
+				assertConnectionIsReused(testApp.GetConnStates(),
+					"new", "active", "idle", "active", "idle", "active", "idle")
+			})
+		})
+
+		Context("when connecting to a TLS-enabled backend", func() {
+			BeforeEach(func() {
+				testApp.TLS = testState.trustedBackendTLSConfig
+				testApp.StartTLS()
+				testState.registerAsTLS(testApp.Server, testAppRoute, testState.trustedBackendServerCertSAN)
+			})
+
+			Specify("connections to backends are persisted after requests finish", func() {
+				By("doing a couple requests")
+				doRequest()
+				doRequest()
+
+				By("checking that only one backend connection is used for both requests")
+				assertConnectionIsReused(testApp.GetConnStates(), "new", "active", "idle", "active", "idle")
+
+				By("re-registering the route")
+				testState.registerAsTLS(testApp.Server, testAppRoute, testState.trustedBackendServerCertSAN)
+
+				By("doing a third request")
+				doRequest()
+
+				By("checking that the same connection is *still* being re-used on the backend")
+				assertConnectionIsReused(testApp.GetConnStates(),
+					"new", "active", "idle", "active", "idle", "active", "idle")
+			})
+		})
+	})
+})
+
+type ConnState struct {
+	ConnPtr    string
+	RemoteAddr string
+	State      string
+}
+
+type StateTrackingTestApp struct {
+	*httptest.Server
+	backendConnStates []ConnState
+	m                 sync.Mutex
+}
+
+func (s *StateTrackingTestApp) GetConnStates() []ConnState {
+	s.m.Lock()
+	defer s.m.Unlock()
+	ret := make([]ConnState, len(s.backendConnStates))
+	copy(ret, s.backendConnStates) // copy(dst, src)
+	return ret
+}
+
+func assertConnectionIsReused(actualStates []ConnState, expectedStates ...string) {
+	// get initial connection
+	p := actualStates[0].ConnPtr
+	a := actualStates[0].RemoteAddr
+
+	// check length
+	Expect(actualStates).To(HaveLen(len(expectedStates)))
+
+	// construct slice of expected connection state values
+	expectedConnStates := make([]ConnState, len(expectedStates))
+	for i := 0; i < len(expectedStates); i++ {
+		expectedConnStates[i] = ConnState{ConnPtr: p, RemoteAddr: a, State: expectedStates[i]}
+	}
+
+	// assert
+	Expect(actualStates).To(Equal(expectedConnStates))
+}
+
+func NewUnstartedTestApp(handler http.Handler) *StateTrackingTestApp {
+	a := &StateTrackingTestApp{
+		Server: httptest.NewUnstartedServer(handler),
+	}
+	a.Server.Config.ConnState = func(conn net.Conn, state http.ConnState) {
+		a.m.Lock()
+		defer a.m.Unlock()
+		a.backendConnStates = append(a.backendConnStates,
+			ConnState{
+				ConnPtr:    fmt.Sprintf("%p", conn),
+				RemoteAddr: conn.RemoteAddr().String(),
+				State:      state.String(),
+			})
+	}
+	a.Server.Config.IdleTimeout = 5 * time.Second
+	return a
+}

--- a/integration/tls_to_backends_test.go
+++ b/integration/tls_to_backends_test.go
@@ -1,15 +1,12 @@
 package integration
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"time"
 
-	"code.cloudfoundry.org/gorouter/config"
 	"code.cloudfoundry.org/gorouter/route"
 	"code.cloudfoundry.org/gorouter/test"
 	"code.cloudfoundry.org/gorouter/test/common"
@@ -19,38 +16,12 @@ import (
 )
 
 var _ = Describe("TLS to backends", func() {
-	const serverCertDomainSAN = "example.com"
-
 	var (
-		testState        *testState
-		backendCertChain test_util.CertChain
-		clientCertChain  test_util.CertChain
-		backendTLSConfig *tls.Config
+		testState *testState
 	)
 
 	BeforeEach(func() {
 		testState = NewTestState()
-		testState.cfg.SkipSSLValidation = false
-		testState.cfg.CipherSuites = []uint16{tls.TLS_RSA_WITH_AES_256_CBC_SHA}
-
-		backendCertChain = test_util.CreateSignedCertWithRootCA(test_util.CertNames{CommonName: serverCertDomainSAN})
-		testState.cfg.CACerts = string(backendCertChain.CACertPEM)
-
-		clientCertChain = test_util.CreateSignedCertWithRootCA(test_util.CertNames{CommonName: "gorouter"})
-		backendTLSConfig = backendCertChain.AsTLSConfig()
-		backendTLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
-
-		// set Gorouter to use client certs
-		testState.cfg.Backends.TLSPem = config.TLSPem{
-			CertChain:  string(clientCertChain.CertPEM),
-			PrivateKey: string(clientCertChain.PrivKeyPEM),
-		}
-
-		// make backend trust the CA that signed the gorouter's client cert
-		certPool := x509.NewCertPool()
-		certPool.AddCert(clientCertChain.CACert)
-		backendTLSConfig.ClientCAs = certPool
-
 		testState.StartGorouter()
 	})
 
@@ -87,8 +58,8 @@ var _ = Describe("TLS to backends", func() {
 
 		It("successfully connects with both websockets and TLS to backends", func() {
 			wsApp := test.NewWebSocketApp([]route.Uri{"ws-app." + test_util.LocalhostDNS}, testState.cfg.Port, testState.mbusClient, time.Millisecond, "")
-			wsApp.TlsRegister(serverCertDomainSAN)
-			wsApp.TlsListen(backendTLSConfig)
+			wsApp.TlsRegister(testState.trustedBackendServerCertSAN)
+			wsApp.TlsListen(testState.trustedBackendTLSConfig)
 
 			assertWebsocketSuccess(wsApp)
 		})
@@ -149,14 +120,14 @@ var _ = Describe("TLS to backends", func() {
 
 	It("successfully establishes a mutual TLS connection with backend", func() {
 		runningApp1 := test.NewGreetApp([]route.Uri{"some-app-expecting-client-certs." + test_util.LocalhostDNS}, testState.cfg.Port, testState.mbusClient, nil)
-		runningApp1.TlsRegister(serverCertDomainSAN)
-		runningApp1.TlsListen(backendTLSConfig)
+		runningApp1.TlsRegister(testState.trustedBackendServerCertSAN)
+		runningApp1.TlsListen(testState.trustedBackendTLSConfig)
 		heartbeatInterval := 200 * time.Millisecond
 		runningTicker := time.NewTicker(heartbeatInterval)
 		go func() {
 			for {
 				<-runningTicker.C
-				runningApp1.TlsRegister(serverCertDomainSAN)
+				runningApp1.TlsRegister(testState.trustedBackendServerCertSAN)
 			}
 		}()
 		routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Port)

--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -43,7 +43,7 @@ type RoundTripperFactory interface {
 
 func GetRoundTripper(e *route.Endpoint, roundTripperFactory RoundTripperFactory) ProxyRoundTripper {
 	e.RoundTripperInit.Do(func() {
-		e.SetRoundTripper(roundTripperFactory.New(e.ServerCertDomainSAN))
+		e.SetRoundTripperIfNil(func() route.ProxyRoundTripper { return roundTripperFactory.New(e.ServerCertDomainSAN) })
 	})
 
 	return e.RoundTripper()

--- a/route/pool.go
+++ b/route/pool.go
@@ -91,6 +91,15 @@ func (e *Endpoint) SetRoundTripper(tripper ProxyRoundTripper) {
 	e.roundTripper = tripper
 }
 
+func (e *Endpoint) SetRoundTripperIfNil(roundTripperCtor func() ProxyRoundTripper) {
+	e.roundTripperMutex.Lock()
+	defer e.roundTripperMutex.Unlock()
+
+	if e.roundTripper == nil {
+		e.roundTripper = roundTripperCtor()
+	}
+}
+
 //go:generate counterfeiter -o fakes/fake_endpoint_iterator.go . EndpointIterator
 type EndpointIterator interface {
 	Next() *Endpoint


### PR DESCRIPTION
In reviewing our proposed fixes to #235, I realized that idle connections to backends were only surviving until the next route registration message arrived.

this PR adds integration test coverage for HTTP persistent connections (keep-alive) to backends, and introduces a (kind of hacky) fix to enable the connections to survive beyond the route registration messages.


to test, push an app which prints logs when the state of its remote connections change, and observe how those connections persist when new route registration messages are published to gorouter.