### PR TITLE
Suppress query params in logs

### DIFF
--- a/accesslog/file_and_loggregator_access_logger.go
+++ b/accesslog/file_and_loggregator_access_logger.go
@@ -34,6 +34,7 @@ type FileAndLoggregatorAccessLogger struct {
 	writerCount            int
 	disableXFFLogging      bool
 	disableSourceIPLogging bool
+	redactQueryParams      string
 	logger                 logger.Logger
 	logsender              schema.LogSender
 }
@@ -69,6 +70,7 @@ func CreateRunningAccessLogger(logger logger.Logger, logsender schema.LogSender,
 		stopCh:                 make(chan struct{}),
 		disableXFFLogging:      config.Logging.DisableLogForwardedFor,
 		disableSourceIPLogging: config.Logging.DisableLogSourceIP,
+		redactQueryParams:      config.Logging.RedactQueryParams,
 		logger:                 logger,
 		logsender:              logsender,
 	}
@@ -109,6 +111,7 @@ func (x *FileAndLoggregatorAccessLogger) Stop() {
 func (x *FileAndLoggregatorAccessLogger) Log(r schema.AccessLogRecord) {
 	r.DisableXFFLogging = x.disableXFFLogging
 	r.DisableSourceIPLogging = x.disableSourceIPLogging
+	r.RedactQueryParams = x.redactQueryParams
 	x.channel <- r
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -156,6 +156,7 @@ suspend_pruning_if_nats_unavailable: true
 			Expect(config.Logging.LoggregatorEnabled).To(Equal(false))
 			Expect(config.Logging.DisableLogForwardedFor).To(Equal(false))
 			Expect(config.Logging.DisableLogSourceIP).To(Equal(false))
+			Expect(config.Logging.RedactQueryParams).To(Equal("none"))
 			Expect(config.Logging.Format.Timestamp).To(Equal("unix-epoch"))
 		})
 

--- a/test_util/helpers.go
+++ b/test_util/helpers.go
@@ -190,11 +190,9 @@ func generateConfig(statusPort, proxyPort uint16, natsPorts ...uint16) *config.C
 		})
 	}
 
-	c.Logging = config.LoggingConfig{
-		Level:         "debug",
-		MetronAddress: "localhost:3457",
-		JobName:       "router_test_z1_0",
-	}
+	c.Logging.Level = "debug"
+	c.Logging.MetronAddress = "localhost:3457"
+	c.Logging.JobName = "router_test_z1_0"
 
 	c.OAuth = config.OAuthConfig{
 		TokenEndpoint:     "uaa.cf.service.internal",


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:
As discussed in [this routing-release issue](https://github.com/cloudfoundry/routing-release/issues/173) I have provided logic to redact query parameters of GET requests from getting logged to the access log.

* An explanation of the use cases your change solves
There are three options:
`none` (default) retains the current behavior: All parameters are logged
`all` Removes all query parameters from the log
`hash` performs a SHA1 over the query parameters and logs only the hash sum.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

Default behavior:
1. In gorouter BOSH job set property `redact_query_parameters` to `none`
2. `bosh -d cf deploy`
3. `curl https://some-app.cf-app.com/?password=secret`
4. `bosh -d cf ssh gorouter`
5. `vi access_log`
6. The access_log should say `some-app.cf-app.com - [timestamp] "GET /?password=secret HTTP/1.1"`

Log no query parameters:
1. In gorouter BOSH job set property `redact_query_parameters` to `all`
2. `bosh -d cf deploy`
3. `curl https://some-app.cf-app.com/?password=secret`
4. `bosh -d cf ssh gorouter`
5. `vi access_log`
6. The access_log should say `some-app.cf-app.com - [timestamp] "GET / HTTP/1.1"`

Log only hash of query parameters:
1. In gorouter BOSH job set property `redact_query_parameters` to `hash`
2. `bosh -d cf deploy`
3. `curl https://some-app.cf-app.com/?password=secret`
4. `bosh -d cf ssh gorouter`
5. `vi access_log`
6. The access_log should say `some-app.cf-app.com - [timestamp] "GET /?hash=878830dc19ac17a15b189cad83b7809975bc525e HTTP/1.1"`

* Expected result after the change
GET query parameters are hidden or hashed if needed.

* Current result before the change
GET query parameters are logged.

* Links to any other associated PRs
tbd

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
