### PR TITLE
Add support for W3C tracing headers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -137,7 +137,9 @@ type AccessLog struct {
 }
 
 type Tracing struct {
-	EnableZipkin bool `yaml:"enable_zipkin"`
+	EnableZipkin bool   `yaml:"enable_zipkin"`
+	EnableW3C    bool   `yaml:"enable_w3c"`
+	W3CTenantID  string `yaml:"w3c_tenant_id"`
 }
 
 type TLSPem struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -484,6 +484,40 @@ enable_proxy: true
 			Expect(config.Tracing.EnableZipkin).To(BeFalse())
 		})
 
+		It("sets Tracing.EnableW3C", func() {
+			var b = []byte("tracing:\n  enable_w3c: true")
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(config.Tracing.EnableW3C).To(BeTrue())
+
+		})
+
+		It("defaults Tracing.W3C", func() {
+			var b = []byte(``)
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(config.Tracing.EnableW3C).To(BeFalse())
+		})
+
+		It("sets Tracing.W3CTenantID", func() {
+			var b = []byte("tracing:\n  w3c_tenant_id: cf")
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(config.Tracing.W3CTenantID).To(Equal("cf"))
+
+		})
+
+		It("defaults Tracing.W3CTenantID", func() {
+			var b = []byte(``)
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(config.Tracing.W3CTenantID).To(BeEmpty())
+		})
+
 		It("sets the proxy forwarded proto header", func() {
 			var b = []byte("force_forwarded_proto_https: true")
 			config.Initialize(b)

--- a/handlers/w3c.go
+++ b/handlers/w3c.go
@@ -1,0 +1,100 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/uber-go/zap"
+	"github.com/urfave/negroni"
+
+	"code.cloudfoundry.org/gorouter/logger"
+)
+
+const (
+	W3CTraceparentHeader = "traceparent"
+	W3CTracestateHeader  = "tracestate"
+
+	W3CVendorID = "gorouter"
+)
+
+// W3C is a handler that sets W3C headers on requests
+type W3C struct {
+	w3cEnabled  bool
+	w3cTenantID string
+	logger      logger.Logger
+}
+
+var _ negroni.Handler = new(W3C)
+
+// NewW3C creates a new handler that sets W3C headers on requests
+func NewW3C(enabled bool, tenantID string, logger logger.Logger) *W3C {
+	return &W3C{
+		w3cEnabled:  enabled,
+		w3cTenantID: tenantID,
+		logger:      logger,
+	}
+}
+
+func (m *W3C) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	defer next(rw, r)
+
+	if !m.w3cEnabled {
+		return
+	}
+
+	prevTraceparent := ParseW3CTraceparent(r.Header.Get(W3CTraceparentHeader))
+
+	if prevTraceparent == nil {
+		// If we cannot parse an existing traceparent header
+		// or if there is no traceparent header
+		// then we should generate new traceparent and tracestate headers
+		m.ServeNewTraceparent(rw, r)
+	} else {
+		m.ServeUpdatedTraceparent(rw, r, *prevTraceparent)
+	}
+}
+
+func (m *W3C) ServeNewTraceparent(rw http.ResponseWriter, r *http.Request) {
+	traceparent, err := NewW3CTraceparent()
+
+	if err != nil {
+		m.logger.Info("failed-to-create-w3c-traceparent", zap.Error(err))
+		return
+	}
+
+	tracestate := NewW3CTracestate(m.w3cTenantID, traceparent.ParentID)
+
+	r.Header.Set(W3CTraceparentHeader, traceparent.String())
+	r.Header.Set(W3CTracestateHeader, tracestate.String())
+}
+
+func (m *W3C) ServeUpdatedTraceparent(
+	rw http.ResponseWriter,
+	r *http.Request,
+	prevTraceparent W3CTraceparent,
+) {
+	traceparent, err := prevTraceparent.Next()
+
+	if err != nil {
+		m.logger.Info("failed-to-generate-next-w3c-traceparent", zap.Error(err))
+		return
+	}
+
+	tracestate := ParseW3CTracestate(r.Header.Get(W3CTracestateHeader))
+	tracestate = tracestate.Next(m.w3cTenantID, traceparent.ParentID)
+
+	r.Header.Set(W3CTraceparentHeader, traceparent.String())
+	r.Header.Set(W3CTracestateHeader, tracestate.String())
+}
+
+// HeadersToLog specifies the headers which should be logged if W3C headers are
+// enabled
+func (m *W3C) HeadersToLog() []string {
+	if !m.w3cEnabled {
+		return []string{}
+	}
+
+	return []string{
+		W3CTraceparentHeader,
+		W3CTracestateHeader,
+	}
+}

