### PR TITLE
Update Router to serve HTTP/2 traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,9 +650,15 @@ header is `1.2.3.4`. You can read more about the PROXY Protocol
 
 ## HTTP/2 Support
 
-The Gorouter does not currently support proxying HTTP/2 connections, even over
-TLS. Connections made using HTTP/1.1, either by TLS or cleartext, will be
-proxied to backends over cleartext.
+The Gorouter supports accepting HTTP/2 connections when the manifest property is
+enabled. Connections made using HTTP/2 will be proxied to backends over
+HTTP/1.1.
+
+```yaml
+properties:
+  router:
+    enable_http2: true
+```
 
 ## Logs
 

--- a/config/config.go
+++ b/config/config.go
@@ -195,6 +195,7 @@ type Config struct {
 	EnableSSL       bool              `yaml:"enable_ssl,omitempty"`
 	SSLPort         uint16            `yaml:"ssl_port,omitempty"`
 	DisableHTTP     bool              `yaml:"disable_http,omitempty"`
+	EnableHTTP2     bool              `yaml:"enable_http2,omitempty"`
 	SSLCertificates []tls.Certificate `yaml:"-"`
 	TLSPEM          []TLSPem          `yaml:"tls_pem,omitempty"`
 	CACerts         string            `yaml:"ca_certs,omitempty"`
@@ -292,6 +293,7 @@ var defaultConfig = Config{
 	EnableSSL:     false,
 	SSLPort:       443,
 	DisableHTTP:   false,
+	EnableHTTP2:   false,
 	MinTLSVersion: tls.VersionTLS12,
 	MaxTLSVersion: tls.VersionTLS12,
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1399,6 +1399,23 @@ disable_http: true
 			})
 		})
 
