### PR TITLE
Lookup handler should not expose LB IP

### DIFF
--- a/handlers/lookup_test.go
+++ b/handlers/lookup_test.go
@@ -55,6 +55,61 @@ var _ = Describe("Lookup", func() {
 		handler.ServeHTTP(resp, req)
 	})
 
+	Context("when the host is identical to the remote IP address", func() {
+		BeforeEach(func() {
+			req.Host = "1.2.3.4"
+			req.RemoteAddr = "1.2.3.4:60001"
+		})
+
+		It("sends a bad request metric", func() {
+			Expect(rep.CaptureBadRequestCallCount()).To(Equal(1))
+		})
+
+		It("sets X-Cf-RouterError to empty_host", func() {
+			Expect(resp.Header().Get("X-Cf-RouterError")).To(Equal("empty_host"))
+		})
+
+		It("sets Cache-Control to public,max-age=2", func() {
+			Expect(resp.Header().Get("Cache-Control")).To(Equal("public,max-age=2"))
+		})
+
+		It("returns a 400 BadRequest and does not call next", func() {
+			Expect(nextCalled).To(BeFalse())
+			Expect(resp.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		It("has a meaningful response", func() {
+			Expect(resp.Body.String()).To(ContainSubstring("Request had empty Host header"))
+		})
+	})
+
+	Context("when the host is not set", func() {
+		BeforeEach(func() {
+			req.Host = ""
+		})
+
+		It("sends a bad request metric", func() {
+			Expect(rep.CaptureBadRequestCallCount()).To(Equal(1))
+		})
+
+		It("sets X-Cf-RouterError to empty_host", func() {
+			Expect(resp.Header().Get("X-Cf-RouterError")).To(Equal("empty_host"))
+		})
+
+		It("sets Cache-Control to public,max-age=2", func() {
+			Expect(resp.Header().Get("Cache-Control")).To(Equal("public,max-age=2"))
+		})
+
+		It("returns a 400 BadRequest and does not call next", func() {
+			Expect(nextCalled).To(BeFalse())
+			Expect(resp.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		It("has a meaningful response", func() {
+			Expect(resp.Body.String()).To(ContainSubstring("Request had empty Host header"))
+		})
+	})
+
 	Context("when there is no pool that matches the request", func() {
 		It("sends a bad request metric", func() {
 			Expect(rep.CaptureBadRequestCallCount()).To(Equal(1))


### PR DESCRIPTION
A short explanation of the proposed change
---

gorouter requires the Host header to know to which backend to proxy to.

The Host header is optional in HTTP/1.0, so we must explicitly check
that the Host is set.

Also, when some load balancers which are used to load balance gorouters (e.g. AWS Classic ELB) receive HTTP/1.0 requests without a host headers, they optimistically add their IP address to the host header.

Therefore to not expose the internal IP address of the load balancer, we must check that the Host is not also the source of the request.

It is not valid for the Host header to be an IP address, because Gorouter should not have an IP address as a route.

See (search "private ip") https://aws.amazon.com/premiumsupport/knowledge-center/elb-fix-failing-health-checks-alb/ for more information about the Host header and ELBs. This should not affect healthchecking because there is a different handler for health.

An explanation of the use cases your change solves
---

Closes #256

Instructions to test the behavior 
---

See #256, in which they reported:

```
curl https://foo.cloud.pcftest.com -H 'Host: ' --http1.0
```

returns:

```
404 Not Found: Requested route ('10.10.2.218') does not exist.
```

Expected result after the change
---

Gorouter should:

* return a 400 BadRequest with an `empty_host` value for `X-Cf-RouterError`
* record a bad request metric.

Gorouter should do this if:

* the Host header is _actually_ empty
* if the Host header is _presumed_ to be empty before the load balancer fiddled with it

Current result before the change
---

```
404 Not Found: Requested route ('10.10.2.218') does not exist.
```

Links to any other associated PRs
---

N/A

Checklist
---

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bin/test`

* [ ] I have run CF Acceptance Tests on bosh lite