--- a/handlers/w3c_test.go
+++ b/handlers/w3c_test.go
@@ -1,0 +1,294 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+
+	"code.cloudfoundry.org/gorouter/handlers"
+	"code.cloudfoundry.org/gorouter/test_util"
+
+	"code.cloudfoundry.org/gorouter/logger"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("W3C", func() {
+	extractParentID := func(traceparent string) string {
+		r := regexp.MustCompile("^00-[a-f0-9]{32}-([a-f0-9]{16})-01$")
+
+		matches := r.FindStringSubmatch(traceparent)
+
+		// First match is entire string
+		// Seocnd match is parentID
+		if len(matches) != 2 {
+			return ""
+		}
+
+		return matches[1]
+	}
+
+	var (
+		handler    *handlers.W3C
+		logger     logger.Logger
+		resp       http.ResponseWriter
+		req        *http.Request
+		nextCalled bool
+	)
+
+	nextHandler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		nextCalled = true
+	})
+
+	BeforeEach(func() {
+		logger = test_util.NewTestZapLogger("w3c")
+		req = test_util.NewRequest("GET", "example.com", "/", nil)
+		resp = httptest.NewRecorder()
+		nextCalled = false
+	})
+
+	AfterEach(func() {
+	})
+
+	Context("with W3C enabled", func() {
+		Context("without a tenantID set", func() {
+			BeforeEach(func() {
+				handler = handlers.NewW3C(true, "", logger)
+			})
+
+			Context("when there are no pre-existing headers", func() {
+				It("sets W3C headers and calls the next handler", func() {
+					handler.ServeHTTP(resp, req, nextHandler)
+
+					traceparentHeader := req.Header.Get(handlers.W3CTraceparentHeader)
+
+					Expect(traceparentHeader).To(MatchRegexp(
+						"^00-[a-f0-9]{32}-[a-f0-9]{16}-01$"), "Must match the W3C spec",
+					)
+
+					parentID := extractParentID(traceparentHeader)
+
+					Expect(req.Header.Get(handlers.W3CTracestateHeader)).To(
+						Equal(fmt.Sprintf("gorouter=%s", parentID)),
+					)
+
+					Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+				})
+			})
+
+			Context("when there are pre-existing headers", func() {
+				BeforeEach(func() {
+					req.Header.Set(
+						handlers.W3CTraceparentHeader,
+						"00-11111111111111111111111111111111-2222222222222222-01",
+					)
+
+					req.Header.Set(
+						handlers.W3CTracestateHeader,
+						"rojo=00f067aa0ba902b7,congo=t61rcWkgMzE",
+					)
+				})
+
+				It("sets W3C headers and calls the next handler", func() {
+					handler.ServeHTTP(resp, req, nextHandler)
+
+					traceparentHeader := req.Header.Get(handlers.W3CTraceparentHeader)
+
+					Expect(traceparentHeader).To(MatchRegexp(
+						"^00-[1]{32}-[a-f0-9]{16}-01$"),
+						"Must update the parent ID but not the trace ID",
+					)
+
+					parentID := extractParentID(traceparentHeader)
+
+					Expect(req.Header.Get(handlers.W3CTracestateHeader)).To(
+						Equal(fmt.Sprintf(
+							"gorouter=%s,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE", parentID,
+						)),
+					)
+
+					Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+				})
+			})
+
+			Context("when there are pre-existing headers including gorouter", func() {
+				BeforeEach(func() {
+					req.Header.Set(
+						handlers.W3CTraceparentHeader,
+						"00-11111111111111111111111111111111-2222222222222222-01",
+					)
+
+					req.Header.Set(
+						handlers.W3CTracestateHeader,
+						"rojo=00f067aa0ba902b7,gorouter=t61rcWkgMzE",
+					)
+				})
+
+				It("sets W3C headers, replacing the older gorouter header, and calls the next handler", func() {
+					handler.ServeHTTP(resp, req, nextHandler)
+
+					traceparentHeader := req.Header.Get(handlers.W3CTraceparentHeader)
+
+					Expect(traceparentHeader).To(MatchRegexp(
+						"^00-[1]{32}-[a-f0-9]{16}-01$"),
+						"Must update the parent ID but not the trace ID",
+					)
+
+					parentID := extractParentID(traceparentHeader)
+
+					Expect(req.Header.Get(handlers.W3CTracestateHeader)).To(
+						Equal(fmt.Sprintf("gorouter=%s,rojo=00f067aa0ba902b7", parentID)),
+						"The old gorouter value should be replaced by the newer parentID",
+					)
+
+					Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+				})
+			})
+		})
+		Context("with a tenantID set", func() {
+			BeforeEach(func() {
+				handler = handlers.NewW3C(true, "tid", logger)
+			})
+
+			Context("when there are no pre-existing headers", func() {
+				It("sets W3C headers and calls the next handler", func() {
+					handler.ServeHTTP(resp, req, nextHandler)
+
+					traceparentHeader := req.Header.Get(handlers.W3CTraceparentHeader)
+
+					Expect(traceparentHeader).To(MatchRegexp(
+						"^00-[a-f0-9]{32}-[a-f0-9]{16}-01$"), "Must match the W3C spec",
+					)
+
+					parentID := extractParentID(traceparentHeader)
+
+					Expect(req.Header.Get(handlers.W3CTracestateHeader)).To(
+						Equal(fmt.Sprintf("tid@gorouter=%s", parentID)),
+					)
+
+					Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+				})
+			})
+
+			Context("when there are pre-existing headers", func() {
+				BeforeEach(func() {
+					req.Header.Set(
+						handlers.W3CTraceparentHeader,
+						"00-11111111111111111111111111111111-2222222222222222-01",
+					)
+
+					req.Header.Set(
+						handlers.W3CTracestateHeader,
+						"rojo=00f067aa0ba902b7,congo=t61rcWkgMzE",
+					)
+				})
+
+				It("sets W3C headers and calls the next handler", func() {
+					handler.ServeHTTP(resp, req, nextHandler)
+
+					traceparentHeader := req.Header.Get(handlers.W3CTraceparentHeader)
+
+					Expect(traceparentHeader).To(MatchRegexp(
+						"^00-[1]{32}-[a-f0-9]{16}-01$"),
+						"Must update the parent ID but not the trace ID",
+					)
+
+					parentID := extractParentID(traceparentHeader)
+
+					Expect(req.Header.Get(handlers.W3CTracestateHeader)).To(
+						Equal(fmt.Sprintf(
+							"tid@gorouter=%s,rojo=00f067aa0ba902b7,congo=t61rcWkgMzE", parentID,
+						)),
+					)
+
+					Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+				})
+			})
+
+			Context("when there are pre-existing headers including gorouter which has a different tenant ID", func() {
+				BeforeEach(func() {
+					req.Header.Set(
+						handlers.W3CTraceparentHeader,
+						"00-11111111111111111111111111111111-2222222222222222-01",
+					)
+
+					req.Header.Set(
+						handlers.W3CTracestateHeader,
+						"rojo=00f067aa0ba902b7,gorouter=t61rcWkgMzE",
+					)
+				})
+
+				It("sets W3C headers, without replacing the older gorouter header, and calls the next handler", func() {
+					handler.ServeHTTP(resp, req, nextHandler)
+
+					traceparentHeader := req.Header.Get(handlers.W3CTraceparentHeader)
+
+					Expect(traceparentHeader).To(MatchRegexp(
+						"^00-[1]{32}-[a-f0-9]{16}-01$"),
+						"Must update the parent ID but not the trace ID",
+					)
+
+					parentID := extractParentID(traceparentHeader)
+
+					Expect(req.Header.Get(handlers.W3CTracestateHeader)).To(
+						Equal(fmt.Sprintf("tid@gorouter=%s,rojo=00f067aa0ba902b7,gorouter=t61rcWkgMzE", parentID)),
+						"The other gorouter value should not be replaced by the newer parentID as they have separate tenant IDs",
+					)
+
+					Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+				})
+			})
+
+			Context("when there are pre-existing headers including gorouter which has the same tenant ID", func() {
+				BeforeEach(func() {
+					req.Header.Set(
+						handlers.W3CTraceparentHeader,
+						"00-11111111111111111111111111111111-2222222222222222-01",
+					)
+
+					req.Header.Set(
+						handlers.W3CTracestateHeader,
+						"rojo=00f067aa0ba902b7,tid@gorouter=t61rcWkgMzE",
+					)
+				})
+
+				It("sets W3C headers, replacing the other gorouter header, and calls the next handler", func() {
+					handler.ServeHTTP(resp, req, nextHandler)
+
+					traceparentHeader := req.Header.Get(handlers.W3CTraceparentHeader)
+
+					Expect(traceparentHeader).To(MatchRegexp(
+						"^00-[1]{32}-[a-f0-9]{16}-01$"),
+						"Must update the parent ID but not the trace ID",
+					)
+
+					parentID := extractParentID(traceparentHeader)
+
+					Expect(req.Header.Get(handlers.W3CTracestateHeader)).To(
+						Equal(fmt.Sprintf("tid@gorouter=%s,rojo=00f067aa0ba902b7", parentID)),
+						"The other gorouter value should be replaced by the newer parentID as they have same tenant IDs",
+					)
+
+					Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+				})
+			})
+		})
+
+	})
+
+	Context("with W3C disabled", func() {
+		BeforeEach(func() {
+			handler = handlers.NewW3C(false, "", logger)
+		})
+
+		It("doesn't set any headers", func() {
+			handler.ServeHTTP(resp, req, nextHandler)
+
+			Expect(req.Header.Get(handlers.W3CTraceparentHeader)).To(BeEmpty())
+			Expect(req.Header.Get(handlers.W3CTracestateHeader)).To(BeEmpty())
+
+			Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+		})
+	})
+})

