### PR TITLE
Allow users to HTML template error messages

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -261,6 +261,8 @@ type Config struct {
 	HTTPRewrite HTTPRewrite `yaml:"http_rewrite,omitempty"`
 
 	EmptyPoolResponseCode503 bool `yaml:"empty_pool_response_code_503,omitempty"`
+
+	HTMLErrorTemplateFile string `yaml:"html_error_template_file,omitempty"`
 }
 
 var defaultConfig = Config{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -604,6 +604,17 @@ backends:
 			Expect(err).ToNot(HaveOccurred())
 			Expect(config.DisableHTTP).To(BeTrue())
 		})
+
+		It("defaults HTMLErrorTemplateFile to empty", func() {
+			Expect(config.HTMLErrorTemplateFile).To(Equal(""))
+		})
+
+		It("sets HTMLErrorTemplateFile", func() {
+			var b = []byte(`html_error_template_file: "/path/to/file"`)
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.HTMLErrorTemplateFile).To(Equal("/path/to/file"))
+		})
 	})
 
 	Describe("Process", func() {

--- a/errorwriter/error_writer.go
+++ b/errorwriter/error_writer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"io/ioutil"
 	"net/http"
 
 	"code.cloudfoundry.org/gorouter/logger"
@@ -50,10 +51,15 @@ type htmlErrorWriter struct {
 	tpl *template.Template
 }
 
-func NewHTMLErrorWriter(text string) (ErrorWriter, error) {
+func NewHTMLErrorWriterFromFile(path string) (ErrorWriter, error) {
 	ew := &htmlErrorWriter{}
 
-	tpl, err := template.New("error-message").Parse(text)
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("Could not read HTML error template file: %s", err)
+	}
+
+	tpl, err := template.New("error-message").Parse(string(bytes))
 	if err != nil {
 		return nil, err
 	}

--- a/errorwriter/error_writer.go
+++ b/errorwriter/error_writer.go
@@ -1,4 +1,4 @@
-package handlers
+package errorwriter
 
 import (
 	"bytes"

--- a/errorwriter/error_writer_test.go
+++ b/errorwriter/error_writer_test.go
@@ -50,8 +50,16 @@ var _ = Describe("Plaintext ErrorWriter", func() {
 			Expect(message).To(Equal("status"))
 		})
 
-		It("should keep the connection header", func() {
+		It("should keep the Connection header", func() {
 			Expect(recorder.Result().Header.Get("Connection")).To(Equal("dummy"))
+		})
+
+		It("should set the Content-Type header", func() {
+			Expect(recorder.Result().Header.Get("Content-Type")).To(Equal("text/plain; charset=utf-8"))
+		})
+
+		It("should set the X-Content-Type-Options header", func() {
+			Expect(recorder.Result().Header.Get("X-Content-Type-Options")).To(Equal("nosniff"))
 		})
 	})
 
@@ -74,7 +82,7 @@ var _ = Describe("Plaintext ErrorWriter", func() {
 			Expect(message).To(Equal("status"))
 		})
 
-		It("should delete the connection header", func() {
+		It("should delete the Connection header", func() {
 			Expect(recorder.Result().Header.Get("Connection")).To(Equal(""))
 		})
 	})
@@ -155,8 +163,16 @@ var _ = Describe("HTML ErrorWriter", func() {
 				Expect(message).To(Equal("status"))
 			})
 
-			It("should keep the connection header", func() {
+			It("should keep the Connection header", func() {
 				Expect(recorder.Result().Header.Get("Connection")).To(Equal("dummy"))
+			})
+
+			It("should set the Content-Type header", func() {
+				Expect(recorder.Result().Header.Get("Content-Type")).To(Equal("text/plain; charset=utf-8"))
+			})
+
+			It("should set the X-Content-Type-Options header", func() {
+				Expect(recorder.Result().Header.Get("X-Content-Type-Options")).To(Equal("nosniff"))
 			})
 		})
 
@@ -180,8 +196,16 @@ var _ = Describe("HTML ErrorWriter", func() {
 				Eventually(BufferReader(recorder.Result().Body)).Should(Say("400 Bad Request: bad"))
 			})
 
-			It("should delete the connection header", func() {
+			It("should delete the Connection header", func() {
 				Expect(recorder.Result().Header.Get("Connection")).To(Equal(""))
+			})
+
+			It("should set the Content-Type header", func() {
+				Expect(recorder.Result().Header.Get("Content-Type")).To(Equal("text/plain; charset=utf-8"))
+			})
+
+			It("should set the X-Content-Type-Options header", func() {
+				Expect(recorder.Result().Header.Get("X-Content-Type-Options")).To(Equal("nosniff"))
 			})
 		})
 	})
@@ -214,8 +238,16 @@ var _ = Describe("HTML ErrorWriter", func() {
 				Eventually(BufferReader(recorder.Result().Body)).Should(Say("200 OK: hi"))
 			})
 
-			It("should keep the connection header", func() {
+			It("should keep the Connection header", func() {
 				Expect(recorder.Result().Header.Get("Connection")).To(Equal("dummy"))
+			})
+
+			It("should set the Content-Type header", func() {
+				Expect(recorder.Result().Header.Get("Content-Type")).To(Equal("text/html; charset=utf-8"))
+			})
+
+			It("should set the X-Content-Type-Options header", func() {
+				Expect(recorder.Result().Header.Get("X-Content-Type-Options")).To(Equal("nosniff"))
 			})
 		})
 
@@ -242,8 +274,16 @@ var _ = Describe("HTML ErrorWriter", func() {
 				Eventually(BufferReader(recorder.Result().Body)).Should(Say("400 Bad Request: bad"))
 			})
 
-			It("should delete the connection header", func() {
+			It("should delete the Connection header", func() {
 				Expect(recorder.Result().Header.Get("Connection")).To(Equal(""))
+			})
+
+			It("should set the Content-Type header", func() {
+				Expect(recorder.Result().Header.Get("Content-Type")).To(Equal("text/html; charset=utf-8"))
+			})
+
+			It("should set the X-Content-Type-Options header", func() {
+				Expect(recorder.Result().Header.Get("X-Content-Type-Options")).To(Equal("nosniff"))
 			})
 		})
 	})

--- a/errorwriter/error_writer_test.go
+++ b/errorwriter/error_writer_test.go
@@ -1,4 +1,4 @@
-package handlers_test
+package errorwriter_test
 
 import (
 	_ "html/template"
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 
-	. "code.cloudfoundry.org/gorouter/handlers"
+	. "code.cloudfoundry.org/gorouter/errorwriter"
 	loggerfakes "code.cloudfoundry.org/gorouter/logger/fakes"
 )
 