+		Context("enable_http2", func() {
+			It("defaults to false", func() {
+				Expect(config.Process()).To(Succeed())
+				Expect(config.EnableHTTP2).To(BeFalse())
+			})
+
+			It("setting enable_http2 succeeds", func() {
+				var b = []byte(fmt.Sprintf(`
+enable_http2: true
+`))
+				err := config.Initialize(b)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(config.Process()).To(Succeed())
+				Expect(config.EnableHTTP2).To(BeTrue())
+			})
+		})
+
 		Context("When given a routing_table_sharding_mode that is supported ", func() {
 			Context("sharding mode `all`", func() {
 				It("succeeds", func() {

--- a/handlers/protocolcheck.go
+++ b/handlers/protocolcheck.go
@@ -59,5 +59,5 @@ func (p *protocolCheck) hijack(rw http.ResponseWriter) (net.Conn, *bufio.ReadWri
 }
 
 func isProtocolSupported(request *http.Request) bool {
-	return request.ProtoMajor == 1 && (request.ProtoMinor == 0 || request.ProtoMinor == 1)
+	return request.ProtoMajor == 2 || (request.ProtoMajor == 1 && (request.ProtoMinor == 0 || request.ProtoMinor == 1))
 }

--- a/handlers/protocolcheck_test.go
+++ b/handlers/protocolcheck_test.go
@@ -48,6 +48,22 @@ var _ = Describe("Protocolcheck", func() {
 		server.Close()
 	})
 
+	Context("http2", func() {
+		It("passes the request through", func() {
+			conn, err := net.Dial("tcp", server.Addr())
+			defer conn.Close()
+			Expect(err).ToNot(HaveOccurred())
+			respReader := bufio.NewReader(conn)
+
+			conn.Write([]byte("PRI * HTTP/2.0\r\nHost: example.com\r\n\r\n"))
+			resp, err := http.ReadResponse(respReader, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(resp.StatusCode).To(Equal(200))
+			Expect(nextCalled).To(BeTrue())
+		})
+	})
+
 	Context("http 1.1", func() {
 		It("passes the request through", func() {
 			conn, err := net.Dial("tcp", server.Addr())
@@ -92,20 +108,6 @@ var _ = Describe("Protocolcheck", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 
 			Expect(nextCalled).To(BeFalse())
-		})
-	})
-
-	Context("http2", func() {
-		It("returns a 400 bad request", func() {
-			conn, err := net.Dial("tcp", server.Addr())
-			Expect(err).ToNot(HaveOccurred())
-			respReader := bufio.NewReader(conn)
-
-			conn.Write([]byte("PRI * HTTP/2.0\r\nHost: example.com\r\n\r\n"))
-
-			resp, err := http.ReadResponse(respReader, nil)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 		})
 	})
 })

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -255,12 +255,14 @@ var _ = Describe("Router Integration", func() {
 			clientTLSConfig *tls.Config
 			mbusClient      *nats.Conn
 		)
+
 		BeforeEach(func() {
 			cfg, clientTLSConfig = createSSLConfig(statusPort, proxyPort, sslPort, natsPort)
-
 		})
+
 		JustBeforeEach(func() {
 			var err error
+			cfg.EnableHTTP2 = true
 			writeConfig(cfg, cfgFile)
 			mbusClient, err = newMessageBus(cfg)
 			Expect(err).ToNot(HaveOccurred())
@@ -297,7 +299,6 @@ var _ = Describe("Router Integration", func() {
 	})
 
 	Context("Drain", func() {
-
 		BeforeEach(func() {
 			cfg = createConfig(statusPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 1, false, 0, natsPort)
 		})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -174,7 +174,7 @@ func NewProxy(
 	n.Use(handlers.NewProxyHealthcheck(cfg.HealthCheckUserAgent, p.health, logger))
 	n.Use(zipkinHandler)
 	n.Use(w3cHandler)
-	n.Use(handlers.NewProtocolCheck(logger, errorWriter))
+	n.Use(handlers.NewProtocolCheck(logger, errorWriter, cfg.EnableHTTP2))
 	n.Use(handlers.NewLookup(registry, reporter, logger, errorWriter, cfg.EmptyPoolResponseCode503))
 	n.Use(handlers.NewClientCert(
 		SkipSanitize(routeServiceHandler.(*handlers.RouteService)),

--- a/router/router.go
+++ b/router/router.go
@@ -228,6 +228,7 @@ func (r *Router) serveHTTPS(server *http.Server, errChan chan error) error {
 	}
 
 	tlsConfig := &tls.Config{
+		NextProtos:   []string{"h2"},
 		Certificates: r.config.SSLCertificates,
 		CipherSuites: r.config.CipherSuites,
 		MinVersion:   r.config.MinTLSVersion,

--- a/router/router.go
+++ b/router/router.go
@@ -228,13 +228,16 @@ func (r *Router) serveHTTPS(server *http.Server, errChan chan error) error {
 	}
 
 	tlsConfig := &tls.Config{
-		NextProtos:   []string{"h2"},
 		Certificates: r.config.SSLCertificates,
 		CipherSuites: r.config.CipherSuites,
 		MinVersion:   r.config.MinTLSVersion,
 		MaxVersion:   r.config.MaxTLSVersion,
 		ClientCAs:    r.config.ClientCAPool,
 		ClientAuth:   r.config.ClientCertificateValidation,
+	}
+
+	if r.config.EnableHTTP2 {
+		tlsConfig.NextProtos = []string{"h2"}
 	}
 
 	tlsConfig.BuildNameToCertificate()


### PR DESCRIPTION
Adds a manifest property, `enable_http2`, to enable the Gorouter to accept HTTP/2 connections. The property changes the protocol checking middleware and the `serveHTTPS` function to allow HTTP/2. Note that connections made using HTTP/2 will still be proxied to backends over HTTP/1.1 because Envoy isn't currently configured to accept HTTP/2.

We added integration tests to check HTTP/2 (and updated the old ones to check that gorouter can still serve HTTP/1.1). However, we weren't able to get a router/router test working because making HTTP/2 requests to the test Server resulted in broken pipes. We believe this is due to differences in the test Server setup and the `main.go` setup used in the integration tests. This will require additional investigation.

[cloudfoundry/routing-release#200]