--- a/handlers/w3c_traceparent.go
+++ b/handlers/w3c_traceparent.go
@@ -1,0 +1,130 @@
+package handlers
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"code.cloudfoundry.org/gorouter/common/secure"
+)
+
+const (
+	W3CTraceparentVersion    = uint8(0)
+	W3CTraceparentSampled    = uint8(1)
+	W3CTraceparentNotSampled = uint8(0)
+)
+
+// W3CTraceparent is a struct which represents the traceparent header
+// See https://www.w3.org/TR/trace-context/
+type W3CTraceparent struct {
+	Version  uint8
+	TraceID  []byte
+	ParentID []byte
+	Flags    uint8
+}
+
+// NewW3CTraceparent generates a W3C traceparent header value according to
+// https://www.w3.org/TR/trace-context/#version-format
+func NewW3CTraceparent() (W3CTraceparent, error) {
+	traceID, err := generateW3CTraceID()
+	if err != nil {
+		return W3CTraceparent{}, err
+	}
+
+	parentID, err := generateW3CParentID()
+	if err != nil {
+		return W3CTraceparent{}, err
+	}
+
+	return W3CTraceparent{
+		Version: W3CTraceparentVersion,
+		Flags:   W3CTraceparentSampled,
+
+		TraceID:  traceID,
+		ParentID: parentID,
+	}, nil
+}
+
+// ParseW3CTraceparent parses a W3C traceparent header value according to
+// https://www.w3.org/TR/trace-context/#version-format
+// If it cannot parse the input header string it returns nil
+func ParseW3CTraceparent(header string) *W3CTraceparent {
+	// In the format of
+	// 00-00000000000000000000000000000000-0000000000000000-00
+	sanitizedHeader := strings.TrimSpace(strings.ToLower(header))
+
+	if len(sanitizedHeader) != 55 {
+		return nil
+	}
+
+	versionBytes, err := hex.DecodeString(sanitizedHeader[0:2])
+	if err != nil {
+		return nil
+	}
+
+	traceIDBytes, err := hex.DecodeString(sanitizedHeader[3:35])
+	if err != nil {
+		return nil
+	}
+
+	parentIDBytes, err := hex.DecodeString(sanitizedHeader[36:52])
+	if err != nil {
+		return nil
+	}
+
+	flagBytes, err := hex.DecodeString(sanitizedHeader[53:55])
+	if err != nil {
+		return nil
+	}
+
+	return &W3CTraceparent{
+		Version: uint8(versionBytes[0]),
+		Flags:   uint8(flagBytes[0]),
+
+		TraceID:  traceIDBytes,
+		ParentID: parentIDBytes,
+	}
+}
+
+func generateW3CTraceID() ([]byte, error) {
+	randBytes, err := secure.RandomBytes(16)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return randBytes, nil
+}
+
+func generateW3CParentID() ([]byte, error) {
+	randBytes, err := secure.RandomBytes(8)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return randBytes, nil
+}
+
+// Next generates a new Traceparent
+func (h W3CTraceparent) Next() (W3CTraceparent, error) {
+	parentID, err := generateW3CParentID()
+
+	if err != nil {
+		return h, err
+	}
+
+	return W3CTraceparent{
+		Version:  W3CTraceparentVersion,
+		Flags:    h.Flags,
+		TraceID:  h.TraceID,
+		ParentID: parentID,
+	}, nil
+}
+
+// String generates the W3C traceparent header value according to
+// https://www.w3.org/TR/trace-context/#version-format
+func (h W3CTraceparent) String() string {
+	return fmt.Sprintf(
+		"%02x-%032x-%016x-%02x",
+		h.Version, h.TraceID, h.ParentID, h.Flags,
+	)
+}

