### PR TITLE
Disable caching for unknown_route responses

### DIFF
--- a/handlers/lookup.go
+++ b/handlers/lookup.go
@@ -60,6 +60,7 @@ func (l *lookupHandler) handleMissingRoute(rw http.ResponseWriter, r *http.Reque
 	l.reporter.CaptureBadRequest()
 
 	rw.Header().Set("X-Cf-RouterError", "unknown_route")
+	rw.Header().Set("Cache-Control", "public,max-age=2")
 
 	writeStatus(
 		rw,

--- a/handlers/lookup_test.go
+++ b/handlers/lookup_test.go
@@ -64,6 +64,10 @@ var _ = Describe("Lookup", func() {
 			Expect(resp.Header().Get("X-Cf-RouterError")).To(Equal("unknown_route"))
 		})
 
+		It("Sets Cache-Control to public,max-age=2", func() {
+			Expect(resp.Header().Get("Cache-Control")).To(Equal("public,max-age=2"))
+		})
+
 		It("returns a 404 NotFound and does not call next", func() {
 			Expect(nextCalled).To(BeFalse())
 			Expect(resp.Code).To(Equal(http.StatusNotFound))


### PR DESCRIPTION
## A short explanation of the proposed change:

See #243 - it's possible that caches in front of gorouter will cache temporary "unknown route" 404s. Adding a cache-control header should prevent this.

## An explanation of the use cases your change solves

If all of the apps serving a particular app fail their healthcheck,
gorouter will respond with a 404.

If there are caching proxies in front of gorouter these may decide to
cache this 404 beyond the point when applications become healthy again.

This can result in the undesirable situation that an application that
has a few seconds of downtime can end up with a cached 404 for hours
(depending on the cache configuration).

By setting `Cache-Control: no-cache` on unknown_route responses we can
instruct any caches in front of gorouter to always check that the
response is current before deciding to serve a 404 from their cache.

We could consider setting `no-store` instead, which would prevent all
caching, but `no-cache` should be enough to prevent any issues.

## Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics):

`curl http://asldkfjaldkjfalsdk.some-gorouter`

## Expected result after the change

Unknown route responses should contain the `Cache-Control: no-cache` header

## Current result before the change

Unknown route responses contain no caching headers

## Links to any other associated PRs

Fixes #243

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bin/test`

* [ ] I have run CF Acceptance Tests on bosh lite
