### PR TITLE
Fix issue 159: Gorouter emits way too many metrics 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -273,6 +273,8 @@ type Config struct {
 	EmptyPoolResponseCode503 bool `yaml:"empty_pool_response_code_503,omitempty"`
 
 	HTMLErrorTemplateFile string `yaml:"html_error_template_file,omitempty"`
+
+	PerRequestMetricsReporting bool `yaml:"per_request_metrics_reporting,omitempty"`
 }
 
 var defaultConfig = Config{
@@ -326,6 +328,8 @@ var defaultConfig = Config{
 	MaxIdleConnsPerHost: 2,
 
 	StickySessionCookieNames: StringSet{"JSESSIONID": struct{}{}},
+
+	PerRequestMetricsReporting: true,
 }
 
 func DefaultConfig() (*Config, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -275,6 +275,8 @@ type Config struct {
 	HTMLErrorTemplateFile string `yaml:"html_error_template_file,omitempty"`
 
 	PerRequestMetricsReporting bool `yaml:"per_request_metrics_reporting,omitempty"`
+
+	SendHttpStartStopServerEvent bool `yaml:"send_http_start_stop_server_event,omitempty"`
 }
 
 var defaultConfig = Config{
@@ -330,6 +332,8 @@ var defaultConfig = Config{
 	StickySessionCookieNames: StringSet{"JSESSIONID": struct{}{}},
 
 	PerRequestMetricsReporting: true,
+
+	SendHttpStartStopServerEvent: true,
 }
 
 func DefaultConfig() (*Config, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -277,6 +277,8 @@ type Config struct {
 	PerRequestMetricsReporting bool `yaml:"per_request_metrics_reporting,omitempty"`
 
 	SendHttpStartStopServerEvent bool `yaml:"send_http_start_stop_server_event,omitempty"`
+
+	SendHttpStartStopClientEvent bool `yaml:"send_http_start_stop_client_event,omitempty"`
 }
 
 var defaultConfig = Config{
@@ -334,6 +336,8 @@ var defaultConfig = Config{
 	PerRequestMetricsReporting: true,
 
 	SendHttpStartStopServerEvent: true,
+
+	SendHttpStartStopClientEvent: true,
 }
 
 func DefaultConfig() (*Config, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -616,6 +616,18 @@ backends:
 			Expect(err).ToNot(HaveOccurred())
 			Expect(config.HTMLErrorTemplateFile).To(Equal("/path/to/file"))
 		})
+
+		It("defaults PerRequestMetricsReporting to true", func() {
+			Expect(config.PerRequestMetricsReporting).To(Equal(true))
+		})
+
+		It("sets PerRequestMetricsReporting", func() {
+			var b = []byte(`per_request_metrics_reporting: false`)
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.PerRequestMetricsReporting).To(BeFalse())
+		})
+
 	})
 
 	Describe("Process", func() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -628,6 +628,17 @@ backends:
 			Expect(config.PerRequestMetricsReporting).To(BeFalse())
 		})
 
+		It("defaults SendHttpStartStopServerEvent to true", func() {
+			Expect(config.SendHttpStartStopServerEvent).To(Equal(true))
+		})
+
+		It("sets SendHttpStartStopServerEvent", func() {
+			var b = []byte(`send_http_start_stop_server_event: false`)
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.SendHttpStartStopServerEvent).To(BeFalse())
+		})
+
 	})
 
 	Describe("Process", func() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -639,6 +639,17 @@ backends:
 			Expect(config.SendHttpStartStopServerEvent).To(BeFalse())
 		})
 