--- a/handlers/w3c_traceparent_test.go
+++ b/handlers/w3c_traceparent_test.go
@@ -1,0 +1,158 @@
+package handlers_test
+
+import (
+	"encoding/hex"
+
+	"code.cloudfoundry.org/gorouter/handlers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("W3CTraceparent", func() {
+	Context("when given a valid traceparent header", func() {
+		var (
+			sampleHeader string
+
+			expectedTraceID  []byte
+			expectedParentID []byte
+		)
+
+		BeforeEach(func() {
+			expectedTraceID, _ = hex.DecodeString(
+				"4bf92f3577b34da6a3ce929d0e0e4736",
+			)
+			expectedParentID, _ = hex.DecodeString(
+				"00f067aa0ba902b7",
+			)
+		})
+
+		Context("when the request has been sampled", func() {
+			BeforeEach(func() {
+				sampleHeader = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+			})
+
+			It("should parse correctly", func() {
+				parsed := handlers.ParseW3CTraceparent(sampleHeader)
+
+				Expect(parsed).NotTo(BeNil())
+
+				Expect(parsed.Version).To(Equal(handlers.W3CTraceparentVersion))
+				Expect(parsed.Flags).To(Equal(handlers.W3CTraceparentSampled))
+
+				Expect(parsed.TraceID).To(Equal(expectedTraceID))
+				Expect(parsed.ParentID).To(Equal(expectedParentID))
+
+				Expect(parsed.String()).To(Equal(sampleHeader))
+			})
+
+			It("should generate a new header correctly", func() {
+				parsed := handlers.ParseW3CTraceparent(sampleHeader)
+
+				Expect(parsed).NotTo(BeNil())
+				Expect(parsed.String()).To(Equal(sampleHeader))
+
+				next, err := parsed.Next()
+
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(parsed.TraceID).To(
+					Equal(next.TraceID), "the trace IDs should match",
+				)
+
+				Expect(parsed.ParentID).NotTo(
+					Equal(next.ParentID), "the parent IDs should not match",
+				)
+
+				Expect(next.Version).To(Equal(handlers.W3CTraceparentVersion))
+				Expect(next.Flags).To(Equal(parsed.Flags))
+			})
+		})
+
+		Context("when the request has not been sampled", func() {
+			BeforeEach(func() {
+				sampleHeader = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"
+			})
+
+			It("should parse correctly", func() {
+
+				parsed := handlers.ParseW3CTraceparent(sampleHeader)
+
+				Expect(parsed).NotTo(BeNil())
+
+				Expect(parsed.Version).To(Equal(handlers.W3CTraceparentVersion))
+				Expect(parsed.Flags).To(Equal(handlers.W3CTraceparentNotSampled))
+
+				Expect(parsed.TraceID).To(Equal(expectedTraceID))
+				Expect(parsed.ParentID).To(Equal(expectedParentID))
+
+				Expect(parsed.String()).To(Equal(sampleHeader))
+			})
+
+			It("should generate a new header correctly", func() {
+				parsed := handlers.ParseW3CTraceparent(sampleHeader)
+
+				Expect(parsed).NotTo(BeNil())
+				Expect(parsed.String()).To(Equal(sampleHeader))
+
+				next, err := parsed.Next()
+
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(parsed.TraceID).To(
+					Equal(next.TraceID), "the trace IDs should match",
+				)
+
+				Expect(parsed.ParentID).NotTo(
+					Equal(next.ParentID), "the parent IDs should not match",
+				)
+
+				Expect(next.Version).To(Equal(handlers.W3CTraceparentVersion))
+				Expect(next.Flags).To(Equal(parsed.Flags))
+			})
+		})
+
+		Context("when the request has some non-standard flags", func() {
+			BeforeEach(func() {
+				sampleHeader = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-99"
+			})
+
+			It("should parse correctly", func() {
+
+				parsed := handlers.ParseW3CTraceparent(sampleHeader)
+
+				Expect(parsed).NotTo(BeNil())
+
+				Expect(parsed.Version).To(Equal(handlers.W3CTraceparentVersion))
+				Expect(parsed.Flags).To(Equal(uint8(153)), "Hex -> Dec")
+
+				Expect(parsed.TraceID).To(Equal(expectedTraceID))
+				Expect(parsed.ParentID).To(Equal(expectedParentID))
+
+				Expect(parsed.String()).To(Equal(sampleHeader))
+			})
+
+			It("should generate a new header correctly", func() {
+				parsed := handlers.ParseW3CTraceparent(sampleHeader)
+
+				Expect(parsed).NotTo(BeNil())
+				Expect(parsed.String()).To(Equal(sampleHeader))
+
+				next, err := parsed.Next()
+
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(parsed.TraceID).To(
+					Equal(next.TraceID), "the trace IDs should match",
+				)
+
+				Expect(parsed.ParentID).NotTo(
+					Equal(next.ParentID), "the parent IDs should not match",
+				)
+
+				Expect(next.Version).To(Equal(handlers.W3CTraceparentVersion))
+				Expect(next.Flags).To(Equal(uint8(153)), "Hex -> Dec")
+			})
+		})
+	})
+})

--- a/handlers/w3c_tracestate.go
+++ b/handlers/w3c_tracestate.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// W3CTracestateEntry represents a Tracestate entry: a key value pair
+type W3CTracestateEntry struct {
+	Key string
+	Val string
+}
+
+func (s W3CTracestateEntry) String() string {
+	return fmt.Sprintf("%s=%s", s.Key, s.Val)
+}
+
+// W3CTracestate is an alias for a slice W3CTracestateEntry; has helper funcs
+type W3CTracestate []W3CTracestateEntry
+
+func (s W3CTracestate) String() string {
+	states := make([]string, 0)
+
+	for i := 1; i <= len(s); i++ {
+		states = append(states, s[len(s)-i].String())
+	}
+
+	return strings.Join(states, ",")
+}
+
+func NextW3CTracestate(tenantID string, parentID []byte) W3CTracestateEntry {
+	var key string
+
+	if tenantID == "" {
+		key = W3CVendorID
+	} else {
+		key = fmt.Sprintf("%s@%s", tenantID, W3CVendorID)
+	}
+
+	return W3CTracestateEntry{Key: key, Val: hex.EncodeToString(parentID)}
+}
+
+func (s W3CTracestate) Next(tenantID string, parentID []byte) W3CTracestate {
+	entry := NextW3CTracestate(tenantID, parentID)
+
+	newEntries := make(W3CTracestate, 0)
+
+	// We should not persist entries which have the same key
+	for _, existingEntry := range s {
+		if existingEntry.Key != entry.Key {
+			newEntries = append(newEntries, existingEntry)
+		}
+	}
+
+	return append(newEntries, entry)
+}
+
+func ParseW3CTracestate(header string) W3CTracestate {
+	parsed := make(W3CTracestate, 0)
+
+	// Arbitrarily ignore large traces for performance reasons
+	if len(header) > 2048 {
+		return parsed
+	}
+
+	states := strings.Split(header, ",")
+
+	// We loop in reverse because the headers are oldest at the end
+	for i := 1; i <= len(states); i++ {
+		pair := states[len(states)-i]
+		split := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+		if len(split) == 2 {
+			parsed = append(parsed, W3CTracestateEntry{Key: split[0], Val: split[1]})
+		}
+	}
+
+	return parsed
+}
+
+// NewW3CTracestate generates a new set of W3C tracestate pairs according to
+// https://www.w3.org/TR/trace-context/#version-format
+// Initially it is populated with the current tracestate determined by
+// arguments tenantID and parentID
+func NewW3CTracestate(tenantID string, parentID []byte) W3CTracestate {
+	return W3CTracestate{NextW3CTracestate(tenantID, parentID)}
+}

