### PR TITLE
Add support for talking to NATS over mTLS

### DIFF
--- a/integration/common_integration_test.go
+++ b/integration/common_integration_test.go
@@ -254,7 +254,7 @@ func (s *testState) registerAndWait(rm mbus.RegistryMessage) {
 func (s *testState) StartGorouter() *Session {
 	Expect(s.cfg).NotTo(BeNil(), "set up test cfg before calling this function")
 
-	s.natsRunner = test_util.NewNATSRunner(int(s.cfg.Nats[0].Port))
+	s.natsRunner = test_util.NewNATSRunner(int(s.cfg.Nats.Hosts[0].Port))
 	s.natsRunner.Start()
 
 	var err error

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -1111,14 +1111,14 @@ func hostnameAndPort(url string) (string, int) {
 }
 
 func newMessageBus(c *config.Config) (*nats.Conn, error) {
-	natsMembers := make([]string, len(c.Nats))
+	natsMembers := make([]string, len(c.Nats.Hosts))
 	options := nats.DefaultOptions
 	options.PingInterval = 200 * time.Millisecond
-	for _, info := range c.Nats {
+	for _, host := range c.Nats.Hosts {
 		uri := url.URL{
 			Scheme: "nats",
-			User:   url.UserPassword(info.User, info.Pass),
-			Host:   fmt.Sprintf("%s:%d", info.Host, info.Port),
+			User:   url.UserPassword(c.Nats.User, c.Nats.Pass),
+			Host:   fmt.Sprintf("%s:%d", host.Hostname, host.Port),
 		}
 		natsMembers = append(natsMembers, uri.String())
 	}

--- a/test_util/helpers.go
+++ b/test_util/helpers.go
@@ -240,14 +240,15 @@ func generateConfig(statusPort, proxyPort uint16, natsPorts ...uint16) *config.C
 		Pass: "pass",
 	}
 
-	c.Nats = []config.NatsConfig{}
-	for _, natsPort := range natsPorts {
-		c.Nats = append(c.Nats, config.NatsConfig{
-			Host: "localhost",
-			Port: natsPort,
-			User: "nats",
-			Pass: "nats",
-		})
+	natsHosts := make([]config.NatsHost, len(natsPorts))
+	for i, natsPort := range natsPorts {
+		natsHosts[i].Hostname = "localhost"
+		natsHosts[i].Port = natsPort
+	}
+	c.Nats = config.NatsConfig{
+		User:  "nats",
+		Pass:  "nats",
+		Hosts: natsHosts,
 	}
 
 	c.Logging.Level = "debug"


### PR DESCRIPTION
* *A short explanation of the proposed change:* this PR makes Gorouter able to talk to NATS via Mutual TLS. This can remove one of the [remaining non-TLS uses within Cloud Foundry](https://github.com/cloudfoundry/cf-deployment/issues/906).

* *An explanation of the use cases your change solves:* many organisations using Cloud Foundry want it to use TLS everywhere. This ensures no sensitive data can be snooped on the network, and helps with compliance. 

* *Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics):* followup PRs are coming shortly to cf-deployment and routing-release that can be deployed.

* *Expected result after the change:* Gorouter will connect to NATS over Mutual TLS. Also, nothing will be left connecting to NATS over plaintext.

* *Links to any other associated PRs:* https://github.com/cloudfoundry/routing-release/pull/204 and https://github.com/cloudfoundry/cf-deployment/pull/925

* [x] *I have viewed signed and have submitted the Contributor License Agreement:* this is actively in-progress

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