+		It("defaults SendHttpStartStopClientEvent to true", func() {
+			Expect(config.SendHttpStartStopClientEvent).To(Equal(true))
+		})
+
+		It("sets SendHttpStartStopClientEvent", func() {
+			var b = []byte(`send_http_start_stop_client_event: false`)
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.SendHttpStartStopClientEvent).To(BeFalse())
+		})
+
 	})
 
 	Describe("Process", func() {

--- a/main.go
+++ b/main.go
@@ -124,7 +124,8 @@ func main() {
 	}
 
 	sender := metric_sender.NewMetricSender(dropsonde.AutowiredEmitter())
-	metricsReporter := initializeMetrics(sender)
+
+	metricsReporter := initializeMetrics(sender, c)
 	fdMonitor := initializeFDMonitor(sender, logger)
 	registry := rregistry.NewRouteRegistry(logger.Session("registry"), c, metricsReporter)
 	if c.SuspendPruningIfNatsUnavailable {
@@ -270,7 +271,7 @@ func initializeNATSMonitor(subscriber *mbus.Subscriber, sender *metric_sender.Me
 	}
 }
 
-func initializeMetrics(sender *metric_sender.MetricSender) *metrics.MetricsReporter {
+func initializeMetrics(sender *metric_sender.MetricSender, c *config.Config) *metrics.MetricsReporter {
 	// 5 sec is dropsonde default batching interval
 	batcher := metricbatcher.New(sender, 5*time.Second)
 	batcher.AddConsistentlyEmittedMetrics("bad_gateways",
@@ -292,7 +293,7 @@ func initializeMetrics(sender *metric_sender.MetricSender) *metrics.MetricsRepor
 		"websocket_upgrades",
 	)
 
-	return &metrics.MetricsReporter{Sender: sender, Batcher: batcher}
+	return &metrics.MetricsReporter{Sender: sender, Batcher: batcher, PerRequestMetricsReporting: c.PerRequestMetricsReporting}
 }
 
 func createCrypto(logger goRouterLogger.Logger, secret string) *secure.AesGCM {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -164,7 +164,9 @@ func NewProxy(
 	n.Use(handlers.NewRequestInfo())
 	n.Use(handlers.NewProxyWriter(logger))
 	n.Use(handlers.NewVcapRequestIdHeader(logger))
-	n.Use(handlers.NewHTTPStartStop(dropsonde.DefaultEmitter, logger))
+	if cfg.SendHttpStartStopServerEvent {
+		n.Use(handlers.NewHTTPStartStop(dropsonde.DefaultEmitter, logger))
+	}
 	n.Use(handlers.NewAccessLog(accessLogger, headersToLog, logger))
 	n.Use(handlers.NewReporter(reporter, logger))
 	n.Use(handlers.NewHTTPRewriteHandler(cfg.HTTPRewrite, headersToAlwaysRemove))

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -125,6 +125,7 @@ func NewProxy(
 			DisableCompression:  true,
 			TLSClientConfig:     routeServiceTLSConfig,
 		},
+		IsInstrumented: cfg.SendHttpStartStopClientEvent,
 	}
 
 	prt := round_tripper.NewProxyRoundTripper(

--- a/proxy/round_tripper/dropsonde_round_tripper.go
+++ b/proxy/round_tripper/dropsonde_round_tripper.go
@@ -30,6 +30,7 @@ func (d *dropsondeRoundTripper) CancelRequest(r *http.Request) {
 type FactoryImpl struct {
 	BackendTemplate      *http.Transport
 	RouteServiceTemplate *http.Transport
+	IsInstrumented       bool
 }
 
 func (t *FactoryImpl) New(expectedServerName string, isRouteService bool) ProxyRoundTripper {
@@ -52,5 +53,10 @@ func (t *FactoryImpl) New(expectedServerName string, isRouteService bool) ProxyR
 		TLSClientConfig:     customTLSConfig,
 		TLSHandshakeTimeout: template.TLSHandshakeTimeout,
 	}
-	return NewDropsondeRoundTripper(newTransport)
+	if t.IsInstrumented {
+		return NewDropsondeRoundTripper(newTransport)
+	} else {
+		return newTransport
+	}
+
 }


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:
This change addresses https://github.com/cloudfoundry/gorouter/issues/159.
On large scale landscapes the loggregator stack is a limiting factor for further growth. A big part of the loggregator load is due to the per-request envelopes sent by the gorouter. The envelopes are the following: The metrics `latency`, `latency .<component>` and `route_lookup_time `, two envelopes of type `timer`, and the access log.
This change makes sending the metrics and the two envelopes of type `timer` configurable.

* An explanation of the use cases your change solves
In our load tests we measured a decrease of CPU load on gorouter and doppler of about 40% without the metrics and of about 60% without metrics and timer

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
Switch off sending the metrics and/or the timer envelopes in the manifest:
per_request_metrics_reporting: false
send_http_start_stop_server_event: false
send_http_start_stop_client_event: false 
Please note that send_http_start_stop_client_event should not be set to false when the app autoscaler is used.

* Expected result after the change
Neither the metrics nor the timer events are sent. This can be seen with `cf tail <appname>`.
The gorouter and doppler CPU load decreases.

* Current result before the change
The settings have no effect

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).
