### PR TITLE
Do not set VCAP_ID stickyness cookie if value already provided by backend. 

### DIFF
--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -310,6 +310,13 @@ func setupStickySession(
 			break
 		}
 	}
+	
+	for _, v := range response.Cookies() {
+		if v.Name == VcapCookieId {
+			sticky = false
+			break
+		}
+	}	
 
 	if sticky {
 		// right now secure attribute would as equal to the JSESSION ID cookie (if present),

--- a/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/proxy/round_tripper/proxy_round_tripper_test.go
@@ -874,6 +874,69 @@ var _ = Describe("ProxyRoundTripper", func() {
 				})
 			})
 		})
+		
+
+		Context("when sticky session vcap cookie provided by backend", func() {
+				var (
+						sessionCookie *http.Cookie
+						vcapCookie    *http.Cookie
+						endpoint1     *route.Endpoint
+						endpoint2     *route.Endpoint
+				)
+
+				BeforeEach(func() {
+						sessionCookie = &http.Cookie{
+								Name: round_tripper.StickyCookieKey,
+						}
+
+						vcapCookie = &http.Cookie{
+								Name: round_tripper.VcapCookieId,
+						}
+
+						transport.RoundTripStub = func(req *http.Request) (*http.Response, error) {
+								resp := &http.Response{StatusCode: http.StatusTeapot, Header: make(map[string][]string)}
+
+								vcapCookie.Value = "id-5"
+								resp.Header.Add(round_tripper.CookieHeader, vcapCookie.String())
+
+								if len(req.Cookies()) > 0 {
+										//Only attach the JSESSIONID on to the response
+										resp.Header.Add(round_tripper.CookieHeader, req.Cookies()[0].String())
+										return resp, nil
+								}
+
+								sessionCookie.Value, _ = uuid.GenerateUUID()
+								resp.Header.Add(round_tripper.CookieHeader, sessionCookie.String())
+								return resp, nil
+						}
+
+						endpoint1 = route.NewEndpoint(&route.EndpointOpts{
+								Host: "1.1.1.1", Port: 9091, PrivateInstanceId: "id-1",
+						})
+						endpoint2 = route.NewEndpoint(&route.EndpointOpts{
+								Host: "1.1.1.1", Port: 9092, PrivateInstanceId: "id-2",
+						})
+
+						added := routePool.Put(endpoint1)
+						Expect(added).To(Equal(route.ADDED))
+						added = routePool.Put(endpoint2)
+						Expect(added).To(Equal(route.ADDED))
+						removed := routePool.Remove(endpoint)
+						Expect(removed).To(BeTrue())
+				})
+
+				It("will pass on backend provided vcap cookie header with the privateInstanceId", func() {
+						resp, err := proxyRoundTripper.RoundTrip(req)
+						Expect(err).ToNot(HaveOccurred())
+
+						cookies := resp.Cookies()
+						Expect(cookies).To(HaveLen(2))
+						Expect(cookies[1].Raw).To(Equal(sessionCookie.String()))
+						Expect(cookies[0].Name).To(Equal(round_tripper.VcapCookieId))
+						Expect(cookies[0].Value).To(Equal("id-5"))
+				})
+		})
+
 
 		Context("CancelRequest", func() {
 			It("can cancel requests", func() {


### PR DESCRIPTION
See
https://github.com/cloudfoundry/gorouter/pull/220

I could no reopen the Request #220 so I had to created this new one.
I updated the missing test from #220 now.


Thanks for contributing to gorouter. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Do not set VCAP_ID stickyness cookie if value already provided by backend. 
GoRoute would set the VCAP_ID Cookie ignoring an already present Set-Cookie Header from the backend, which results in a dublicate Set-Cookie Header.
This is important to allow the backend to change the routing of a sticky session to a different instance.

* An explanation of the use cases your change solves
Rerouting indication from the backend where overwritten by gorouter. gorouter schould not set the 
VCAP_ID Cookie twice if it is already present in the backend response.



* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests using `bin/test`

* [ ] I have run CF Acceptance Tests on bosh lite
