### PR TITLE
Remove extra newline that was written to `cf logs` output

### DIFF
--- a/accesslog/file_and_loggregator_access_logger_test.go
+++ b/accesslog/file_and_loggregator_access_logger_test.go
@@ -52,7 +52,7 @@ var _ = Describe("AccessLog", func() {
 				Eventually(ls.SendAppLogCallCount).Should(Equal(1))
 				appID, message, tags := ls.SendAppLogArgsForCall(0)
 				Expect(appID).To(Equal("my_awesome_id"))
-				Expect(message).To(MatchRegexp("^.*foo.bar.*\n"))
+				Expect(message).To(MatchRegexp("^.*foo.bar.*"))
 				Expect(tags).To(BeNil())
 
 				accessLogger.Stop()

--- a/accesslog/schema/access_log_record.go
+++ b/accesslog/schema/access_log_record.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"bytes"
-	"code.cloudfoundry.org/gorouter/config"
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
@@ -11,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"code.cloudfoundry.org/gorouter/config"
 
 	"code.cloudfoundry.org/gorouter/route"
 )
@@ -203,8 +204,6 @@ func (r *AccessLogRecord) makeRecord() []byte {
 
 	r.addExtraHeaders(b)
 
-	b.WriteByte('\n')
-
 	return b.Bytes()
 }
 
@@ -230,7 +229,11 @@ func redactURI(r AccessLogRecord) string {
 // WriteTo allows the AccessLogRecord to implement the io.WriterTo interface
 func (r *AccessLogRecord) WriteTo(w io.Writer) (int64, error) {
 	bytesWritten, err := w.Write(r.getRecord())
-	return int64(bytesWritten), err
+	if err != nil {
+		return int64(bytesWritten), err
+	}
+	newline, err := w.Write([]byte("\n"))
+	return int64(bytesWritten + newline), err
 }
 
 func (r *AccessLogRecord) SendLog(ls LogSender) {

--- a/accesslog/schema/access_log_record_test.go
+++ b/accesslog/schema/access_log_record_test.go
@@ -2,6 +2,7 @@ package schema_test
 
 import (
 	"bytes"
+
 	"code.cloudfoundry.org/gorouter/accesslog/schema"
 	"code.cloudfoundry.org/gorouter/config"
 	"code.cloudfoundry.org/gorouter/handlers"
@@ -68,7 +69,7 @@ var _ = Describe("AccessLogRecord", func() {
 			Eventually(r).Should(Say(`x_forwarded_proto:"FakeOriginalRequestProto" `))
 			Eventually(r).Should(Say(`vcap_request_id:"abc-123-xyz-pdq" response_time:60.000000 gorouter_time:10.000000 app_id:"FakeApplicationId" `))
 			Eventually(r).Should(Say(`app_index:"3"`))
-			Eventually(r).Should(Say(`x_cf_routererror:"some-router-error"\n`))
+			Eventually(r).Should(Say(`x_cf_routererror:"some-router-error"`))
 		})
 
 		Context("when DisableSourceIPLogging is specified", func() {
@@ -153,7 +154,7 @@ var _ = Describe("AccessLogRecord", func() {
 				Eventually(r).Should(Say(`x_forwarded_proto:"FooOriginalRequestProto" `))
 				Eventually(r).Should(Say(`vcap_request_id:"abc-123-xyz-pdq" response_time:60.000000 gorouter_time:10.000000 app_id:"FakeApplicationId" `))
 				Eventually(r).Should(Say(`app_index:"3"`))
-				Eventually(r).Should(Say(`x_cf_routererror:"some-router-error"\n`))
+				Eventually(r).Should(Say(`x_cf_routererror:"some-router-error"`))
 			})
 		})
 
@@ -181,7 +182,7 @@ var _ = Describe("AccessLogRecord", func() {
 				Eventually(r).Should(Say(`x_forwarded_proto:"-" `))
 				Eventually(r).Should(Say(`vcap_request_id:"-" response_time:"-" gorouter_time:"-" app_id:"FakeApplicationId" `))
 				Eventually(r).Should(Say(`app_index:"-"`))
-				Eventually(r).Should(Say(`x_cf_routererror:"-"\n`))
+				Eventually(r).Should(Say(`x_cf_routererror:"-"`))
 			})
 		})
 
@@ -212,7 +213,7 @@ var _ = Describe("AccessLogRecord", func() {
 				Eventually(r).Should(Say(`x_forwarded_proto:"FakeOriginalRequestProto" `))
 				Eventually(r).Should(Say(`vcap_request_id:"abc-123-xyz-pdq" response_time:60.000000 gorouter_time:10.000000 app_id:"FakeApplicationId" `))
 				Eventually(r).Should(Say(`app_index:"3" x_cf_routererror:"some-router-error" cache_control:"no-cache" accept_encoding:"gzip, deflate" `))
-				Eventually(r).Should(Say(`if_match:"737060cd8c284d8af7ad3082f209582d" doesnt_exist:"-"\n`))
+				Eventually(r).Should(Say(`if_match:"737060cd8c284d8af7ad3082f209582d" doesnt_exist:"-"`))
 			})
 		})
 
@@ -254,7 +255,7 @@ var _ = Describe("AccessLogRecord", func() {
 				Eventually(r).Should(Say(`x_forwarded_proto:"FakeOriginalRequestProto" `))
 				Eventually(r).Should(Say(`vcap_request_id:"abc-123-xyz-pdq" response_time:60.000000 gorouter_time:10.000000 app_id:"FakeApplicationId" `))
 				Eventually(r).Should(Say(`app_index:"3"`))
-				Eventually(r).Should(Say(`x_cf_routererror:"-"\n`))
+				Eventually(r).Should(Say(`x_cf_routererror:"-"`))
 			})
 		})
 	})


### PR DESCRIPTION


<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

  * This line is necessary in the access log (WriteTo) so they show up  as
distinct lines
  * It was redundant in `cf logs` (LogMessage); this was problematic
because it sent extra envelopes through the loggregator system.

  Fixes cloudfoundry/routing-release#124
  Fixes cloudfoundry/gorouter#202



* An explanation of the use cases your change solves
  * Fixes confusion from developers running `cf logs` against their apps.
  * Fixes problem operators may face with too many log envelopes overfilling Dopplers.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
1. Push an app
2. curl [app url]
2. `cf logs [app name]`
3. Do not see empty `[RTR/0] OUT` log line
3. `bosh ssh router/0`
4. `tail /var/vcap/sys/log/gorouter/access.log`
5. Confirm `RTR` log lines are distinct from each other (not concatnated).


* Expected result after the change
1. `cf logs` output does not contain empty `[RTR/0] OUT` log line after every router log line. 

* Current result before the change
1. `cf logs` output did contain empty `[RTR/0] OUT` log line after every router log line. 

* Links to any other associated PRs
n/a

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