--- a/handlers/w3c_tracestate_test.go
+++ b/handlers/w3c_tracestate_test.go
@@ -1,0 +1,209 @@
+package handlers_test
+
+import (
+	"code.cloudfoundry.org/gorouter/handlers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("W3CTracestate", func() {
+	Context("when creating a new W3CTracestate", func() {
+		Context("when there is no tenantID", func() {
+			It("should create the entry without an @ symbol", func() {
+				tenantID := ""
+				parentID := []byte("cf")
+
+				tracestate := handlers.NewW3CTracestate(tenantID, parentID)
+
+				Expect(tracestate).To(HaveLen(1))
+				Expect(tracestate[0].Key).To(Equal("gorouter"))
+				Expect(tracestate[0].Val).To(Equal("6366"))
+				Expect(tracestate[0].String()).To(Equal("gorouter=6366"))
+			})
+		})
+
+		Context("when there is a tenantID", func() {
+			It("should create the entry with @ symbol and the tenantID", func() {
+				tenantID := "tid"
+				parentID := []byte("cf")
+
+				tracestate := handlers.NewW3CTracestate(tenantID, parentID)
+
+				Expect(tracestate).To(HaveLen(1))
+				Expect(tracestate[0].Key).To(Equal("tid@gorouter"))
+				Expect(tracestate[0].Val).To(Equal("6366"))
+				Expect(tracestate[0].String()).To(Equal("tid@gorouter=6366"))
+			})
+		})
+	})
+
+	Context("when updating an existing W3CTracestate", func() {
+		Context("when there is no tenantID", func() {
+			Context("when the W3CTracestate is empty", func() {
+				It("should create the entry without an @ symbol", func() {
+					tenantID := ""
+					parentID := []byte("cf")
+
+					tracestate := make(handlers.W3CTracestate, 0)
+					tracestate = tracestate.Next(tenantID, parentID)
+
+					Expect(tracestate).To(HaveLen(1))
+					Expect(tracestate[0].Key).To(Equal("gorouter"))
+					Expect(tracestate[0].Val).To(Equal("6366"))
+					Expect(tracestate[0].String()).To(Equal("gorouter=6366"))
+				})
+			})
+
+			Context("when the W3CTracestate is not empty", func() {
+				It("should create the entry without an @ symbol", func() {
+					tenantID := ""
+					parentID := []byte("cf")
+
+					ts := handlers.W3CTracestate{
+						handlers.W3CTracestateEntry{Key: "congo", Val: "t61rcWkgMzE"},
+					}
+
+					ts = ts.Next(tenantID, parentID)
+
+					Expect(ts).To(HaveLen(2))
+
+					Expect(ts[0].String()).To(Equal("congo=t61rcWkgMzE"))
+					Expect(ts[1].String()).To(Equal("gorouter=6366"))
+
+					Expect(ts.String()).To(Equal("gorouter=6366,congo=t61rcWkgMzE"))
+				})
+
+				Context("when a matching tracestate entry already exists", func() {
+					It("should keep the most recent entry with the tenant id", func() {
+						tenantID := ""
+						parentID := []byte("cf")
+
+						ts := handlers.W3CTracestate{
+							handlers.W3CTracestateEntry{Key: "rojo", Val: "00f067aa0ba902b7"},
+							handlers.W3CTracestateEntry{Key: "gorouter", Val: "prev"},
+							handlers.W3CTracestateEntry{Key: "congo", Val: "t61rcWkgMzE"},
+						}
+
+						ts = ts.Next(tenantID, parentID)
+
+						Expect(ts).To(HaveLen(3))
+
+						Expect(ts[0].String()).To(Equal("rojo=00f067aa0ba902b7"))
+						Expect(ts[1].String()).To(Equal("congo=t61rcWkgMzE"))
+						Expect(ts[2].String()).To(Equal("gorouter=6366"))
+
+						Expect(ts.String()).To(
+							Equal("gorouter=6366,congo=t61rcWkgMzE,rojo=00f067aa0ba902b7"),
+						)
+					})
+
+					It("should persist gorouters with different tenantIDs", func() {
+						tenantID := ""
+						parentID := []byte("cf")
+
+						ts := handlers.W3CTracestate{
+							handlers.W3CTracestateEntry{Key: "gorouter", Val: "a"},
+							handlers.W3CTracestateEntry{Key: "other@gorouter", Val: "b"},
+						}
+
+						ts = ts.Next(tenantID, parentID)
+
+						Expect(ts).To(HaveLen(2))
+
+						Expect(ts[0].String()).To(Equal("other@gorouter=b"))
+						Expect(ts[1].String()).To(Equal("gorouter=6366"))
+
+						Expect(ts.String()).To(
+							Equal("gorouter=6366,other@gorouter=b"),
+						)
+					})
+				})
+			})
+		})
+
+		Context("when there is a tenantID", func() {
+			Context("when the W3CTracestate is empty", func() {
+				It("should create the entry with @ symbol and the tenantID", func() {
+					tenantID := "tid"
+					parentID := []byte("cf")
+
+					tracestate := make(handlers.W3CTracestate, 0)
+					tracestate = tracestate.Next(tenantID, parentID)
+
+					Expect(tracestate).To(HaveLen(1))
+					Expect(tracestate[0].Key).To(Equal("tid@gorouter"))
+					Expect(tracestate[0].Val).To(Equal("6366"))
+					Expect(tracestate[0].String()).To(Equal("tid@gorouter=6366"))
+				})
+			})
+
+			Context("when the W3CTracestate is not empty", func() {
+				It("should create the entry with @ symbol and the tenantID", func() {
+					tenantID := "tid"
+					parentID := []byte("cf")
+
+					ts := handlers.W3CTracestate{
+						handlers.W3CTracestateEntry{Key: "congo", Val: "t61rcWkgMzE"},
+					}
+
+					ts = ts.Next(tenantID, parentID)
+
+					Expect(ts).To(HaveLen(2))
+
+					Expect(ts[0].String()).To(Equal("congo=t61rcWkgMzE"))
+					Expect(ts[1].String()).To(Equal("tid@gorouter=6366"))
+
+					Expect(ts.String()).To(Equal("tid@gorouter=6366,congo=t61rcWkgMzE"))
+				})
+
+				Context("when a gorouter tracestate entry already exists", func() {
+					It("should keep the most recent entry with the tenant id", func() {
+						tenantID := "tid"
+						parentID := []byte("cf")
+
+						ts := handlers.W3CTracestate{
+							handlers.W3CTracestateEntry{Key: "rojo", Val: "00f067aa0ba902b7"},
+							handlers.W3CTracestateEntry{Key: "tid@gorouter", Val: "prev"},
+							handlers.W3CTracestateEntry{Key: "congo", Val: "t61rcWkgMzE"},
+						}
+
+						ts = ts.Next(tenantID, parentID)
+
+						Expect(ts).To(HaveLen(3))
+
+						Expect(ts[0].String()).To(Equal("rojo=00f067aa0ba902b7"))
+						Expect(ts[1].String()).To(Equal("congo=t61rcWkgMzE"))
+						Expect(ts[2].String()).To(Equal("tid@gorouter=6366"))
+
+						Expect(ts.String()).To(
+							Equal("tid@gorouter=6366,congo=t61rcWkgMzE,rojo=00f067aa0ba902b7"),
+						)
+					})
+
+					It("should persist gorouters with different tenantIDs", func() {
+						tenantID := "tid"
+						parentID := []byte("cf")
+
+						ts := handlers.W3CTracestate{
+							handlers.W3CTracestateEntry{Key: "gorouter", Val: "a"},
+							handlers.W3CTracestateEntry{Key: "other@gorouter", Val: "b"},
+						}
+
+						ts = ts.Next(tenantID, parentID)
+
+						Expect(ts).To(HaveLen(3))
+
+						Expect(ts[0].String()).To(Equal("gorouter=a"))
+						Expect(ts[1].String()).To(Equal("other@gorouter=b"))
+						Expect(ts[2].String()).To(Equal("tid@gorouter=6366"))
+
+						Expect(ts.String()).To(
+							Equal("tid@gorouter=6366,other@gorouter=b,gorouter=a"),
+						)
+					})
+				})
+			})
+		})
+	})
+})

