### PR TITLE
reverse proxy retruns 502 instead of 499 when client disconnects

### DIFF
--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -201,6 +201,12 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 
 	reqInfo.StoppedAt = time.Now()
 
+	// if the client disconnects before response is sent then return context.Canceled (499) instead of the gateway error
+	if err != nil && originalRequest.Context().Err() == context.Canceled && err != context.Canceled {
+		rt.logger.Error("gateway-error-and-original-request-context-cancelled", zap.Error(err))
+		err = originalRequest.Context().Err()
+	}
+
 	finalErr := err
 	if finalErr == nil {
 		finalErr = selectEndpointErr


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

Recently observed the gorouter will randomly return a 499 or 502 status code when the originating client disconnects   ([tracker story](https://www.pivotaltracker.com/n/projects/2477027/stories/177007392)).

The most common case for this to happen is when gorouter reverse proxy is reading from downstream client who originated the request and the TCP socket is closed abruptly.  

* An explanation of the use cases your change solves

The 502 and 499 status codes have a specific meaning and it can make troubleshooting difficult when they are incorrectly reported.  When we see a 502 error we expect the backend has failed in some way vs when we see a 499 where we expect the frontend to have failed.   It is challenging for operation teams to determine the severity of the situation when these results are misreported. 

There are a few OSS projects that solve this very same issue by simply checking the originating client context before passing the reverse proxy error through.  Essentially when there is a failure on the reverse proxy we are checking to make sure the frontend is still there, and if not we return a 499.
https://github.com/zalando/skipper/issues/1631
https://github.com/grafana/metrictank/pull/1821/files

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

to reproduce simply curl and app through gorouter that uploads a large file.  Then kill the curl command after a second.  You will start to see an even distribution of 499 and 502 errors.  ussing this [app](https://github.com/randomtask1155/simple-http) as an example.



```
#!/bin/bash

for i in {1..1000}
do
	curl -X POST "https://simple-http.appps.domain/post/data" -k -F 'file=@/Users/user/Downloads/ubuntu.iso' &
	sleep 1
	killall curl
done
```

To confirm this fix does not breaking some of the other types of workflow failures i ran 4 different tests for the fix and the results are [here](https://docs.google.com/spreadsheets/d/1bKJ9TdKSyyaGOonwMhMm-35bULNPdSHFTkGgueoaW4s/edit#gid=0)

download kill backend - Run a curl to the backend that downloads a file and use tcpkill to kill the apps tls port on the diego cell
download kill frontend - Run a curl to the backend that downloads a file and kill the curl command in the middle of the download
upload kill backend - same as download kill backend test except we upload a file
upload kill frontend - same as download kill frontend test except we upload a file




* Expected result after the change

expect gorouter to return 499 http status error when originating client abruptly goes away

* Current result before the change

gorouter will randomly return a 499 or 502 when downstream client cancels request.

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

i might need to sign the updated CLA.

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

yes i ran the unit test.  But i had to modify the test script to install golang 1.15 because the ci pipeline image uses 1.16 which was not compatible.  the round tripper code base passed but there were some other errors related to certs that I don't think correlate with this change. 

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

no

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite


no