### PR TITLE
Set proxy net.Dial KeepAlive to 1 second

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -208,7 +208,7 @@ type Config struct {
 	StartResponseDelayInterval      time.Duration `yaml:"start_response_delay_interval,omitempty"`
 	EndpointTimeout                 time.Duration `yaml:"endpoint_timeout,omitempty"`
 	EndpointDialTimeout             time.Duration `yaml:"-"`
-	EndpointKeepAliveProbeInterval  time.Duration `yaml:"-"`
+	EndpointKeepAliveProbeInterval  time.Duration `yaml:"endpoint_keep_alive_probe_interval,omitempty"`
 	RouteServiceTimeout             time.Duration `yaml:"route_services_timeout,omitempty"`
 	FrontendIdleTimeout             time.Duration `yaml:"frontend_idle_timeout,omitempty"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -208,6 +208,7 @@ type Config struct {
 	StartResponseDelayInterval      time.Duration `yaml:"start_response_delay_interval,omitempty"`
 	EndpointTimeout                 time.Duration `yaml:"endpoint_timeout,omitempty"`
 	EndpointDialTimeout             time.Duration `yaml:"-"`
+	EndpointKeepAliveProbeInterval  time.Duration `yaml:"-"`
 	RouteServiceTimeout             time.Duration `yaml:"route_services_timeout,omitempty"`
 	FrontendIdleTimeout             time.Duration `yaml:"frontend_idle_timeout,omitempty"`
 
@@ -262,9 +263,10 @@ var defaultConfig = Config{
 	DisableHTTP:   false,
 	MinTLSVersion: tls.VersionTLS12,
 
-	EndpointTimeout:     60 * time.Second,
-	EndpointDialTimeout: 5 * time.Second,
-	RouteServiceTimeout: 60 * time.Second,
+	EndpointTimeout:                60 * time.Second,
+	EndpointDialTimeout:            5 * time.Second,
+	EndpointKeepAliveProbeInterval: 1 * time.Second,
+	RouteServiceTimeout:            60 * time.Second,
 
 	PublishStartMessageInterval:               30 * time.Second,
 	PruneStaleDropletsInterval:                30 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -105,6 +105,17 @@ endpoint_timeout: 10s
 			Expect(config.EndpointKeepAliveProbeInterval).To(Equal(1 * time.Second))
 		})
 
+		It("sets keep alive probe interval", func() {
+			var b = []byte(`
+endpoint_keep_alive_probe_interval: 500ms
+`)
+
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(config.EndpointKeepAliveProbeInterval).To(Equal(500 * time.Millisecond))
+		})
+
 		It("sets nats config", func() {
 			var b = []byte(`
 nats:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -100,6 +100,11 @@ endpoint_timeout: 10s
 			Expect(config.EndpointTimeout).To(Equal(10 * time.Second))
 		})
 
+		It("defaults keep alive probe interval to 1 second", func() {
+			Expect(config.FrontendIdleTimeout).To(Equal(900 * time.Second))
+			Expect(config.EndpointKeepAliveProbeInterval).To(Equal(1 * time.Second))
+		})
+
 		It("sets nats config", func() {
 			var b = []byte(`
 nats:

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -93,9 +93,14 @@ func NewProxy(
 		stickySessionCookieNames: cfg.StickySessionCookieNames,
 	}
 
+	dialer := &net.Dialer{
+		Timeout:   cfg.EndpointDialTimeout,
+		KeepAlive: cfg.EndpointKeepAliveProbeInterval,
+	}
+
 	roundTripperFactory := &round_tripper.FactoryImpl{
 		BackendTemplate: &http.Transport{
-			Dial:                (&net.Dialer{Timeout: cfg.EndpointDialTimeout}).Dial,
+			Dial:                dialer.Dial,
 			DisableKeepAlives:   cfg.DisableKeepAlives,
 			MaxIdleConns:        cfg.MaxIdleConns,
 			IdleConnTimeout:     90 * time.Second, // setting the value to golang default transport
@@ -104,7 +109,7 @@ func NewProxy(
 			TLSClientConfig:     backendTLSConfig,
 		},
 		RouteServiceTemplate: &http.Transport{
-			Dial:                (&net.Dialer{Timeout: cfg.EndpointDialTimeout}).Dial,
+			Dial:                dialer.Dial,
 			DisableKeepAlives:   cfg.DisableKeepAlives,
 			MaxIdleConns:        cfg.MaxIdleConns,
 			IdleConnTimeout:     90 * time.Second, // setting the value to golang default transport


### PR DESCRIPTION
### A short explanation of the proposed change:

Configure proxy's `net.Dialer` to probe idle connections every 1s instead of every 15s.

### An explanation of the use cases your change solves

When gorouter is configured to keep connections alive (`DisableKeepAlives: false`) then it will keep idle TCP connections open to backends for up to 90 seconds. If the connection is not used after 90 seconds then it is closed; if a new request comes in, and there is a idle connection to the backend ready, then it will be used instead of a new TCP connection being made.

If a backend endpoint closes a connection which has been kept alive at
the same time as gorouter tries to use the connection, then Gorouter
returns a 502 and logs `backend-endpoint-failed` due to an io.EOF on the socket.

The underlying TCP connection is managed by `net.Dialer` which by default probes the status of the underlying connection [every 15s](https://golang.org/pkg/net/#Dialer.KeepAlive), which communicates to the recipient that the connection should still be kept open.

Some apps running in our deployment have keep-alives configured to be less than the 15s default probe interval.

Enabling connection keep alives in our foundry caused gorouter to return 502 (backend-endpoint-failed) for approximately ~0.01% of requests to backends which had short keepalive durations.

It did not appear to have a substantial effect on apps with longer keepalive durations, although I have not conclusively tested this.

Now that routing-release ([since 0.192](https://github.com/cloudfoundry/routing-release/releases/tag/0.192.0)) defaults keep-alives to backend connections to be on, it may be sensible to have a shorter probe interval, to avoid these hard to diagnose networking issues.

This PR configures the default probe interval of the underlying net.Dialer in the same style as EndpointDialTimeout; it adds a new
configuration parameter EndpointKeepAliveProbeInterval which configures the underlying net.Dialer KeepAlive parameter, and overrides the default of 15s to be 1s.

I chose 1s somewhat arbitrarily, but it has the property of being lower than the 2s default keepalive duration that some of the pathological apps deployed to our CF have.

This should not adversely affect the performance of gorouter, however that it will send 1 probe per connection idle connection every one second, instead of 1 probe per connection every 15 seconds.

### Instructions to functionally test the behavior change

I found this quite hard to test as it only appears at scale, when traffic fluctuates, for requests which cannot be retried.

I would appreciate advice in how to write a test case for this (perhaps a soak test in one of CFF's long lived environments might do the trick?).

### Expected result after the change

When I deploy this change, when keepalive's to backends are enabled, I will not see 0.01% of requests 502 with backend-endpoint-failed due to keepalives.

The `net.Dialer` probe will signal to the backend to keep the connection open.

### Current result before the change

We have deployed routing-release with `max_idle_connections: 2500` twice, and reverted it twice. When `max_idle_connections` is non-zero then gorouter will keep up to [100 idle connections (hardcoded)](https://github.com/cloudfoundry/routing-release/blob/98ec12a72ac0bfe19fef08d833bb8f350e94c890/jobs/gorouter/templates/gorouter.yml.erb#L77) open to backends.

The backends may close the connection while gorouter is trying to use them.

Since [routing-release 0.192](https://github.com/cloudfoundry/routing-release/releases/tag/0.192.0) the default value for max_idle_connections is non-zero, so I expect to see other deployments experience this. 

### Links to any other associated PRs

This issue https://github.com/cloudfoundry/gorouter/issues/209 has similar symptoms but the cause is different

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bin/test`

* [ ] I have run CF Acceptance Tests on bosh lite
