### PR TITLE
Return a 503 not a 404 when no endpoint available

### DIFF
--- a/accesslog/schema/access_log_record_test.go
+++ b/accesslog/schema/access_log_record_test.go
@@ -57,7 +57,7 @@ var _ = Describe("AccessLogRecord", func() {
 	})
 
 	Describe("LogMessage", func() {
-		It("Makes a record with all values", func() {
+		It("makes a record with all values", func() {
 			r := BufferReader(bytes.NewBufferString(record.LogMessage()))
 			Eventually(r).Should(Say(`FakeRequestHost\s-\s\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+\d{4}\]`))
 			Eventually(r).Should(Say(`"FakeRequestMethod http://example.com/request FakeRequestProto" `))
@@ -100,7 +100,7 @@ var _ = Describe("AccessLogRecord", func() {
 				}
 			})
 
-			It("Makes a record with all values", func() {
+			It("makes a record with all values", func() {
 				r := BufferReader(bytes.NewBufferString(record.LogMessage()))
 				Eventually(r).Should(Say(`FakeRequestHost\s-\s\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+\d{4}\]`))
 				Eventually(r).Should(Say(`"FakeRequestMethod http://example.com/request FakeRequestProto" `))
@@ -169,7 +169,7 @@ var _ = Describe("AccessLogRecord", func() {
 		})
 
 		Context("when extra headers is an empty slice", func() {
-			It("Makes a record with all values", func() {
+			It("makes a record with all values", func() {
 				record := schema.AccessLogRecord{
 					Request: &http.Request{
 						Host:   "FakeRequestHost",

--- a/common/secure/crypto_test.go
+++ b/common/secure/crypto_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Crypto", func() {
 	})
 
 	Describe("RandomBytes", func() {
-		It("Generates a random byte array with the specified length", func() {
+		It("generates a random byte array with the specified length", func() {
 			randBytes, err := secure.RandomBytes(123)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(randBytes).To(HaveLen(123))

--- a/handlers/helpers.go
+++ b/handlers/helpers.go
@@ -5,9 +5,25 @@ import (
 	"net/http"
 	"strings"
 
+	router_http "code.cloudfoundry.org/gorouter/common/http"
 	"code.cloudfoundry.org/gorouter/logger"
 	"github.com/uber-go/zap"
 )
+
+const (
+	cacheMaxAgeSeconds = 2
+)
+
+func AddRouterErrorHeader(rw http.ResponseWriter, val string) {
+	rw.Header().Set(router_http.CfRouterError, val)
+}
+
+func addInvalidResponseCacheControlHeader(rw http.ResponseWriter) {
+	rw.Header().Set(
+		"Cache-Control",
+		fmt.Sprintf("public,max-age=%d", cacheMaxAgeSeconds),
+	)
+}
 
 func writeStatus(rw http.ResponseWriter, code int, message string, logger logger.Logger) {
 	body := fmt.Sprintf("%d %s: %s", code, http.StatusText(code), message)

--- a/handlers/lookup.go
+++ b/handlers/lookup.go
@@ -18,8 +18,6 @@ import (
 const (
 	CfInstanceIdHeader = "X-CF-InstanceID"
 	CfAppInstance      = "X-CF-APP-INSTANCE"
-
-	cacheMaxAgeSeconds = 2
 )
 
 type lookupHandler struct {
@@ -61,11 +59,8 @@ func (l *lookupHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 func (l *lookupHandler) handleMissingRoute(rw http.ResponseWriter, r *http.Request) {
 	l.reporter.CaptureBadRequest()
 
-	rw.Header().Set("X-Cf-RouterError", "unknown_route")
-	rw.Header().Set(
-		"Cache-Control",
-		fmt.Sprintf("public,max-age=%d", cacheMaxAgeSeconds),
-	)
+	AddRouterErrorHeader(rw, "unknown_route")
+	addInvalidResponseCacheControlHeader(rw)
 
 	writeStatus(
 		rw,
@@ -79,7 +74,7 @@ func (l *lookupHandler) handleOverloadedRoute(rw http.ResponseWriter, r *http.Re
 	l.reporter.CaptureBackendExhaustedConns()
 	l.logger.Info("connection-limit-reached")
 
-	rw.Header().Set("X-Cf-RouterError", "Connection Limit Reached")
+	AddRouterErrorHeader(rw, "Connection Limit Reached")
 
 	writeStatus(
 		rw,

--- a/handlers/lookup_test.go
+++ b/handlers/lookup_test.go
@@ -60,11 +60,11 @@ var _ = Describe("Lookup", func() {
 			Expect(rep.CaptureBadRequestCallCount()).To(Equal(1))
 		})
 
-		It("Sets X-Cf-RouterError to unknown_route", func() {
+		It("sets X-Cf-RouterError to unknown_route", func() {
 			Expect(resp.Header().Get("X-Cf-RouterError")).To(Equal("unknown_route"))
 		})
 
-		It("Sets Cache-Control to public,max-age=2", func() {
+		It("sets Cache-Control to public,max-age=2", func() {
 			Expect(resp.Header().Get("Cache-Control")).To(Equal("public,max-age=2"))
 		})
 
@@ -96,7 +96,7 @@ var _ = Describe("Lookup", func() {
 			Expect(rep.CaptureBadRequestCallCount()).To(Equal(1))
 		})
 
-		It("Sets X-Cf-RouterError to unknown_route", func() {
+		It("sets X-Cf-RouterError to unknown_route", func() {
 			Expect(resp.Header().Get("X-Cf-RouterError")).To(Equal("unknown_route"))
 		})
 

--- a/handlers/lookup_test.go
+++ b/handlers/lookup_test.go
@@ -92,23 +92,26 @@ var _ = Describe("Lookup", func() {
 			reg.LookupReturns(pool)
 		})
 
-		It("sends a bad request metric", func() {
-			Expect(rep.CaptureBadRequestCallCount()).To(Equal(1))
+		It("does not send a bad request metric", func() {
+			Expect(rep.CaptureBadRequestCallCount()).To(Equal(0))
 		})
 
-		It("sets X-Cf-RouterError to unknown_route", func() {
-			Expect(resp.Header().Get("X-Cf-RouterError")).To(Equal("unknown_route"))
+		It("sets X-Cf-RouterError to no_endpoints", func() {
+			Expect(resp.Header().Get("X-Cf-RouterError")).To(Equal("no_endpoints"))
 		})
 
-		It("returns a 404 NotFound and does not call next", func() {
+		It("returns a 503 ServiceUnavailable and does not call next", func() {
 			Expect(nextCalled).To(BeFalse())
-			Expect(resp.Code).To(Equal(http.StatusNotFound))
+			Expect(resp.Code).To(Equal(http.StatusServiceUnavailable))
 		})
 
 		It("has a meaningful response", func() {
-			Expect(resp.Body.String()).To(ContainSubstring("Requested route ('example.com') does not exist"))
+			Expect(resp.Body.String()).To(ContainSubstring("Requested route ('example.com') has no available endpoints"))
 		})
 
+		It("Sets Cache-Control to public,max-age=2", func() {
+			Expect(resp.Header().Get("Cache-Control")).To(Equal("public,max-age=2"))
+		})
 	})
 
 	Context("when there is a pool that matches the request, and it has endpoints", func() {

--- a/handlers/routeservice.go
+++ b/handlers/routeservice.go
@@ -50,7 +50,8 @@ func (r *RouteService) ServeHTTP(rw http.ResponseWriter, req *http.Request, next
 	if !r.config.RouteServiceEnabled() {
 		r.logger.Info("route-service-unsupported")
 
-		rw.Header().Set("X-Cf-RouterError", "route_service_unsupported")
+		AddRouterErrorHeader(rw, "route_service_unsupported")
+
 		writeStatus(
 			rw,
 			http.StatusBadGateway,
@@ -62,7 +63,8 @@ func (r *RouteService) ServeHTTP(rw http.ResponseWriter, req *http.Request, next
 	if IsTcpUpgrade(req) {
 		r.logger.Info("route-service-unsupported")
 
-		rw.Header().Set("X-Cf-RouterError", "route_service_unsupported")
+		AddRouterErrorHeader(rw, "route_service_unsupported")
+
 		writeStatus(
 			rw,
 			http.StatusServiceUnavailable,
@@ -74,7 +76,8 @@ func (r *RouteService) ServeHTTP(rw http.ResponseWriter, req *http.Request, next
 	if IsWebSocketUpgrade(req) {
 		r.logger.Info("route-service-unsupported")
 
-		rw.Header().Set("X-Cf-RouterError", "route_service_unsupported")
+		AddRouterErrorHeader(rw, "route_service_unsupported")
+
 		writeStatus(
 			rw,
 			http.StatusServiceUnavailable,

--- a/proxy/handler/request_handler.go
+++ b/proxy/handler/request_handler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	router_http "code.cloudfoundry.org/gorouter/common/http"
+	"code.cloudfoundry.org/gorouter/handlers"
 	"code.cloudfoundry.org/gorouter/logger"
 	"code.cloudfoundry.org/gorouter/metrics"
 	"code.cloudfoundry.org/gorouter/proxy/utils"
@@ -104,7 +105,8 @@ func (h *RequestHandler) Logger() logger.Logger {
 func (h *RequestHandler) HandleBadGateway(err error, request *http.Request) {
 	h.reporter.CaptureBadGateway()
 
-	h.response.Header().Set("X-Cf-RouterError", "endpoint_failure")
+	handlers.AddRouterErrorHeader(h.response, "endpoint_failure")
+
 	h.writeStatus(http.StatusBadGateway, "Registered endpoint failed to handle the request.")
 	h.response.Done()
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Proxy", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		})
 
-		It("Does not append ? to the request", func() {
+		It("does not append ? to the request", func() {
 			ln := test_util.RegisterHandler(r, "test/?", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET /? HTTP/1.1")
 
@@ -1026,7 +1026,7 @@ var _ = Describe("Proxy", func() {
 	})
 
 	Describe("Access Logging", func() {
-		It("Logs a request", func() {
+		It("logs a request", func() {
 			ln := test_util.RegisterHandler(r, "test", func(conn *test_util.HttpConn) {
 				req, body := conn.ReadRequest()
 				Expect(req.Method).To(Equal("POST"))
@@ -1075,7 +1075,7 @@ var _ = Describe("Proxy", func() {
 			Expect(b[len(b)-1]).To(Equal(byte('\n')))
 		})
 
-		It("Logs a request when X-Forwarded-Proto and X-Forwarded-For are provided", func() {
+		It("logs a request when X-Forwarded-Proto and X-Forwarded-For are provided", func() {
 			ln := test_util.RegisterHandler(r, "test", func(conn *test_util.HttpConn) {
 				conn.ReadRequest()
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
@@ -1111,7 +1111,7 @@ var _ = Describe("Proxy", func() {
 			Expect(b[len(b)-1]).To(Equal(byte('\n')))
 		})
 
-		It("Logs a request when it exits early", func() {
+		It("logs a request when it exits early", func() {
 			conn := dialProxy(proxyServer)
 
 			body := &bytes.Buffer{}
@@ -1542,7 +1542,7 @@ var _ = Describe("Proxy", func() {
 			conn.Close()
 		})
 
-		It("Logs the response time and status code 101 in the access logs", func() {
+		It("logs the response time and status code 101 in the access logs", func() {
 			done := make(chan bool)
 			ln := test_util.RegisterHandler(r, "ws", func(conn *test_util.HttpConn) {
 				req, err := http.ReadRequest(conn.Reader)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -993,7 +993,7 @@ var _ = Describe("Proxy", func() {
 
 			Context("when the server cert does not match the client", func() {
 				It("prunes the route", func() {
-					for _, status := range []int{http.StatusServiceUnavailable, http.StatusNotFound} {
+					for _, status := range []int{http.StatusServiceUnavailable, http.StatusServiceUnavailable} {
 						body := &bytes.Buffer{}
 						body.WriteString("use an actual body")
 						conn := dialProxy(proxyServer)
@@ -1010,7 +1010,7 @@ var _ = Describe("Proxy", func() {
 					})
 
 					It("prunes the route", func() {
-						for _, status := range []int{http.StatusServiceUnavailable, http.StatusNotFound} {
+						for _, status := range []int{http.StatusServiceUnavailable, http.StatusServiceUnavailable} {
 							body := &bytes.Buffer{}
 							body.WriteString("use an actual body")
 							conn := dialProxy(proxyServer)
@@ -1328,7 +1328,7 @@ var _ = Describe("Proxy", func() {
 				}
 			}
 
-			It("responds with a 404 NotFound", func() {
+			It("responds with a 503 ServiceUnavailable", func() {
 				ln := test_util.RegisterHandler(r, "nil-endpoint", func(conn *test_util.HttpConn) {
 					conn.CheckLine("GET / HTTP/1.1")
 					resp := test_util.NewResponse(http.StatusOK)
@@ -1349,7 +1349,7 @@ var _ = Describe("Proxy", func() {
 				res, _ := conn.ReadResponse()
 				log.SetOutput(os.Stderr)
 				Expect(buf).NotTo(ContainSubstring("multiple response.WriteHeader calls"))
-				Expect(res.StatusCode).To(Equal(http.StatusNotFound))
+				Expect(res.StatusCode).To(Equal(http.StatusServiceUnavailable))
 			})
 		})
 	})
@@ -1948,7 +1948,7 @@ var _ = Describe("Proxy", func() {
 				}
 			}
 
-			It("captures bad gateway but does not capture routing response", func() {
+			It("captures neither bad gateway nor routing response", func() {
 				ln := test_util.RegisterHandler(r, "nil-endpoint", func(conn *test_util.HttpConn) {
 					conn.CheckLine("GET / HTTP/1.1")
 					resp := test_util.NewResponse(http.StatusOK)
@@ -1964,8 +1964,8 @@ var _ = Describe("Proxy", func() {
 				conn.WriteRequest(req)
 
 				res, _ := conn.ReadResponse()
-				Expect(res.StatusCode).To(Equal(http.StatusNotFound))
-				Expect(fakeReporter.CaptureBadRequestCallCount()).To(Equal(1))
+				Expect(res.StatusCode).To(Equal(http.StatusServiceUnavailable))
+				Expect(fakeReporter.CaptureBadRequestCallCount()).To(Equal(0))
 				Expect(fakeReporter.CaptureRoutingResponseCallCount()).To(Equal(0))
 				Expect(fakeReporter.CaptureRoutingResponseLatencyCallCount()).To(Equal(0))
 			})

--- a/proxy/round_tripper/error_handler_test.go
+++ b/proxy/round_tripper/error_handler_test.go
@@ -60,7 +60,7 @@ var _ = Describe("HandleError", func() {
 		responseWriter = utils.NewProxyResponseWriter(responseRecorder)
 	})
 
-	It("Sets a header to describe the endpoint_failure", func() {
+	It("sets a header to describe the endpoint_failure", func() {
 		errorHandler.HandleError(responseWriter, errors.New("potato"))
 		Expect(responseWriter.Header().Get(router_http.CfRouterError)).To(Equal("endpoint_failure"))
 	})
@@ -129,11 +129,11 @@ var _ = Describe("HandleError", func() {
 				errorHandler.HandleError(responseWriter, err)
 			})
 
-			It("Has a 503 Status Code", func() {
+			It("has a 503 Status Code", func() {
 				Expect(responseWriter.Status()).To(Equal(503))
 			})
 
-			It("Emits a backend_invalid_id metric", func() {
+			It("emits a backend_invalid_id metric", func() {
 				Expect(metricReporter.CaptureBackendInvalidIDCallCount()).To(Equal(1))
 			})
 		})
@@ -144,11 +144,11 @@ var _ = Describe("HandleError", func() {
 				errorHandler.HandleError(responseWriter, err)
 			})
 
-			It("Has a 526 Status Code", func() {
+			It("has a 526 Status Code", func() {
 				Expect(responseWriter.Status()).To(Equal(526))
 			})
 
-			It("Emits a backend_invalid_tls_cert metric", func() {
+			It("emits a backend_invalid_tls_cert metric", func() {
 				Expect(metricReporter.CaptureBackendInvalidTLSCertCallCount()).To(Equal(1))
 			})
 		})
@@ -159,11 +159,11 @@ var _ = Describe("HandleError", func() {
 				errorHandler.HandleError(responseWriter, err)
 			})
 
-			It("Has a 525 Status Code", func() {
+			It("has a 525 Status Code", func() {
 				Expect(responseWriter.Status()).To(Equal(525))
 			})
 
-			It("Emits a backend_tls_handshake_failed metric", func() {
+			It("emits a backend_tls_handshake_failed metric", func() {
 				Expect(metricReporter.CaptureBackendTLSHandshakeFailedCallCount()).To(Equal(1))
 			})
 		})
@@ -174,11 +174,11 @@ var _ = Describe("HandleError", func() {
 				errorHandler.HandleError(responseWriter, err)
 			})
 
-			It("Has a 525 Status Code", func() {
+			It("has a 525 Status Code", func() {
 				Expect(responseWriter.Status()).To(Equal(525))
 			})
 
-			It("Emits a backend_tls_handshake_failed metric", func() {
+			It("emits a backend_tls_handshake_failed metric", func() {
 				Expect(metricReporter.CaptureBackendTLSHandshakeFailedCallCount()).To(Equal(1))
 			})
 		})
@@ -189,7 +189,7 @@ var _ = Describe("HandleError", func() {
 				errorHandler.HandleError(responseWriter, err)
 			})
 
-			It("Has a 499 Status Code", func() {
+			It("has a 499 Status Code", func() {
 				Expect(responseWriter.Status()).To(Equal(499))
 			})
 		})

--- a/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/proxy/round_tripper/proxy_round_tripper_test.go
@@ -179,7 +179,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 					transport.RoundTripReturns(resp.Result(), nil)
 				})
 
-				It("Sends X-cf headers", func() {
+				It("sends X-cf headers", func() {
 					_, err := proxyRoundTripper.RoundTrip(req)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(req.Header.Get("X-CF-ApplicationID")).To(Equal("appId"))

--- a/registry/container/trie_test.go
+++ b/registry/container/trie_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Trie", func() {
 			Expect(pool).NotTo(BeNil())
 		})
 
-		It("Returns the number of pools after deleting one", func() {
+		It("returns the number of pools after deleting one", func() {
 			r.Insert("/foo/bar/baz", p1)
 			r.Insert("/foo/bar", p2)
 
@@ -253,7 +253,7 @@ var _ = Describe("Trie", func() {
 		})
 	})
 
-	It("Returns the number of pools", func() {
+	It("returns the number of pools", func() {
 		Expect(r.PoolCount()).To(Equal(0))
 
 		r.Insert("/foo/bar/baz", p1)
@@ -367,7 +367,7 @@ var _ = Describe("Trie", func() {
 	})
 
 	Describe(".ToMap", func() {
-		It("Can be represented by a map", func() {
+		It("can be represented by a map", func() {
 			e1 := route.NewEndpoint(&route.EndpointOpts{Port: 1234})
 			e2 := route.NewEndpoint(&route.EndpointOpts{Port: 4321})
 			p1.Put(e1)
@@ -384,7 +384,7 @@ var _ = Describe("Trie", func() {
 	})
 
 	Describe(".ToPath", func() {
-		It("Returns full URI", func() {
+		It("returns full URI", func() {
 			e1 := route.NewEndpoint(&route.EndpointOpts{})
 			p1.Put(e1)
 			node1 := r.Insert("foo.com", p1)

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -433,7 +433,7 @@ var _ = Describe("RouteRegistry", func() {
 			})
 		})
 
-		It("Handles unknown URIs", func() {
+		It("handles unknown URIs", func() {
 			r.Unregister("bar", barEndpoint)
 			Expect(r.NumUris()).To(Equal(0))
 			Expect(r.NumEndpoints()).To(Equal(0))


### PR DESCRIPTION
Context
---

Currently gorouter returns a 404 when a route is known but there is nothing in the pool available to handle the request.

HTTP 4xx is for user related problems, HTTP 5xx is for server related problems.

An empty pool is incorrect platform behaviour. HTTP `503 ServiceUnavailable` which accurately describes this behaviour.

Change
---

Instead of returning a `404 NotFound` when the pool `IsEmpty`, return a `503 ServiceUnavailable`.

Why
---

We currently have to differentiate whether the 404 is:
> A real lack of a route

or

> Nothing being available currently to handle the route

by looking in gorouter logs, checking whether there is an upstream (e.g. `"10.x.x.x:xxxxx"` vs `"-"`)

It would be better if this was a `503` because it more accurately describes the situation.

Decisions to make
---

- Record a metric, what metric should be recorded, do we need a new one?
- Does this behaviour need to be configurable?
- Is `503` the correct status code? `521 WebServerIsDown` is a Cloudflare status code (like `526` which is also used by gorouter) which more accurately describes this situation.

---

***THIS IS A DRAFT***

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bin/test`

* [ ] I have run CF Acceptance Tests on bosh lite