--- a/handlers/zipkin.go
+++ b/handlers/zipkin.go
@@ -133,12 +133,3 @@ func (z *Zipkin) HeadersToLog() []string {
 		B3Header,
 	}
 }
-
-func contains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}

--- a/handlers/zipkin.go
+++ b/handlers/zipkin.go
@@ -26,16 +26,14 @@ const (
 type Zipkin struct {
 	zipkinEnabled bool
 	logger        logger.Logger
-	headersToLog  []string // Shared state with proxy for access logs
 }
 
 var _ negroni.Handler = new(Zipkin)
 
 // NewZipkin creates a new handler that sets Zipkin headers on requests
-func NewZipkin(enabled bool, headersToLog []string, logger logger.Logger) *Zipkin {
+func NewZipkin(enabled bool, logger logger.Logger) *Zipkin {
 	return &Zipkin{
 		zipkinEnabled: enabled,
-		headersToLog:  headersToLog,
 		logger:        logger,
 	}
 }
@@ -121,30 +119,19 @@ func BuildB3SingleHeader(traceID, spanID, sampling, flags, parentSpanID string) 
 	return traceID + "-" + spanID + "-" + samplingBit + "-" + parentSpanID
 }
 
-// HeadersToLog returns headers that should be logged in the access logs and
-// includes Zipkin headers in this set if necessary
+// HeadersToLog specifies the headers which should be logged if Zipkin headers
+// are enabled
 func (z *Zipkin) HeadersToLog() []string {
 	if !z.zipkinEnabled {
-		return z.headersToLog
-	}
-	headersToLog := z.headersToLog
-	if !contains(headersToLog, B3TraceIdHeader) {
-		headersToLog = append(headersToLog, B3TraceIdHeader)
+		return []string{}
 	}
 
-	if !contains(headersToLog, B3SpanIdHeader) {
-		headersToLog = append(headersToLog, B3SpanIdHeader)
+	return []string{
+		B3TraceIdHeader,
+		B3SpanIdHeader,
+		B3ParentSpanIdHeader,
+		B3Header,
 	}
-
-	if !contains(headersToLog, B3ParentSpanIdHeader) {
-		headersToLog = append(headersToLog, B3ParentSpanIdHeader)
-	}
-
-	if !contains(headersToLog, B3Header) {
-		headersToLog = append(headersToLog, B3Header)
-	}
-
-	return headersToLog
 }
 
 func contains(s []string, e string) bool {

--- a/integration/w3c_tracing_test.go
+++ b/integration/w3c_tracing_test.go
@@ -1,0 +1,202 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("W3C tracing headers", func() {
+	const (
+		hostname = "w3c-tracing-app.cloudfoundry.org"
+	)
+
+	var (
+		testState *testState
+		testApp   *httptest.Server
+
+		appReceivedHeaders chan http.Header
+
+		doRequest func(http.Header)
+	)
+
+	BeforeEach(func() {
+		testState = NewTestState()
+		testState.cfg.Tracing.EnableW3C = true
+
+		appReceivedHeaders = make(chan http.Header, 1)
+
+		doRequest = func(headers http.Header) {
+			req := testState.newRequest(fmt.Sprintf("http://%s", hostname))
+
+			for headerName, headerVals := range headers {
+				for _, headerVal := range headerVals {
+					req.Header.Set(headerName, headerVal)
+				}
+			}
+
+			resp, err := testState.client.Do(req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(200))
+
+			resp.Body.Close()
+		}
+	})
+
+	JustBeforeEach(func() {
+		testState.StartGorouter()
+
+		testApp = httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				appReceivedHeaders <- r.Header
+				w.WriteHeader(200)
+			}),
+		)
+
+		testState.register(testApp, hostname)
+	})
+
+	AfterEach(func() {
+		testApp.Close()
+
+		if testState != nil {
+			testState.StopAndCleanup()
+		}
+	})
+
+	Context("when W3C is enabled without a tenant ID", func() {
+		BeforeEach(func() {
+			testState.cfg.Tracing.EnableW3C = true
+		})
+
+		It("generates new trace headers when the request has none", func() {
+			doRequest(http.Header{})
+
+			var expectedBackendHeader http.Header
+			Eventually(appReceivedHeaders, "3s").Should(Receive(&expectedBackendHeader))
+
+			Expect(expectedBackendHeader).To(HaveKeyWithValue("Traceparent",
+				ConsistOf(MatchRegexp("^00-[a-f0-9]{32}-[a-f0-9]{16}-01$"))),
+			)
+
+			Expect(expectedBackendHeader).To(HaveKeyWithValue("Tracestate",
+				ConsistOf(MatchRegexp("gorouter=[a-f0-9]{16}"))),
+			)
+		})
+
+		It("updates existing trace headers when the request has them", func() {
+			doRequest(http.Header{
+				"traceparent": []string{
+					"00-11111111111111111111111111111111-9999999999999999-01",
+				},
+				"tracestate": []string{
+					"congo=12345678",
+				},
+			})
+
+			var expectedBackendHeader http.Header
+			Eventually(appReceivedHeaders, "3s").Should(Receive(&expectedBackendHeader))
+
+			Expect(expectedBackendHeader).To(HaveKeyWithValue("Traceparent",
+				ConsistOf(MatchRegexp("^00-[1]{32}-[a-f0-9]{16}-01$"))),
+			)
+
+			Expect(expectedBackendHeader).To(HaveKeyWithValue("Tracestate",
+				ConsistOf(MatchRegexp("gorouter=[a-f0-9]{16},congo=12345678"))),
+			)
+		})
+
+		It("updates existing trace headers with the same tenant ID", func() {
+			doRequest(http.Header{
+				"traceparent": []string{
+					"00-11111111111111111111111111111111-9999999999999999-01",
+				},
+				"tracestate": []string{
+					"congo=12345678,gorouter=abcdefg,rojo=xyz1234",
+				},
+			})
+
+			var expectedBackendHeader http.Header
+			Eventually(appReceivedHeaders, "3s").Should(Receive(&expectedBackendHeader))
+
+			Expect(expectedBackendHeader).To(HaveKeyWithValue("Traceparent",
+				ConsistOf(MatchRegexp("^00-[1]{32}-[a-f0-9]{16}-01$"))),
+			)
+
+			Expect(expectedBackendHeader).To(HaveKeyWithValue("Tracestate",
+				ConsistOf(MatchRegexp("gorouter=[a-f0-9]{16},congo=12345678,rojo=xyz1234"))),
+			)
+		})
+	})
+
+	Context("when W3C is enabled with a tenant ID", func() {
+		BeforeEach(func() {
+
+			testState.cfg.Tracing.EnableW3C = true
+			testState.cfg.Tracing.W3CTenantID = "tid"
+		})
+
+		It("generates new trace headers when the request has none", func() {
+			doRequest(http.Header{})
+
+			var expectedBackendHeader http.Header
+			Eventually(appReceivedHeaders, "3s").Should(Receive(&expectedBackendHeader))
+
+			Expect(expectedBackendHeader).To(HaveKeyWithValue("Traceparent",
+				ConsistOf(MatchRegexp("^00-[a-f0-9]{32}-[a-f0-9]{16}-01$"))),
+			)
+
+			Expect(expectedBackendHeader).To(HaveKeyWithValue("Tracestate",
+				ConsistOf(MatchRegexp("tid@gorouter=[a-f0-9]{16}"))),
+			)
+		})
+
+		It("updates existing trace headers when the request has them", func() {
+			doRequest(http.Header{
+				"traceparent": []string{
+					"00-11111111111111111111111111111111-9999999999999999-01",
+				},
+				"tracestate": []string{
+					"congo=12345678",
+				},
+			})
+
+			var expectedBackendHeader http.Header
+			Eventually(appReceivedHeaders, "3s").Should(Receive(&expectedBackendHeader))
+
+			Expect(expectedBackendHeader).To(HaveKeyWithValue("Traceparent",
+				ConsistOf(MatchRegexp("^00-[1]{32}-[a-f0-9]{16}-01$"))),
+			)
+
+			Expect(expectedBackendHeader).To(HaveKeyWithValue("Tracestate",
+				ConsistOf(MatchRegexp("tid@gorouter=[a-f0-9]{16},congo=12345678"))),
+			)
+		})
+
+		It("updates existing trace headers with the same tenant ID", func() {
+			doRequest(http.Header{
+				"traceparent": []string{
+					"00-11111111111111111111111111111111-9999999999999999-01",
+				},
+				"tracestate": []string{
+					"congo=12345678,tid@gorouter=abcdefg,rojo=xyz1234",
+				},
+			})
+
+			var expectedBackendHeader http.Header
+			Eventually(appReceivedHeaders, "3s").Should(Receive(&expectedBackendHeader))
+
+			Expect(expectedBackendHeader).To(HaveKeyWithValue("Traceparent",
+				ConsistOf(MatchRegexp("^00-[1]{32}-[a-f0-9]{16}-01$"))),
+			)
+
+			Expect(expectedBackendHeader).To(HaveKeyWithValue("Tracestate",
+				ConsistOf(MatchRegexp("tid@gorouter=[a-f0-9]{16},congo=12345678,rojo=xyz1234"))),
+			)
+		})
+	})
+})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -143,10 +143,12 @@ func NewProxy(
 	routeServiceHandler := handlers.NewRouteService(routeServiceConfig, registry, logger)
 
 	zipkinHandler := handlers.NewZipkin(cfg.Tracing.EnableZipkin, logger)
+	w3cHandler := handlers.NewW3C(cfg.Tracing.EnableW3C, cfg.Tracing.W3CTenantID, logger)
 
 	headersToLog := utils.CollectHeadersToLog(
 		cfg.ExtraHeadersToLog,
 		zipkinHandler.HeadersToLog(),
+		w3cHandler.HeadersToLog(),
 	)
 
 	n := negroni.New()
@@ -163,6 +165,7 @@ func NewProxy(
 	}
 	n.Use(handlers.NewProxyHealthcheck(cfg.HealthCheckUserAgent, p.health, logger))
 	n.Use(zipkinHandler)
+	n.Use(w3cHandler)
 	n.Use(handlers.NewProtocolCheck(logger))
 	n.Use(handlers.NewLookup(registry, reporter, logger))
 	n.Use(handlers.NewClientCert(

--- a/proxy/utils/logging.go
+++ b/proxy/utils/logging.go
@@ -1,0 +1,26 @@
+package utils
+
+// CollectHeadersToLog returns an ordered slice of slices of headers to be
+// logged and returns a unique, ordered slice of headers to be logged
+func CollectHeadersToLog(headerGroups ...[]string) []string {
+	// We want the headers to be ordered, so we need a slice and a map
+	var (
+		collectedHeaders = make([]string, 0)
+		seenHeaders      = make(map[string]bool)
+	)
+
+	for _, headerGroup := range headerGroups {
+		for _, header := range headerGroup {
+
+			if _, seen := seenHeaders[header]; !seen {
+
+				seenHeaders[header] = true
+				collectedHeaders = append(collectedHeaders, header)
+
+			}
+		}
+
+	}
+
+	return collectedHeaders
+}

--- a/proxy/utils/logging_test.go
+++ b/proxy/utils/logging_test.go
@@ -1,0 +1,62 @@
+package utils_test
+
+import (
+	"code.cloudfoundry.org/gorouter/proxy/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CollectHeadersToLog", func() {
+	Context("when there are no headers to be logged", func() {
+		It("returns no headers", func() {
+			Expect(utils.CollectHeadersToLog()).To(HaveLen(0))
+		})
+	})
+
+	Context("when there are some headers to be logged", func() {
+		It("returns the headers in order", func() {
+			headersToLog := utils.CollectHeadersToLog(
+				[]string{"X-Forwarded-For", "Host", "Content-Length"},
+			)
+
+			Expect(headersToLog).To(HaveLen(3))
+			Expect(headersToLog[0]).To(Equal("X-Forwarded-For"))
+			Expect(headersToLog[1]).To(Equal("Host"))
+			Expect(headersToLog[2]).To(Equal("Content-Length"))
+		})
+	})
+
+	Context("when there are multiple groups of headers to be logged", func() {
+		Context("when there are no duplicates", func() {
+			It("returns the headers in order", func() {
+				headersToLog := utils.CollectHeadersToLog(
+					[]string{"X-Forwarded-For", "Host", "Content-Length"},
+					[]string{"X-Forwarded-Proto", "Content-Type"},
+				)
+
+				Expect(headersToLog).To(HaveLen(5))
+				Expect(headersToLog[0]).To(Equal("X-Forwarded-For"))
+				Expect(headersToLog[1]).To(Equal("Host"))
+				Expect(headersToLog[2]).To(Equal("Content-Length"))
+				Expect(headersToLog[3]).To(Equal("X-Forwarded-Proto"))
+				Expect(headersToLog[4]).To(Equal("Content-Type"))
+			})
+		})
+		Context("when there are duplicates", func() {
+			It("returns the headers in order", func() {
+				headersToLog := utils.CollectHeadersToLog(
+					[]string{"X-Forwarded-For", "Host", "Content-Length"},
+					[]string{"X-Forwarded-Proto", "Content-Type", "Host"},
+				)
+
+				Expect(headersToLog).To(HaveLen(5))
+				Expect(headersToLog[0]).To(Equal("X-Forwarded-For"))
+				Expect(headersToLog[1]).To(Equal("Host"))
+				Expect(headersToLog[2]).To(Equal("Content-Length"))
+				Expect(headersToLog[3]).To(Equal("X-Forwarded-Proto"))
+				Expect(headersToLog[4]).To(Equal("Content-Type"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
### A short explanation of the proposed change:

Add support for [W3C tracing headers](https://www.w3.org/TR/trace-context/) as requested in https://github.com/cloudfoundry/gorouter/issues/260

I have chosen to follow Go convention and use canonicalised headers `Traceparent` and `Tracestate` instead of rigorously following the spec (which supports `Traceparent` and `traceparent` but prefers the latter).

I have implemented this such that there are no interactions with the existing Zipkin headers, in order to reduce complexity.

I have added new configuration parameters, under the tracing section:

- `enable_w3c` - which controls whether W3C headers are added
- `w3c_tenant_id` - which is an optional parameter which species the tenant ID
  - if not specified the gorouter's tracestate is `gorouter`
  - if it is specified then it is prepended: e.g. `my-tenant-id@gorouter`

I have slightly refactored how headers get logged, because before it was kind of Zipkin specific.

### Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

Run the tests

Deploy gorouter and observe the new headers using `curl`, any requests to Gorouter should set the `Traceparent` and `Tracestate` headers, similar to `X-Vcap-Request-Id`

### Expected result after the change

When making requests to Gorouter, there should be the `Traceparent` and `Tracestate` headers set, in accordance with the W3C spec.

### Current result before the change

There are no interactions with the `Traceparent` and `Tracestate` headers

### Checklist

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bin/test`

* [ ] I have run CF Acceptance Tests on bosh lite
