### PR TITLE
Allow X-Forwarded-Client-Cert header to reach apps in ALWAYS_FORWARD mode

### DIFF
--- a/handlers/clientcert_test.go
+++ b/handlers/clientcert_test.go
@@ -128,6 +128,7 @@ var _ = Describe("Clientcert", func() {
 				}))
 			}
 		})
+
 		By("when there is a mtls connection with client certs", func() {
 			privKey, certDER := test_util.CreateCertDER("client_cert1.com")
 			keyPEM, certPEM := test_util.CreateKeyPairFromDER(certDER, privKey)

--- a/integration/xfcc_integration_test.go
+++ b/integration/xfcc_integration_test.go
@@ -46,17 +46,17 @@ var _ = Describe("modifications of X-Forwarded-Client-Cert", func() {
 			// | client scheme | route service scheme | clientCert | clientXFCC | expectedXFCCAtRouteService | expectedXFCCAtApp |
 			// |---------------|----------------------|------------|------------|----------------------------|-------------------|
 			{"http", "http", false, false, "", ""},
-			{"http", "http", false, true, "clientXFCC", ""},
+			{"http", "http", false, true, "clientXFCC", "clientXFCC"},
 			{"http", "https", false, false, "", ""},
-			{"http", "https", false, true, "clientXFCC", ""},
+			{"http", "https", false, true, "clientXFCC", "clientXFCC"},
 			{"https", "http", false, false, "", ""},
-			{"https", "http", false, true, "clientXFCC", ""},
+			{"https", "http", false, true, "clientXFCC", "clientXFCC"},
 			{"https", "http", true, false, "", ""},
-			{"https", "http", true, true, "clientXFCC", ""},
+			{"https", "http", true, true, "clientXFCC", "clientXFCC"},
 			{"https", "https", false, false, "", ""},
-			{"https", "https", false, true, "clientXFCC", ""},
+			{"https", "https", false, true, "clientXFCC", "clientXFCC"},
 			{"https", "https", true, false, "", ""},
-			{"https", "https", true, true, "clientXFCC", ""},
+			{"https", "https", true, true, "clientXFCC", "clientXFCC"},
 		},
 		{config.FORWARD}: {
 			// | client scheme | route service scheme | clientCert | clientXFCC | expectedXFCCAtRouteService | expectedXFCCAtApp |

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -219,7 +219,7 @@ func ForceDeleteXFCCHeader(routeServiceValidator RouteServiceValidator, forwarde
 		if err != nil {
 			return false, err
 		}
-		return valid && forwardedClientCert != config.SANITIZE_SET, nil
+		return valid && forwardedClientCert != config.SANITIZE_SET && forwardedClientCert != config.ALWAYS_FORWARD, nil
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change: allow the `X-Forwarded-Client-Cert` header to reach apps behind route services when Gorouter is in `ALWAYS_FORWARD` mode

* An explanation of the use cases your change solves: this is described well in https://github.com/cloudfoundry/routing-release/issues/203

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics): deploy Gorouter in `ALWAYS_FORWARD` mode, behind https://github.com/cloudfoundry-incubator/haproxy-boshrelease/pull/187 in `forward_only_if_route_service` mode. Push a route service and app to CF. 

* Expected result after the change: See how `X-Forwarded-Client-Cert` is visible to the app, as well as the route service.

* Current result before the change: See how `X-Forwarded-Client-Cert` is only visible to the route service.

* [x] I have viewed signed and have submitted the Contributor License Agreement: **working on this with SAP**

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite