### PR TITLE
Make /healthz an alias for /health.

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,9 +331,8 @@ ok
 * Connection #0 to host 10.0.32.15 left intact
 ```
 
-**DEPRECATED:** The `/healthz` endpoint provides a similar response, but it
-always returns a 200 response regardless of whether or not the GoRouter instance
-is healthy.
+**DEPRECATED:** The `/healthz` endpoint is now an alias for the `/health` endpoint
+to ensure backward compatibility.
 
 ## Instrumentation
 

--- a/common/component.go
+++ b/common/component.go
@@ -211,11 +211,7 @@ func (c *VcapComponent) ListenAndServe() {
 	})
 
 	hs.HandleFunc("/healthz", func(w http.ResponseWriter, req *http.Request) {
-		w.Header().Set("Connection", "close")
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
-
-		fmt.Fprintf(w, c.Healthz.Value())
+		c.Health.ServeHTTP(w, req)
 	})
 
 	hs.HandleFunc("/varz", func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:
Make `/health` and `/healthz` use the same underlying code.

* An explanation of the use cases your change solves
Many TAS customers, due to older terraform scripts provided on pivnet, use `/healthz` as their health check endpoint, which causes an increase in 502s during a period when the routers are being restarted (for example, during an upgrade). The period of increased 502s correlates to the traffic to the foundation, as it directly affects the length of the drain script. `/health`, as noted by cloudfoundry/routing-release#175, has been available for four years. This provides a non-breaking method to introduce this more correct endpoint to a non-trivial portion of our TAS customer base.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

Run a curl every 5s or so against some endpoint backed by the gorouter and collect the status codes while the router VMs recreate (as this adds a nice period of time in which to check).

* Expected result after the change
The number of 502s received by curl should be close to, if not exactly, zero

* Current result before the change
During the drain script for 1 router out of _n_,  roughly 1/_n_ of the status codes will be HTTP 502s.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch.

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker`

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
