### PR TITLE
Set vcap_id SameSite value based on JSESSIONID

### DIFF
--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -294,6 +294,7 @@ func setupStickySession(
 ) {
 	secure := false
 	maxAge := 0
+	sameSite := http.SameSite(0)
 
 	// did the endpoint change?
 	sticky := originalEndpointId != "" && originalEndpointId != endpoint.PrivateInstanceId
@@ -305,6 +306,7 @@ func setupStickySession(
 				maxAge = v.MaxAge
 			}
 			secure = v.Secure
+			sameSite = v.SameSite
 			break
 		}
 	}
@@ -330,6 +332,7 @@ func setupStickySession(
 			MaxAge:   maxAge,
 			HttpOnly: true,
 			Secure:   secure,
+			SameSite: sameSite,
 		}
 
 		if v := cookie.String(); v != "" {


### PR DESCRIPTION
Thanks for contributing to gorouter. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Set the "SameSite" value of the `__VCAP_ID__` cookie based on the value of the `JSESSIONID` cookie
that came back from the app.

* An explanation of the use cases your change solves

Currently, gorouter does not set a value for "SameSite" at all. Some browsers (eg. Chrome, see https://www.chromestatus.com/feature/5088147346030592) used to treat a missing value as "None" which allowed XS sending of the cookie. This default will change to "Lax" which will prevent the cookie from being sent in some use cases:
- A customer runs a CF app that embeds external content (e.g. via an iframe) which requires cookies sent to the main site be forwarded to the embedded site.

Since JSESSIONID and __VCAP_ID__ are tightly coupled, I propose to add the "SameSite" value of JSESSIONID to __VCAP_ID__, just as we do for "secure" and "maxAge".

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

`curl -v https://my-app-that-sets-JSESSIONID.com`

* Expected result after the change

"curl" output should contain:

```
Set-Cookie: JSESSIONID=abc123; HttpOnly; Secure; SameSite=Lax
Set-Cookie: __VCAP_ID__=c635e2d9-3a06-45ce-54f6-dbe7; Path=/; HttpOnly; Secure; SameSite=Lax
```

* Current result before the change

"curl" output contains:

```
Set-Cookie: JSESSIONID=abc123; HttpOnly; Secure; SameSite=Lax
Set-Cookie: __VCAP_ID__=c635e2d9-3a06-45ce-54f6-dbe7; Path=/; HttpOnly; Secure
```

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bin/test`

* [x] I have run CF Acceptance Tests on bosh lite