--- a/errorwriter/error_writer_test.go
+++ b/errorwriter/error_writer_test.go
@@ -217,7 +217,9 @@ var _ = Describe("HTML ErrorWriter", func() {
 
 		Context("when the response is a success", func() {
 			BeforeEach(func() {
-				_, err := tmpFile.Write([]byte(`success`))
+				_, err := tmpFile.Write([]byte(
+					`{{ .Status }} {{ .StatusText }}: {{ .Message }}`,
+				))
 				Expect(err).NotTo(HaveOccurred())
 
 				errorWriter, err = NewHTMLErrorWriterFromFile(tmpFile.Name())
@@ -234,7 +236,7 @@ var _ = Describe("HTML ErrorWriter", func() {
 				Expect(recorder.Result().StatusCode).To(Equal(http.StatusOK))
 			})
 
-			XIt("should write the message as text", func() {
+			It("should write the message as text", func() {
 				Eventually(BufferReader(recorder.Result().Body)).Should(Say("200 OK: hi"))
 			})
 
@@ -253,7 +255,9 @@ var _ = Describe("HTML ErrorWriter", func() {
 
 		Context("when the response is not a success", func() {
 			BeforeEach(func() {
-				_, err := tmpFile.Write([]byte(`failure`))
+				_, err := tmpFile.Write([]byte(
+					`{{ .Status }} {{ .StatusText }}: {{ .Message }}`,
+				))
 				Expect(err).NotTo(HaveOccurred())
 
 				errorWriter, err = NewHTMLErrorWriterFromFile(tmpFile.Name())
@@ -270,7 +274,7 @@ var _ = Describe("HTML ErrorWriter", func() {
 				Expect(recorder.Result().StatusCode).To(Equal(http.StatusBadRequest))
 			})
 
-			XIt("should write the message as text", func() {
+			It("should write the message as text", func() {
 				Eventually(BufferReader(recorder.Result().Body)).Should(Say("400 Bad Request: bad"))
 			})
 

--- a/errorwriter/errorwriter_suite_test.go
+++ b/errorwriter/errorwriter_suite_test.go
@@ -1,0 +1,13 @@
+package errorwriter_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestErrorwriter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ErrorWriter Suite")
+}

--- a/handlers/clientcert.go
+++ b/handlers/clientcert.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"code.cloudfoundry.org/gorouter/config"
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/logger"
 	"github.com/uber-go/zap"
 	"github.com/urfave/negroni"
@@ -18,7 +19,7 @@ type clientCert struct {
 	forceDeleteHeader func(req *http.Request) (bool, error)
 	forwardingMode    string
 	logger            logger.Logger
-	errorWriter       ErrorWriter
+	errorWriter       errorwriter.ErrorWriter
 }
 
 func NewClientCert(
@@ -26,7 +27,7 @@ func NewClientCert(
 	forceDeleteHeader func(req *http.Request) (bool, error),
 	forwardingMode string,
 	logger logger.Logger,
-	ew ErrorWriter,
+	ew errorwriter.ErrorWriter,
 ) negroni.Handler {
 	return &clientCert{
 		skipSanitization:  skipSanitization,

--- a/handlers/clientcert_test.go
+++ b/handlers/clientcert_test.go
@@ -34,11 +34,12 @@ var _ = Describe("Clientcert", func() {
 		errorForceDeleteHeader = func(req *http.Request) (bool, error) { return false, errors.New("forceDelete error") }
 		skipSanitization       = func(req *http.Request) bool { return true }
 		dontSkipSanitization   = func(req *http.Request) bool { return false }
+		errorWriter            = handlers.NewPlaintextErrorWriter()
 	)
 
 	DescribeTable("Client Cert Error Handling", func(forceDeleteHeaderFunc func(*http.Request) (bool, error), skipSanitizationFunc func(*http.Request) bool, errorCase string) {
 		logger := new(logger_fakes.FakeLogger)
-		clientCertHandler := handlers.NewClientCert(skipSanitizationFunc, forceDeleteHeaderFunc, config.SANITIZE_SET, logger)
+		clientCertHandler := handlers.NewClientCert(skipSanitizationFunc, forceDeleteHeaderFunc, config.SANITIZE_SET, logger, errorWriter)
 
 		nextHandlerWasCalled := false
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) { nextHandlerWasCalled = true })
@@ -72,7 +73,7 @@ var _ = Describe("Clientcert", func() {
 
 	DescribeTable("Client Cert Result", func(forceDeleteHeaderFunc func(*http.Request) (bool, error), skipSanitizationFunc func(*http.Request) bool, forwardedClientCert string, noTLSCertStrip bool, TLSCertStrip bool, mTLSCertStrip string) {
 		logger := new(logger_fakes.FakeLogger)
-		clientCertHandler := handlers.NewClientCert(skipSanitizationFunc, forceDeleteHeaderFunc, forwardedClientCert, logger)
+		clientCertHandler := handlers.NewClientCert(skipSanitizationFunc, forceDeleteHeaderFunc, forwardedClientCert, logger, errorWriter)
 
 		nextReq := &http.Request{}
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) { nextReq = r })

--- a/handlers/clientcert_test.go
+++ b/handlers/clientcert_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"code.cloudfoundry.org/gorouter/config"
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/handlers"
 	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
 	"code.cloudfoundry.org/gorouter/test_util"
@@ -34,7 +35,7 @@ var _ = Describe("Clientcert", func() {
 		errorForceDeleteHeader = func(req *http.Request) (bool, error) { return false, errors.New("forceDelete error") }
 		skipSanitization       = func(req *http.Request) bool { return true }
 		dontSkipSanitization   = func(req *http.Request) bool { return false }
-		errorWriter            = handlers.NewPlaintextErrorWriter()
+		errorWriter            = errorwriter.NewPlaintextErrorWriter()
 	)
 
 	DescribeTable("Client Cert Error Handling", func(forceDeleteHeaderFunc func(*http.Request) (bool, error), skipSanitizationFunc func(*http.Request) bool, errorCase string) {

--- a/handlers/error.go
+++ b/handlers/error.go
@@ -1,0 +1,94 @@
+package handlers
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"net/http"
+
+	"code.cloudfoundry.org/gorouter/logger"
+	"github.com/uber-go/zap"
+)
+
+type ErrorWriter interface {
+	WriteError(
+		rw http.ResponseWriter,
+		code int,
+		message string,
+		logger logger.Logger,
+	)
+}
+
+type plaintextErrorWriter struct{}
+
+func NewPlaintextErrorWriter() ErrorWriter {
+	return &plaintextErrorWriter{}
+}
+
+// WriteStatus attempts to template an error message.
+func (ew *plaintextErrorWriter) WriteError(
+	rw http.ResponseWriter,
+	code int,
+	message string,
+	logger logger.Logger,
+) {
+	body := fmt.Sprintf("%d %s: %s", code, http.StatusText(code), message)
+
+	if code != http.StatusNotFound {
+		logger.Info("status", zap.String("body", body))
+	}
+
+	if code > 299 {
+		rw.Header().Del("Connection")
+	}
+
+	rw.WriteHeader(code)
+	rw.Write([]byte(body))
+}
+
+type htmlErrorWriter struct {
+	tpl *template.Template
+}
+
+func NewHTMLErrorWriter(text string) (ErrorWriter, error) {
+	ew := &htmlErrorWriter{}
+
+	tpl, err := template.New("error-message").Parse(text)
+	if err != nil {
+		return nil, err
+	}
+	ew.tpl = tpl
+
+	return ew, nil
+}
+
+// WriteStatus attempts to template an error message.
+// If the template cannot be rendered then text will be sent instead
+// and the error will be returned even though the response has been sent
+func (ew *htmlErrorWriter) WriteError(
+	rw http.ResponseWriter,
+	code int,
+	message string,
+	logger logger.Logger,
+) {
+	body := fmt.Sprintf("%d %s: %s", code, http.StatusText(code), message)
+
+	if code != http.StatusNotFound {
+		logger.Info("status", zap.String("body", body))
+	}
+
+	if code > 299 {
+		rw.Header().Del("Connection")
+	}
+
+	rw.WriteHeader(code)
+
+	var rendered bytes.Buffer
+	if err := ew.tpl.Execute(&rendered, nil); err != nil {
+		logger.Error("render-error-failed", zap.Error(err))
+		rw.Write([]byte(body))
+		return
+	}
+
+	rw.Write(rendered.Bytes())
+}

--- a/handlers/error.go
+++ b/handlers/error.go
@@ -43,7 +43,7 @@ func (ew *plaintextErrorWriter) WriteError(
 	}
 
 	rw.WriteHeader(code)
-	rw.Write([]byte(body))
+	fmt.Fprintln(rw, body)
 }
 
 type htmlErrorWriter struct {
@@ -86,7 +86,7 @@ func (ew *htmlErrorWriter) WriteError(
 	var rendered bytes.Buffer
 	if err := ew.tpl.Execute(&rendered, nil); err != nil {
 		logger.Error("render-error-failed", zap.Error(err))
-		rw.Write([]byte(body))
+		fmt.Fprintln(rw, body)
 		return
 	}
 

--- a/handlers/error_test.go
+++ b/handlers/error_test.go
@@ -1,0 +1,211 @@
+package handlers_test
+
+import (
+	_ "html/template"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+
+	. "code.cloudfoundry.org/gorouter/handlers"
+	loggerfakes "code.cloudfoundry.org/gorouter/logger/fakes"
+)
+
+var _ = Describe("Plaintext ErrorWriter", func() {
+	var (
+		errorWriter ErrorWriter
+		recorder    *httptest.ResponseRecorder
+
+		log *loggerfakes.FakeLogger
+	)
+
+	BeforeEach(func() {
+		errorWriter = NewPlaintextErrorWriter()
+		recorder = httptest.NewRecorder()
+		recorder.Header().Set("Connection", "dummy")
+
+		log = new(loggerfakes.FakeLogger)
+	})
+
+	Context("when the response code is a success", func() {
+		BeforeEach(func() {
+			errorWriter.WriteError(recorder, http.StatusOK, "hi", log)
+		})
+
+		It("should write the status code", func() {
+			Expect(recorder.Result().StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("should write the message", func() {
+			Eventually(BufferReader(recorder.Result().Body)).Should(Say("hi"))
+		})
+
+		It("should log the message", func() {
+			Expect(log.InfoCallCount()).NotTo(Equal(0))
+			message, _ := log.InfoArgsForCall(0)
+			Expect(message).To(Equal("status"))
+		})
+
+		It("should keep the connection header", func() {
+			Expect(recorder.Result().Header.Get("Connection")).To(Equal("dummy"))
+		})
+	})
+
+	Context("when the response code is not a success", func() {
+		BeforeEach(func() {
+			errorWriter.WriteError(recorder, http.StatusBadRequest, "bad", log)
+		})
+
+		It("should write the status code", func() {
+			Expect(recorder.Result().StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("should write the message", func() {
+			Eventually(BufferReader(recorder.Result().Body)).Should(Say("bad"))
+		})
+
+		It("should log the message", func() {
+			Expect(log.InfoCallCount()).NotTo(Equal(0))
+			message, _ := log.InfoArgsForCall(0)
+			Expect(message).To(Equal("status"))
+		})
+
+		It("should delete the connection header", func() {
+			Expect(recorder.Result().Header.Get("Connection")).To(Equal(""))
+		})
+	})
+})
+
+var _ = Describe("HTML ErrorWriter", func() {
+	var (
+		errorWriter ErrorWriter
+		recorder    *httptest.ResponseRecorder
+
+		log *loggerfakes.FakeLogger
+	)
+
+	BeforeEach(func() {
+		recorder = httptest.NewRecorder()
+		recorder.Header().Set("Connection", "dummy")
+
+		log = new(loggerfakes.FakeLogger)
+	})
+
+	Context("when the template has invalid syntax", func() {
+		It("should return constructor error", func() {
+			var err error
+			_, err = NewHTMLErrorWriter("{{")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("when the template errors", func() {
+		Context("when the response is a success", func() {
+			BeforeEach(func() {
+				var err error
+				errorWriter, err = NewHTMLErrorWriter(`{{template "notexists"}}`)
+				Expect(err).NotTo(HaveOccurred())
+
+				errorWriter.WriteError(recorder, http.StatusOK, "hi", log)
+			})
+
+			It("should write the status code", func() {
+				Expect(recorder.Result().StatusCode).To(Equal(http.StatusOK))
+			})
+
+			It("should write the message as text", func() {
+				Eventually(BufferReader(recorder.Result().Body)).Should(Say("200 OK: hi"))
+			})
+
+			It("should log the message", func() {
+				Expect(log.InfoCallCount()).NotTo(Equal(0))
+				message, _ := log.InfoArgsForCall(0)
+				Expect(message).To(Equal("status"))
+			})
+
+			It("should keep the connection header", func() {
+				Expect(recorder.Result().Header.Get("Connection")).To(Equal("dummy"))
+			})
+		})
+
+		Context("when the response is not a success", func() {
+			BeforeEach(func() {
+				var err error
+				errorWriter, err = NewHTMLErrorWriter(`{{template "notexists"}}`)
+				Expect(err).NotTo(HaveOccurred())
+
+				errorWriter.WriteError(recorder, http.StatusBadRequest, "bad", log)
+			})
+
+			It("should write the status code", func() {
+				Expect(recorder.Result().StatusCode).To(Equal(http.StatusBadRequest))
+			})
+
+			It("should write the message as text", func() {
+				Eventually(BufferReader(recorder.Result().Body)).Should(Say("400 Bad Request: bad"))
+			})
+
+			It("should delete the connection header", func() {
+				Expect(recorder.Result().Header.Get("Connection")).To(Equal(""))
+			})
+		})
+	})
+
+	Context("when the template renders", func() {
+		var (
+			err error
+		)
+
+		Context("when the response is a success", func() {
+			BeforeEach(func() {
+				errorWriter, err = NewHTMLErrorWriter(`success`)
+				Expect(err).NotTo(HaveOccurred())
+
+				errorWriter.WriteError(recorder, http.StatusOK, "hi", log)
+			})
+
+			It("should not return an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should write the status code", func() {
+				Expect(recorder.Result().StatusCode).To(Equal(http.StatusOK))
+			})
+
+			XIt("should write the message as text", func() {
+				Eventually(BufferReader(recorder.Result().Body)).Should(Say("200 OK: hi"))
+			})
+
+			It("should keep the connection header", func() {
+				Expect(recorder.Result().Header.Get("Connection")).To(Equal("dummy"))
+			})
+		})
+
+		Context("when the response is not a success", func() {
+			BeforeEach(func() {
+				errorWriter, err = NewHTMLErrorWriter(`failure`)
+				Expect(err).NotTo(HaveOccurred())
+
+				errorWriter.WriteError(recorder, http.StatusBadRequest, "bad", log)
+			})
+
+			It("should not return an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should write the status code", func() {
+				Expect(recorder.Result().StatusCode).To(Equal(http.StatusBadRequest))
+			})
+
+			XIt("should write the message as text", func() {
+				Eventually(BufferReader(recorder.Result().Body)).Should(Say("400 Bad Request: bad"))
+			})
+
+			It("should delete the connection header", func() {
+				Expect(recorder.Result().Header.Get("Connection")).To(Equal(""))
+			})
+		})
+	})
+})

--- a/handlers/helpers.go
+++ b/handlers/helpers.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	router_http "code.cloudfoundry.org/gorouter/common/http"
-	"code.cloudfoundry.org/gorouter/logger"
-	"github.com/uber-go/zap"
 )
 
 const (
@@ -30,19 +28,6 @@ func addNoCacheControlHeader(rw http.ResponseWriter) {
 		"Cache-Control",
 		"no-cache, no-store",
 	)
-}
-
-func writeStatus(rw http.ResponseWriter, code int, message string, logger logger.Logger) {
-	body := fmt.Sprintf("%d %s: %s", code, http.StatusText(code), message)
-
-	if code != 404 {
-		logger.Info("status", zap.String("body", body))
-	}
-
-	http.Error(rw, body, code)
-	if code > 299 {
-		rw.Header().Del("Connection")
-	}
 }
 
 func hostWithoutPort(reqHost string) string {

--- a/handlers/lookup.go
+++ b/handlers/lookup.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	router_http "code.cloudfoundry.org/gorouter/common/http"
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/logger"
 	"code.cloudfoundry.org/gorouter/metrics"
 	"code.cloudfoundry.org/gorouter/registry"
@@ -30,7 +31,7 @@ type lookupHandler struct {
 	registry                 registry.Registry
 	reporter                 metrics.ProxyReporter
 	logger                   logger.Logger
-	errorWriter              ErrorWriter
+	errorWriter              errorwriter.ErrorWriter
 	EmptyPoolResponseCode503 bool
 }
 
@@ -39,7 +40,7 @@ func NewLookup(
 	registry registry.Registry,
 	rep metrics.ProxyReporter,
 	logger logger.Logger,
-	ew ErrorWriter,
+	ew errorwriter.ErrorWriter,
 	emptyPoolResponseCode503 bool,
 ) negroni.Handler {
 	return &lookupHandler{

--- a/handlers/lookup_test.go
+++ b/handlers/lookup_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/handlers"
 	loggerfakes "code.cloudfoundry.org/gorouter/logger/fakes"
 	"code.cloudfoundry.org/gorouter/metrics/fakes"
@@ -30,7 +31,7 @@ var _ = Describe("Lookup", func() {
 		nextCalled     bool
 		nextRequest    *http.Request
 		maxConnections int64
-		ew             = handlers.NewPlaintextErrorWriter()
+		ew             = errorwriter.NewPlaintextErrorWriter()
 	)
 
 	const fakeAppGUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"

--- a/handlers/lookup_test.go
+++ b/handlers/lookup_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Lookup", func() {
 		nextCalled     bool
 		nextRequest    *http.Request
 		maxConnections int64
+		ew             = handlers.NewPlaintextErrorWriter()
 	)
 
 	const fakeAppGUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
@@ -50,7 +51,7 @@ var _ = Describe("Lookup", func() {
 		req = test_util.NewRequest("GET", "example.com", "/", nil)
 		resp = httptest.NewRecorder()
 		handler.Use(handlers.NewRequestInfo())
-		handler.Use(handlers.NewLookup(reg, rep, logger, true))
+		handler.Use(handlers.NewLookup(reg, rep, logger, ew, true))
 		handler.UseHandler(nextHandler)
 	})
 
@@ -172,7 +173,7 @@ var _ = Describe("Lookup", func() {
 				emptyPoolResponseCode503 := true
 				handler = negroni.New()
 				handler.Use(handlers.NewRequestInfo())
-				handler.Use(handlers.NewLookup(reg, rep, logger, emptyPoolResponseCode503))
+				handler.Use(handlers.NewLookup(reg, rep, logger, ew, emptyPoolResponseCode503))
 				handler.UseHandler(nextHandler)
 
 				pool = route.NewPool(&route.PoolOpts{
@@ -212,7 +213,7 @@ var _ = Describe("Lookup", func() {
 				emptyPoolResponseCode503 := false
 				handler = negroni.New()
 				handler.Use(handlers.NewRequestInfo())
-				handler.Use(handlers.NewLookup(reg, rep, logger, emptyPoolResponseCode503))
+				handler.Use(handlers.NewLookup(reg, rep, logger, ew, emptyPoolResponseCode503))
 				handler.UseHandler(nextHandler)
 
 				pool = route.NewPool(&route.PoolOpts{
@@ -470,7 +471,7 @@ var _ = Describe("Lookup", func() {
 		Context("when request info is not set on the request context", func() {
 			BeforeEach(func() {
 				handler = negroni.New()
-				handler.Use(handlers.NewLookup(reg, rep, logger, true))
+				handler.Use(handlers.NewLookup(reg, rep, logger, ew, true))
 				handler.UseHandler(nextHandler)
 
 				pool := route.NewPool(&route.PoolOpts{

--- a/handlers/protocolcheck.go
+++ b/handlers/protocolcheck.go
@@ -13,14 +13,16 @@ import (
 )
 
 type protocolCheck struct {
-	logger logger.Logger
+	logger      logger.Logger
+	errorWriter ErrorWriter
 }
 
 // NewProtocolCheck creates a handler responsible for checking the protocol of
 // the request
-func NewProtocolCheck(logger logger.Logger) negroni.Handler {
+func NewProtocolCheck(logger logger.Logger, errorWriter ErrorWriter) negroni.Handler {
 	return &protocolCheck{
-		logger: logger,
+		logger:      logger,
+		errorWriter: errorWriter,
 	}
 }
 
@@ -29,7 +31,7 @@ func (p *protocolCheck) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 		// must be hijacked, otherwise no response is sent back
 		conn, buf, err := p.hijack(rw)
 		if err != nil {
-			writeStatus(
+			p.errorWriter.WriteError(
 				rw,
 				http.StatusBadRequest,
 				"Unsupported protocol",

--- a/handlers/protocolcheck.go
+++ b/handlers/protocolcheck.go
@@ -8,18 +8,19 @@ import (
 
 	"fmt"
 
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/logger"
 	"github.com/urfave/negroni"
 )
 
 type protocolCheck struct {
 	logger      logger.Logger
-	errorWriter ErrorWriter
+	errorWriter errorwriter.ErrorWriter
 }
 
 // NewProtocolCheck creates a handler responsible for checking the protocol of
 // the request
-func NewProtocolCheck(logger logger.Logger, errorWriter ErrorWriter) negroni.Handler {
+func NewProtocolCheck(logger logger.Logger, errorWriter errorwriter.ErrorWriter) negroni.Handler {
 	return &protocolCheck{
 		logger:      logger,
 		errorWriter: errorWriter,

--- a/handlers/protocolcheck_test.go
+++ b/handlers/protocolcheck_test.go
@@ -17,7 +17,9 @@ import (
 
 var _ = Describe("Protocolcheck", func() {
 	var (
-		logger     logger.Logger
+		logger logger.Logger
+		ew     = handlers.NewPlaintextErrorWriter()
+
 		nextCalled bool
 		server     *ghttp.Server
 		n          *negroni.Negroni
@@ -31,7 +33,7 @@ var _ = Describe("Protocolcheck", func() {
 		n.UseFunc(func(rw http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
 			next(rw, req)
 		})
-		n.Use(handlers.NewProtocolCheck(logger))
+		n.Use(handlers.NewProtocolCheck(logger, ew))
 		n.UseHandlerFunc(func(http.ResponseWriter, *http.Request) {
 			nextCalled = true
 		})

--- a/handlers/protocolcheck_test.go
+++ b/handlers/protocolcheck_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/handlers"
 	"code.cloudfoundry.org/gorouter/logger"
 	"code.cloudfoundry.org/gorouter/test_util"
@@ -18,7 +19,7 @@ import (
 var _ = Describe("Protocolcheck", func() {
 	var (
 		logger logger.Logger
-		ew     = handlers.NewPlaintextErrorWriter()
+		ew     = errorwriter.NewPlaintextErrorWriter()
 
 		nextCalled bool
 		server     *ghttp.Server

--- a/handlers/routeservice.go
+++ b/handlers/routeservice.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/logger"
 	"code.cloudfoundry.org/gorouter/registry"
 	"code.cloudfoundry.org/gorouter/routeservice"
@@ -19,7 +20,7 @@ type RouteService struct {
 	config      *routeservice.RouteServiceConfig
 	registry    registry.Registry
 	logger      logger.Logger
-	errorWriter ErrorWriter
+	errorWriter errorwriter.ErrorWriter
 }
 
 // NewRouteService creates a handler responsible for handling route services
@@ -27,7 +28,7 @@ func NewRouteService(
 	config *routeservice.RouteServiceConfig,
 	routeRegistry registry.Registry,
 	logger logger.Logger,
-	errorWriter ErrorWriter,
+	errorWriter errorwriter.ErrorWriter,
 ) negroni.Handler {
 	return &RouteService{
 		config:      config,

--- a/handlers/routeservice_test.go
+++ b/handlers/routeservice_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/gorouter/common/secure"
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/handlers"
 	"code.cloudfoundry.org/gorouter/route"
 	"code.cloudfoundry.org/gorouter/routeservice"
@@ -38,7 +39,7 @@ var _ = Describe("Route Service Handler", func() {
 		forwardedUrl string
 
 		logger *loggerfakes.FakeLogger
-		ew     = handlers.NewPlaintextErrorWriter()
+		ew     = errorwriter.NewPlaintextErrorWriter()
 
 		reqChan chan *http.Request
 

--- a/handlers/routeservice_test.go
+++ b/handlers/routeservice_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Route Service Handler", func() {
 		forwardedUrl string
 
 		logger *loggerfakes.FakeLogger
+		ew     = handlers.NewPlaintextErrorWriter()
 
 		reqChan chan *http.Request
 
@@ -109,7 +110,7 @@ var _ = Describe("Route Service Handler", func() {
 		handler = negroni.New()
 		handler.Use(handlers.NewRequestInfo())
 		handler.UseFunc(testSetupHandler)
-		handler.Use(handlers.NewRouteService(config, reg, logger))
+		handler.Use(handlers.NewRouteService(config, reg, logger, ew))
 		handler.UseHandlerFunc(nextHandler)
 	})
 
@@ -594,7 +595,7 @@ var _ = Describe("Route Service Handler", func() {
 		var badHandler *negroni.Negroni
 		BeforeEach(func() {
 			badHandler = negroni.New()
-			badHandler.Use(handlers.NewRouteService(config, reg, logger))
+			badHandler.Use(handlers.NewRouteService(config, reg, logger, ew))
 			badHandler.UseHandlerFunc(nextHandler)
 		})
 		It("calls Fatal on the logger", func() {
@@ -609,7 +610,7 @@ var _ = Describe("Route Service Handler", func() {
 		BeforeEach(func() {
 			badHandler = negroni.New()
 			badHandler.Use(handlers.NewRequestInfo())
-			badHandler.Use(handlers.NewRouteService(config, reg, logger))
+			badHandler.Use(handlers.NewRouteService(config, reg, logger, ew))
 			badHandler.UseHandlerFunc(nextHandler)
 		})
 		It("calls Fatal on the logger", func() {

--- a/integration/backend_keepalive_test.go
+++ b/integration/backend_keepalive_test.go
@@ -49,7 +49,7 @@ var _ = Describe("KeepAlive (HTTP Persistent Connections) to backends", func() {
 		BeforeEach(func() {
 			testState.cfg.DisableKeepAlives = true
 
-			testState.StartGorouter()
+			testState.StartGorouterOrFail()
 			testApp.Start()
 			testState.register(testApp.Server, testAppRoute)
 			Expect(testApp.GetConnStates()).To(BeEmpty())
@@ -84,7 +84,7 @@ var _ = Describe("KeepAlive (HTTP Persistent Connections) to backends", func() {
 	Context("when KeepAlives are enabled", func() {
 		BeforeEach(func() {
 			testState.cfg.DisableKeepAlives = false
-			testState.StartGorouter()
+			testState.StartGorouterOrFail()
 		})
 
 		Context("when connecting to a non-TLS backend", func() {

--- a/integration/error_writer_test.go
+++ b/integration/error_writer_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Error Writers", func() {
 			)
 
 			BeforeEach(func() {
-				tpl := `<html><body>an error message</body></html>`
+				tpl := `<html><body>{{ .Message }}</body></html>`
 
 				var err error
 				tmpFile, err = ioutil.TempFile(os.TempDir(), "html-err-tpl")
@@ -117,10 +117,10 @@ var _ = Describe("Error Writers", func() {
 
 				Expect(statusCode).To(Equal(404))
 
-				Expect(string(body)).To(Equal(
-					// FIXME
-					"<html><body>an error message</body></html>",
-				))
+				Expect(string(body)).To(Equal(fmt.Sprintf(
+					"<html><body>Requested route (&#39;not-%s&#39;) does not exist.</body></html>",
+					hostname,
+				)))
 			})
 		})
 	})

--- a/integration/error_writer_test.go
+++ b/integration/error_writer_test.go
@@ -1,0 +1,127 @@
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Error Writers", func() {
+	const (
+		hostname = "error-writers.cloudfoundry.org"
+	)
+
+	var (
+		testState *testState
+
+		statusCode int
+		body       []byte
+
+		doRequest = func() {
+			req := testState.newRequest(fmt.Sprintf("http://not-%s", hostname))
+
+			resp, err := testState.client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+
+			statusCode = resp.StatusCode
+
+			body, err = ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp.Body.Close()
+		}
+	)
+
+	BeforeEach(func() {
+		testState = NewTestState()
+	})
+
+	AfterEach(func() {
+		testState.StopAndCleanup()
+	})
+
+	Context("when using plaintext error writer", func() {
+		BeforeEach(func() {
+		})
+
+		JustBeforeEach(func() {
+			testState.StartGorouterOrFail()
+		})
+
+		BeforeEach(func() {
+			testState.cfg.HTMLErrorTemplateFile = ""
+		})
+
+		It("responds with a plaintext error message", func() {
+			doRequest()
+
+			Expect(statusCode).To(Equal(404))
+
+			Expect(string(body)).To(Equal(fmt.Sprintf(
+				"404 Not Found: Requested route ('not-%s') does not exist.\n",
+				hostname,
+			)))
+		})
+	})
+
+	Context("when using HTML error writer", func() {
+		Context("when the template does not exist", func() {
+			BeforeEach(func() {
+				testState.cfg.HTMLErrorTemplateFile = "/path/to/non/file"
+			})
+
+			It("should log a fatal error", func() {
+				session := testState.StartGorouter()
+
+				Eventually(session).Should(Say("Could not read HTML error template file"))
+				Eventually(session).Should(Say("/path/to/non/file"))
+
+				Eventually(session).Should(Exit())
+				Expect(session.ExitCode()).To(Equal(1))
+			})
+		})
+
+		Context("when the template exists", func() {
+			var (
+				tmpFile *os.File
+			)
+
+			BeforeEach(func() {
+				tpl := `<html><body>an error message</body></html>`
+
+				var err error
+				tmpFile, err = ioutil.TempFile(os.TempDir(), "html-err-tpl")
+				Expect(err).NotTo(HaveOccurred())
+
+				testState.cfg.HTMLErrorTemplateFile = tmpFile.Name()
+
+				_, err = tmpFile.Write([]byte(tpl))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			JustBeforeEach(func() {
+				testState.StartGorouterOrFail()
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("responds with a templated error message", func() {
+				doRequest()
+
+				Expect(statusCode).To(Equal(404))
+
+				Expect(string(body)).To(Equal(
+					// FIXME
+					"<html><body>an error message</body></html>",
+				))
+			})
+		})
+	})
+})

--- a/integration/gdpr_test.go
+++ b/integration/gdpr_test.go
@@ -41,7 +41,7 @@ var _ = Describe("GDPR", func() {
 			testState.cfg.AccessLog.File = filepath.Join(accessLog, "access.log")
 
 			testState.cfg.Logging.DisableLogForwardedFor = true
-			testState.StartGorouter()
+			testState.StartGorouterOrFail()
 
 			testApp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
@@ -74,7 +74,7 @@ var _ = Describe("GDPR", func() {
 			testState.cfg.Status.User = "user"
 			testState.cfg.Status.Port = 6705
 			testState.cfg.Logging.DisableLogForwardedFor = true
-			testState.StartGorouter()
+			testState.StartGorouterOrFail()
 
 			wsApp := test.NewWebSocketApp([]route.Uri{"ws-app." + test_util.LocalhostDNS}, testState.cfg.Port, testState.mbusClient, time.Millisecond, "")
 			wsApp.Register()
@@ -118,7 +118,7 @@ var _ = Describe("GDPR", func() {
 			testState.cfg.AccessLog.File = filepath.Join(accessLog, "access.log")
 
 			testState.cfg.Logging.DisableLogSourceIP = true
-			testState.StartGorouter()
+			testState.StartGorouterOrFail()
 
 			testApp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
@@ -147,7 +147,7 @@ var _ = Describe("GDPR", func() {
 			testState.cfg.Status.User = "user"
 			testState.cfg.Status.Port = 6706
 			testState.cfg.Logging.DisableLogSourceIP = true
-			testState.StartGorouter()
+			testState.StartGorouterOrFail()
 
 			wsApp := test.NewWebSocketApp([]route.Uri{"ws-app." + test_util.LocalhostDNS}, testState.cfg.Port, testState.mbusClient, time.Millisecond, "")
 			wsApp.Register()

--- a/integration/header_test.go
+++ b/integration/header_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Headers", func() {
 
 	Context("Sanity Test", func() {
 		BeforeEach(func() {
-			testState.StartGorouter()
+			testState.StartGorouterOrFail()
 			testApp.Start()
 			testState.register(testApp.Server, testAppRoute)
 		})
@@ -72,7 +72,7 @@ var _ = Describe("Headers", func() {
 					},
 				}
 
-			testState.StartGorouter()
+			testState.StartGorouterOrFail()
 			testApp.Start()
 			testState.register(testApp.Server, testAppRoute)
 		})
@@ -104,7 +104,7 @@ var _ = Describe("Headers", func() {
 					},
 				}
 
-			testState.StartGorouter()
+			testState.StartGorouterOrFail()
 			testApp.Start()
 			testState.register(testApp.Server, testAppRoute)
 		})
@@ -130,7 +130,7 @@ var _ = Describe("Headers", func() {
 
 		BeforeEach(func() {
 
-			testState.StartGorouter()
+			testState.StartGorouterOrFail()
 			testApp.Start()
 			testState.register(testApp.Server, testAppRoute)
 		})

--- a/integration/large_upload_test.go
+++ b/integration/large_upload_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Large upload", func() {
 
 	BeforeEach(func() {
 		testState = NewTestState()
-		testState.StartGorouter()
+		testState.StartGorouterOrFail()
 	})
 
 	AfterEach(func() {

--- a/integration/perf_test.go
+++ b/integration/perf_test.go
@@ -9,6 +9,7 @@ import (
 
 	"code.cloudfoundry.org/gorouter/accesslog"
 	"code.cloudfoundry.org/gorouter/config"
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/metrics"
 	"code.cloudfoundry.org/gorouter/proxy"
 	"code.cloudfoundry.org/gorouter/registry"
@@ -39,10 +40,12 @@ var _ = Describe("AccessLogRecord", func() {
 		accesslog, err := accesslog.CreateRunningAccessLogger(logger, ls, c)
 		Expect(err).ToNot(HaveOccurred())
 
+		ew := errorwriter.NewPlaintextErrorWriter()
+
 		rss, err := router.NewRouteServicesServer()
 		Expect(err).ToNot(HaveOccurred())
 		var h *health.Health
-		proxy.NewProxy(logger, accesslog, c, r, combinedReporter, &routeservice.RouteServiceConfig{},
+		proxy.NewProxy(logger, accesslog, ew, c, r, combinedReporter, &routeservice.RouteServiceConfig{},
 			&tls.Config{}, &tls.Config{}, h, rss.GetRoundTripper())
 
 		b.Time("RegisterTime", func() {

--- a/integration/redirect_test.go
+++ b/integration/redirect_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Headers", func() {
 
 	Context("When an app returns a 3xx-redirect", func() {
 		BeforeEach(func() {
-			testState.StartGorouter()
+			testState.StartGorouterOrFail()
 			testApp.Start()
 			testState.register(testApp.Server, testAppRoute)
 		})

--- a/integration/route_services_test.go
+++ b/integration/route_services_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Route services", func() {
 	BeforeEach(func() {
 		testState = NewTestState()
 
-		testState.StartGorouter()
+		testState.StartGorouterOrFail()
 	})
 
 	AfterEach(func() {

--- a/integration/tls_to_backends_test.go
+++ b/integration/tls_to_backends_test.go
@@ -33,7 +33,7 @@ var _ = Describe("TLS to backends", func() {
 
 		testState = NewTestState()
 		testState.cfg.AccessLog.File = filepath.Join(accessLog, "access.log")
-		testState.StartGorouter()
+		testState.StartGorouterOrFail()
 	})
 
 	AfterEach(func() {

--- a/integration/w3c_tracing_test.go
+++ b/integration/w3c_tracing_test.go
@@ -48,7 +48,7 @@ var _ = Describe("W3C tracing headers", func() {
 	})
 
 	JustBeforeEach(func() {
-		testState.StartGorouter()
+		testState.StartGorouterOrFail()
 
 		testApp = httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/integration/web_socket_test.go
+++ b/integration/web_socket_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Websockets", func() {
 
 		testState = NewTestState()
 		testState.cfg.AccessLog.File = filepath.Join(accessLog, "access.log")
-		testState.StartGorouter()
+		testState.StartGorouterOrFail()
 	})
 
 	AfterEach(func() {

--- a/integration/x_forwarded_proto_integration_test.go
+++ b/integration/x_forwarded_proto_integration_test.go
@@ -94,7 +94,7 @@ var _ = Describe("modifications of X-Forwarded-Proto header", func() {
 		It(fmt.Sprintf("gorouter config %+v: sets the headers correctly", goroutercfg), func() {
 			testState.cfg.ForceForwardedProtoHttps = goroutercfg.forceForwardedProtoHTTPS
 			testState.cfg.SanitizeForwardedProto = goroutercfg.sanitizeForwardedProto
-			testState.StartGorouter()
+			testState.StartGorouterOrFail()
 
 			doRequest := func(testCase testCase, hostname string) {
 				req := testState.newRequest(fmt.Sprintf("%s://%s", testCase.clientRequestScheme, hostname))
@@ -206,7 +206,7 @@ var _ = Describe("modifications of X-Forwarded-Proto header", func() {
 				hostname := "basic-app.some.domain"
 				testState.cfg.ForceForwardedProtoHttps = goroutercfg.forceForwardedProtoHTTPS
 				testState.cfg.SanitizeForwardedProto = goroutercfg.sanitizeForwardedProto
-				testState.StartGorouter()
+				testState.StartGorouterOrFail()
 
 				doRequest := func(testCase rsTestCase, hostname string) {
 					req := testState.newRequest(fmt.Sprintf("%s://%s", testCase.clientRequestScheme, hostname))

--- a/integration/xfcc_integration_test.go
+++ b/integration/xfcc_integration_test.go
@@ -113,7 +113,7 @@ var _ = Describe("modifications of X-Forwarded-Client-Cert", func() {
 					testState.cfg.RouteServiceRecommendHttps = true
 				}
 
-				testState.StartGorouter()
+				testState.StartGorouterOrFail()
 
 				doRequest := func(scheme, hostname string, addXFCCHeader bool) {
 					req := testState.newRequest(fmt.Sprintf("%s://%s", scheme, hostname))

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"code.cloudfoundry.org/gorouter/common/schema"
 	"code.cloudfoundry.org/gorouter/common/secure"
 	"code.cloudfoundry.org/gorouter/config"
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	goRouterLogger "code.cloudfoundry.org/gorouter/logger"
 	"code.cloudfoundry.org/gorouter/mbus"
 	"code.cloudfoundry.org/gorouter/metrics"
@@ -170,10 +171,14 @@ func main() {
 		logger.Fatal("new-route-services-server", zap.Error(err))
 	}
 
+	// TODO make configurable
+	ew := errorwriter.NewPlaintextErrorWriter()
+
 	h = &health.Health{}
 	proxy := proxy.NewProxy(
 		logger,
 		accessLogger,
+		ew,
 		c,
 		registry,
 		compositeReporter,

--- a/main.go
+++ b/main.go
@@ -77,6 +77,16 @@ func main() {
 	logger, minLagerLogLevel := createLogger(prefix, c.Logging.Level, c.Logging.Format.Timestamp)
 	logger.Info("starting")
 
+	var ew errorwriter.ErrorWriter
+	if c.HTMLErrorTemplateFile != "" {
+		ew, err = errorwriter.NewHTMLErrorWriterFromFile(c.HTMLErrorTemplateFile)
+		if err != nil {
+			logger.Fatal("new-html-error-template-from-file", zap.Error(err))
+		}
+	} else {
+		ew = errorwriter.NewPlaintextErrorWriter()
+	}
+
 	err = dropsonde.Initialize(c.Logging.MetronAddress, c.Logging.JobName)
 	if err != nil {
 		logger.Fatal("dropsonde-initialize-error", zap.Error(err))
@@ -170,9 +180,6 @@ func main() {
 	if err != nil {
 		logger.Fatal("new-route-services-server", zap.Error(err))
 	}
-
-	// TODO make configurable
-	ew := errorwriter.NewPlaintextErrorWriter()
 
 	h = &health.Health{}
 	proxy := proxy.NewProxy(

--- a/proxy/handler/request_handler.go
+++ b/proxy/handler/request_handler.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"strconv"
@@ -27,8 +26,9 @@ const (
 var NoEndpointsAvailable = errors.New("No endpoints available")
 
 type RequestHandler struct {
-	logger   logger.Logger
-	reporter metrics.ProxyReporter
+	logger      logger.Logger
+	errorWriter handlers.ErrorWriter
+	reporter    metrics.ProxyReporter
 
 	request  *http.Request
 	response utils.ProxyResponseWriter
@@ -42,8 +42,18 @@ type RequestHandler struct {
 	disableSourceIPLogging bool
 }
 
-func NewRequestHandler(request *http.Request, response utils.ProxyResponseWriter, r metrics.ProxyReporter, logger logger.Logger, endpointDialTimeout time.Duration, tlsConfig *tls.Config, opts ...func(*RequestHandler)) *RequestHandler {
+func NewRequestHandler(
+	request *http.Request,
+	response utils.ProxyResponseWriter,
+	r metrics.ProxyReporter,
+	logger logger.Logger,
+	errorWriter handlers.ErrorWriter,
+	endpointDialTimeout time.Duration,
+	tlsConfig *tls.Config,
+	opts ...func(*RequestHandler),
+) *RequestHandler {
 	reqHandler := &RequestHandler{
+		errorWriter:         errorWriter,
 		reporter:            r,
 		request:             request,
 		response:            response,
@@ -107,7 +117,7 @@ func (h *RequestHandler) HandleBadGateway(err error, request *http.Request) {
 
 	handlers.AddRouterErrorHeader(h.response, "endpoint_failure")
 
-	h.writeStatus(http.StatusBadGateway, "Registered endpoint failed to handle the request.")
+	h.errorWriter.WriteError(h.response, http.StatusBadGateway, "Registered endpoint failed to handle the request.", h.logger)
 	h.response.Done()
 }
 
@@ -118,7 +128,7 @@ func (h *RequestHandler) HandleTcpRequest(iter route.EndpointIterator) {
 	backendStatusCode, err := h.serveTcp(iter, nil, onConnectionFailed)
 	if err != nil {
 		h.logger.Error("tcp-request-failed", zap.Error(err))
-		h.writeStatus(http.StatusBadGateway, "TCP forwarding to endpoint failed.")
+		h.errorWriter.WriteError(h.response, http.StatusBadGateway, "TCP forwarding to endpoint failed.", h.logger)
 		return
 	}
 	h.response.SetStatus(backendStatusCode)
@@ -141,24 +151,13 @@ func (h *RequestHandler) HandleWebSocketRequest(iter route.EndpointIterator) {
 
 	if err != nil {
 		h.logger.Error("websocket-request-failed", zap.Error(err))
-		h.writeStatus(http.StatusBadGateway, "WebSocket request to endpoint failed.")
+		h.errorWriter.WriteError(h.response, http.StatusBadGateway, "WebSocket request to endpoint failed.", h.logger)
 		h.reporter.CaptureWebSocketFailure()
 		return
 	}
 
 	h.response.SetStatus(backendStatusCode)
 	h.reporter.CaptureWebSocketUpdate()
-}
-
-func (h *RequestHandler) writeStatus(code int, message string) {
-	body := fmt.Sprintf("%d %s: %s", code, http.StatusText(code), message)
-
-	h.logger.Info("status", zap.String("body", body))
-
-	http.Error(h.response, body, code)
-	if code > 299 {
-		h.response.Header().Del("Connection")
-	}
 }
 
 type connSuccessCB func(net.Conn, *route.Endpoint) error

--- a/proxy/handler/request_handler.go
+++ b/proxy/handler/request_handler.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	router_http "code.cloudfoundry.org/gorouter/common/http"
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/handlers"
 	"code.cloudfoundry.org/gorouter/logger"
 	"code.cloudfoundry.org/gorouter/metrics"
@@ -27,7 +28,7 @@ var NoEndpointsAvailable = errors.New("No endpoints available")
 
 type RequestHandler struct {
 	logger      logger.Logger
-	errorWriter handlers.ErrorWriter
+	errorWriter errorwriter.ErrorWriter
 	reporter    metrics.ProxyReporter
 
 	request  *http.Request
@@ -47,7 +48,7 @@ func NewRequestHandler(
 	response utils.ProxyResponseWriter,
 	r metrics.ProxyReporter,
 	logger logger.Logger,
-	errorWriter handlers.ErrorWriter,
+	errorWriter errorwriter.ErrorWriter,
 	endpointDialTimeout time.Duration,
 	tlsConfig *tls.Config,
 	opts ...func(*RequestHandler),

--- a/proxy/handler/request_handler_test.go
+++ b/proxy/handler/request_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"time"
 
+	"code.cloudfoundry.org/gorouter/handlers"
 	metric "code.cloudfoundry.org/gorouter/metrics/fakes"
 	"code.cloudfoundry.org/gorouter/proxy/handler"
 	"code.cloudfoundry.org/gorouter/proxy/utils"
@@ -22,6 +23,7 @@ var _ = Describe("RequestHandler", func() {
 	var (
 		rh     *handler.RequestHandler
 		logger *test_util.TestZapLogger
+		ew     = handlers.NewPlaintextErrorWriter()
 		req    *http.Request
 		pr     utils.ProxyResponseWriter
 	)
@@ -45,7 +47,7 @@ var _ = Describe("RequestHandler", func() {
 			}
 			rh = handler.NewRequestHandler(
 				req, pr,
-				&metric.FakeProxyReporter{}, logger,
+				&metric.FakeProxyReporter{}, logger, ew,
 				time.Second*2, &tls.Config{},
 				handler.DisableXFFLogging(true),
 			)
@@ -93,7 +95,7 @@ var _ = Describe("RequestHandler", func() {
 			}
 			rh = handler.NewRequestHandler(
 				req, pr,
-				&metric.FakeProxyReporter{}, logger,
+				&metric.FakeProxyReporter{}, logger, ew,
 				time.Second*2, &tls.Config{},
 				handler.DisableSourceIPLogging(true),
 			)

--- a/proxy/handler/request_handler_test.go
+++ b/proxy/handler/request_handler_test.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"time"
 
-	"code.cloudfoundry.org/gorouter/handlers"
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	metric "code.cloudfoundry.org/gorouter/metrics/fakes"
 	"code.cloudfoundry.org/gorouter/proxy/handler"
 	"code.cloudfoundry.org/gorouter/proxy/utils"
@@ -23,7 +23,7 @@ var _ = Describe("RequestHandler", func() {
 	var (
 		rh     *handler.RequestHandler
 		logger *test_util.TestZapLogger
-		ew     = handlers.NewPlaintextErrorWriter()
+		ew     = errorwriter.NewPlaintextErrorWriter()
 		req    *http.Request
 		pr     utils.ProxyResponseWriter
 	)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -14,6 +14,7 @@ import (
 	"code.cloudfoundry.org/gorouter/accesslog"
 	router_http "code.cloudfoundry.org/gorouter/common/http"
 	"code.cloudfoundry.org/gorouter/config"
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/handlers"
 	"code.cloudfoundry.org/gorouter/logger"
 	"code.cloudfoundry.org/gorouter/metrics"
@@ -41,7 +42,7 @@ type proxy struct {
 	ip                       string
 	traceKey                 string
 	logger                   logger.Logger
-	errorWriter              handlers.ErrorWriter
+	errorWriter              errorwriter.ErrorWriter
 	reporter                 metrics.ProxyReporter
 	accessLogger             accesslog.AccessLogger
 	secureCookies            bool
@@ -75,7 +76,7 @@ func NewProxy(
 ) http.Handler {
 
 	// TODO make configurable
-	ew := handlers.NewPlaintextErrorWriter()
+	ew := errorwriter.NewPlaintextErrorWriter()
 
 	p := &proxy{
 		accessLogger:             accessLogger,

--- a/proxy/proxy_suite_test.go
+++ b/proxy/proxy_suite_test.go
@@ -14,6 +14,7 @@ import (
 	"code.cloudfoundry.org/gorouter/accesslog"
 	"code.cloudfoundry.org/gorouter/common/secure"
 	"code.cloudfoundry.org/gorouter/config"
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/logger"
 	"code.cloudfoundry.org/gorouter/proxy"
 	"code.cloudfoundry.org/gorouter/registry"
@@ -52,6 +53,7 @@ var (
 	fakeEmitter             *fake.FakeEventEmitter
 	fakeRouteServicesClient *sharedfakes.RoundTripper
 	skipSanitization        func(req *http.Request) bool
+	ew                      = errorwriter.NewPlaintextErrorWriter()
 )
 
 func TestProxy(t *testing.T) {
@@ -128,7 +130,7 @@ var _ = JustBeforeEach(func() {
 
 	fakeRouteServicesClient = &sharedfakes.RoundTripper{}
 
-	p = proxy.NewProxy(testLogger, al, conf, r, fakeReporter, routeServiceConfig, tlsConfig, tlsConfig, healthStatus, fakeRouteServicesClient)
+	p = proxy.NewProxy(testLogger, al, ew, conf, r, fakeReporter, routeServiceConfig, tlsConfig, tlsConfig, healthStatus, fakeRouteServicesClient)
 
 	server := http.Server{Handler: p}
 	go server.Serve(proxyServer)

--- a/proxy/proxy_unit_test.go
+++ b/proxy/proxy_unit_test.go
@@ -11,6 +11,7 @@ import (
 	"code.cloudfoundry.org/gorouter/common/health"
 
 	fakelogger "code.cloudfoundry.org/gorouter/accesslog/fakes"
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	sharedfakes "code.cloudfoundry.org/gorouter/fakes"
 	"code.cloudfoundry.org/gorouter/logger"
 	"code.cloudfoundry.org/gorouter/metrics"
@@ -38,6 +39,7 @@ var _ = Describe("Proxy Unit tests", func() {
 		routeServiceConfig *routeservice.RouteServiceConfig
 		rt                 *sharedfakes.RoundTripper
 		tlsConfig          *tls.Config
+		ew                 = errorwriter.NewPlaintextErrorWriter()
 	)
 
 	Describe("ServeHTTP", func() {
@@ -71,7 +73,7 @@ var _ = Describe("Proxy Unit tests", func() {
 			conf.HealthCheckUserAgent = "HTTP-Monitor/1.1"
 
 			skipSanitization = func(req *http.Request) bool { return false }
-			proxyObj = proxy.NewProxy(logger, fakeAccessLogger, conf, r, combinedReporter,
+			proxyObj = proxy.NewProxy(logger, fakeAccessLogger, ew, conf, r, combinedReporter,
 				routeServiceConfig, tlsConfig, tlsConfig, &health.Health{}, rt)
 
 			r.Register(route.Uri("some-app"), &route.Endpoint{Stats: route.NewStats()})

--- a/router/router_drain_test.go
+++ b/router/router_drain_test.go
@@ -15,6 +15,7 @@ import (
 	"code.cloudfoundry.org/gorouter/accesslog"
 	"code.cloudfoundry.org/gorouter/common/schema"
 	cfg "code.cloudfoundry.org/gorouter/config"
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	sharedfakes "code.cloudfoundry.org/gorouter/fakes"
 	"code.cloudfoundry.org/gorouter/logger"
 	"code.cloudfoundry.org/gorouter/mbus"
@@ -50,6 +51,8 @@ var _ = Describe("Router", func() {
 		subscriber       ifrit.Process
 		natsPort         uint16
 		healthStatus     *health.Health
+
+		ew = errorwriter.NewPlaintextErrorWriter()
 	)
 
 	testAndVerifyRouterStopsNoDrain := func(signals chan os.Signal, closeChannel chan struct{}, sigs ...os.Signal) {
@@ -182,7 +185,7 @@ var _ = Describe("Router", func() {
 		config.HealthCheckUserAgent = "HTTP-Monitor/1.1"
 
 		rt := &sharedfakes.RoundTripper{}
-		p = proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, config, registry, combinedReporter,
+		p = proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, ew, config, registry, combinedReporter,
 			&routeservice.RouteServiceConfig{}, &tls.Config{}, &tls.Config{}, healthStatus, rt)
 
 		errChan := make(chan error, 2)
@@ -414,7 +417,7 @@ var _ = Describe("Router", func() {
 				h.SetHealth(health.Healthy)
 				config.HealthCheckUserAgent = "HTTP-Monitor/1.1"
 				rt := &sharedfakes.RoundTripper{}
-				p := proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, config, registry, combinedReporter,
+				p := proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, ew, config, registry, combinedReporter,
 					&routeservice.RouteServiceConfig{}, &tls.Config{}, &tls.Config{}, h, rt)
 
 				errChan = make(chan error, 2)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -30,6 +30,7 @@ import (
 	"code.cloudfoundry.org/gorouter/accesslog"
 	"code.cloudfoundry.org/gorouter/common/schema"
 	cfg "code.cloudfoundry.org/gorouter/config"
+	"code.cloudfoundry.org/gorouter/errorwriter"
 	sharedfakes "code.cloudfoundry.org/gorouter/fakes"
 	"code.cloudfoundry.org/gorouter/handlers"
 	"code.cloudfoundry.org/gorouter/logger"
@@ -1933,10 +1934,12 @@ func initializeRouter(config *cfg.Config, backendIdleTimeout, requestTimeout tim
 	combinedReporter := &metrics.CompositeReporter{VarzReporter: varz, ProxyReporter: metricReporter}
 	routeServiceConfig := routeservice.NewRouteServiceConfig(logger, true, config.RouteServicesHairpinning, config.EndpointTimeout, nil, nil, false)
 
+	ew := errorwriter.NewPlaintextErrorWriter()
+
 	proxyConfig := *config
 	proxyConfig.EndpointTimeout = requestTimeout
 	routeServicesTransport := &sharedfakes.RoundTripper{}
-	p := proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, &proxyConfig, registry, combinedReporter,
+	p := proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, ew, &proxyConfig, registry, combinedReporter,
 		routeServiceConfig, &tls.Config{}, &tls.Config{}, &health.Health{}, routeServicesTransport)
 
 	h := &health.Health{}


### PR DESCRIPTION
Checklist

- [x] basic functionality and tests
- [x] configuration
- [x] contextual helpers available in HTML template
- [x] better PR description
- [x] content types

---

## Context

Currently, when gorouter encounters an error (eg route not found) a user receives a plaintext error response using `http.Error`, which looks like this:

```
404 Not Found: Requested route ('my-route.my-domain.tld') does not exist.
```

This is usually not a big problem because we do not expect users to see gorouter error pages often, however they do occur often enough that users notice:

- App timeouts
- App crashes
- Platform issues (eg TLS certificates)

This has been discussed before in #171 but the work was not pursued

## Explanation

This PR does not change the behaviour of gorouter unless using a newly created configuration parameter `html_error_template_file`.

Templates are written using go `html/template` syntax.

Using this parameter, Gorouter can be configured to generate HTML error messages that render nicely in a user's browser, and an operator can configure the templates to provide additional contextual information that would otherwise require a user to open up their developer tools.

For example:

```
<html>
  <body>
  Code: {{ .Status }}
  Cause: {{ .Header.Get "X-Cf-RouterError" }}
  </body>
</html>
```

I have also created a [GOV.UK PaaS](https://www.cloud.service.gov.uk/) error page:

![Screenshot of GOV.UK PaaS error page](https://user-images.githubusercontent.com/1482692/89939990-bf94aa00-dc10-11ea-8764-49492026c129.png)
_Screenshot of GOV.UK PaaS error page_

The following HTML is the relevant bit:
```html
<h1 class="govuk-heading-xl">Something went wrong</h1>
<details>
  <summary>Additional diagnostic information</summary>
  <dl class="govuk-summary-list">
    <div class="govuk-summary-list__row">
      <dt class="govuk-summary-list__key">HTTP code</dt>
      <dd class="govuk-summary-list__value">{{ .Status}} {{ .StatusText }}</dd>
    </div>

    <div class="govuk-summary-list__row">
      <dt class="govuk-summary-list__key">Error message</dt>
      <dd class="govuk-summary-list__value">{{ .Message }}</dd>
    </div>

    <div class="govuk-summary-list__row">
      <dt class="govuk-summary-list__key">Reason</dt>
      <dd class="govuk-summary-list__value">{{ .Header.Get "X-Cf-RouterError" }}</dd>
    </div>

    {{ if .Header.Get "X-Vcap-Request-Id" }}
    <div class="govuk-summary-list__row">
      <dt class="govuk-summary-list__key">Request ID</dt>
      <dd class="govuk-summary-list__value">{{ .Header.Get "X-Vcap-Request-Id" }}</dd>
    </div>
    {{ end }}
  </dl>
</details>
```

## How to review

Create a configuration file `/tmp/gorouter.yml` with contents:

```yaml
html_error_template_file: /tmp/example.html
```

Create a template `/tmp/example.html` with contents:
```
<html>
  <body>
  Code: {{ .Status }}
  Cause: {{ .Header.Get "X-Cf-RouterError" }}
  <img src="https://golang.org/lib/godoc/images/home-gopher.png" alt="A cute gopher in black and white, as penance for responding with an error"/>
  </body>
</html>
```

Run gorouter:
```bash
go build && ./gorouter -c /tmp/example.yaml
```

Navigate to http://localhost:8081 and observe there is a HTML page which includes

```
Code: 400 Cause: empty_host
```

## Future behaviour

Error pages in your browser render HTML instead of plain text.

## Current behaviour

Error pages cannot be templated, and render as plain text.

## Other PRs

If this change is welcome I will raise a routing release PR which allows a user to provide a template via the gorouter BOSH job.

## Checklist

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch (⚠️  I've done this to `main` not `develop` which I think is correct)

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
