### PR TITLE
Improve cross-endpoint request retries

### DIFF
--- a/proxy/fails/basic_classifiers.go
+++ b/proxy/fails/basic_classifiers.go
@@ -3,10 +3,13 @@ package fails
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"net"
 
 	"context"
 )
+
+var IdempotentRequestEOFError = errors.New("EOF (via idempotent request)")
 
 var AttemptedTLSWithNonTLSBackend = ClassifierFunc(func(err error) bool {
 	switch err.(type) {
@@ -70,4 +73,8 @@ var UntrustedCert = ClassifierFunc(func(err error) bool {
 	default:
 		return false
 	}
+})
+
+var IdempotentRequestEOF = ClassifierFunc(func(err error) bool {
+	return err == IdempotentRequestEOFError
 })

--- a/proxy/fails/classifier_group.go
+++ b/proxy/fails/classifier_group.go
@@ -19,6 +19,7 @@ var RetriableClassifiers = ClassifierGroup{
 	RemoteHandshakeTimeout,
 	UntrustedCert,
 	ExpiredOrNotYetValidCertFailure,
+	IdempotentRequestEOF,
 }
 
 var FailableClassifiers = ClassifierGroup{

--- a/proxy/fails/classifier_group_test.go
+++ b/proxy/fails/classifier_group_test.go
@@ -42,6 +42,7 @@ var _ = Describe("ClassifierGroup", func() {
 			Expect(rc.Classify(x509.UnknownAuthorityError{})).To(BeTrue())
 			Expect(rc.Classify(x509.CertificateInvalidError{Reason: x509.Expired})).To(BeTrue())
 			Expect(rc.Classify(errors.New("i'm a potato"))).To(BeFalse())
+			Expect(rc.Classify(fails.IdempotentRequestEOFError)).To(BeTrue())
 		})
 	})
 
@@ -59,6 +60,7 @@ var _ = Describe("ClassifierGroup", func() {
 			Expect(pc.Classify(x509.UnknownAuthorityError{})).To(BeTrue())
 			Expect(pc.Classify(x509.CertificateInvalidError{Reason: x509.Expired})).To(BeTrue())
 			Expect(pc.Classify(errors.New("i'm a potato"))).To(BeFalse())
+			Expect(pc.Classify(fails.IdempotentRequestEOFError)).To(BeTrue())
 		})
 	})
 })

--- a/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/proxy/round_tripper/proxy_round_tripper_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +20,7 @@ import (
 	sharedfakes "code.cloudfoundry.org/gorouter/fakes"
 	"code.cloudfoundry.org/gorouter/handlers"
 	"code.cloudfoundry.org/gorouter/metrics/fakes"
+	"code.cloudfoundry.org/gorouter/proxy/fails"
 	errorClassifierFakes "code.cloudfoundry.org/gorouter/proxy/fails/fakes"
 	"code.cloudfoundry.org/gorouter/proxy/handler"
 	"code.cloudfoundry.org/gorouter/proxy/round_tripper"
@@ -28,6 +30,7 @@ import (
 	"code.cloudfoundry.org/gorouter/test_util"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/uber-go/zap"
@@ -364,6 +367,94 @@ var _ = Describe("ProxyRoundTripper", func() {
 					Expect(logOutput).To(gbytes.Say(`vcap_request_id`))
 				})
 			})
+
+			DescribeTable("when the backend fails with an empty reponse error (io.EOF)",
+				func(reqBody io.ReadCloser, getBodyIsNil bool, reqMethod string, headers map[string]string, expectRetry bool) {
+					badResponse := &http.Response{
+						Header: make(map[string][]string),
+					}
+					badResponse.Header.Add(handlers.VcapRequestIdHeader, "some-request-id")
+
+					// The first request fails with io.EOF, the second (if retried) succeeds
+					transport.RoundTripStub = func(*http.Request) (*http.Response, error) {
+						switch transport.RoundTripCallCount() {
+						case 1:
+							return nil, io.EOF
+						case 2:
+							return &http.Response{StatusCode: http.StatusTeapot}, nil
+						default:
+							return nil, nil
+						}
+					}
+
+					retriableClassifier.ClassifyStub = fails.IdempotentRequestEOF
+					req.Method = reqMethod
+					req.Body = reqBody
+					if !getBodyIsNil {
+						req.GetBody = func() (io.ReadCloser, error) {
+							return new(testBody), nil
+						}
+					}
+					if headers != nil {
+						for key, value := range headers {
+							req.Header.Add(key, value)
+						}
+					}
+
+					res, err := proxyRoundTripper.RoundTrip(req)
+
+					if expectRetry {
+						Expect(err).NotTo(HaveOccurred())
+						Expect(transport.RoundTripCallCount()).To(Equal(2))
+						Expect(retriableClassifier.ClassifyCallCount()).To(Equal(1))
+						Expect(res.StatusCode).To(Equal(http.StatusTeapot))
+					} else {
+						Expect(err).To(Equal(io.EOF))
+						Expect(transport.RoundTripCallCount()).To(Equal(1))
+						Expect(retriableClassifier.ClassifyCallCount()).To(Equal(1))
+					}
+				},
+
+				Entry("POST, body is empty: does not retry", nil, true, "POST", nil, false),
+				Entry("POST, body is not empty and GetBody is non-nil: does not retry", reqBody, false, "POST", nil, false),
+				Entry("POST, body is not empty: does not retry", reqBody, true, "POST", nil, false),
+				Entry("POST, body is http.NoBody: does not retry", http.NoBody, true, "POST", nil, false),
+
+				Entry("POST, body is empty, X-Idempotency-Key header: attempts retry", nil, true, "POST", map[string]string{"X-Idempotency-Key": "abc123"}, true),
+				Entry("POST, body is not empty and GetBody is non-nil, X-Idempotency-Key header: attempts retry", reqBody, false, "POST", map[string]string{"X-Idempotency-Key": "abc123"}, true),
+				Entry("POST, body is not empty, X-Idempotency-Key header: does not retry", reqBody, true, "POST", map[string]string{"X-Idempotency-Key": "abc123"}, false),
+				Entry("POST, body is http.NoBody, X-Idempotency-Key header: does not retry", http.NoBody, true, "POST", map[string]string{"X-Idempotency-Key": "abc123"}, false),
+
+				Entry("POST, body is empty, Idempotency-Key header: attempts retry", nil, true, "POST", map[string]string{"Idempotency-Key": "abc123"}, true),
+				Entry("POST, body is not empty and GetBody is non-nil, Idempotency-Key header: attempts retry", reqBody, false, "POST", map[string]string{"Idempotency-Key": "abc123"}, true),
+				Entry("POST, body is not empty, Idempotency-Key header: does not retry", reqBody, true, "POST", map[string]string{"Idempotency-Key": "abc123"}, false),
+				Entry("POST, body is http.NoBody, Idempotency-Key header: does not retry", http.NoBody, true, "POST", map[string]string{"Idempotency-Key": "abc123"}, false),
+
+				Entry("GET, body is empty: attempts retry", nil, true, "GET", nil, true),
+				Entry("GET, body is not empty and GetBody is non-nil: attempts retry", reqBody, false, "GET", nil, true),
+				Entry("GET, body is not empty: does not retry", reqBody, true, "GET", nil, false),
+				Entry("GET, body is http.NoBody: does not retry", http.NoBody, true, "GET", nil, false),
+
+				Entry("TRACE, body is empty: attempts retry", nil, true, "TRACE", nil, true),
+				Entry("TRACE, body is not empty: does not retry", reqBody, true, "TRACE", nil, false),
+				Entry("TRACE, body is http.NoBody: does not retry", http.NoBody, true, "TRACE", nil, false),
+				Entry("TRACE, body is not empty and GetBody is non-nil: attempts retry", reqBody, false, "TRACE", nil, true),
+
+				Entry("HEAD, body is empty: attempts retry", nil, true, "HEAD", nil, true),
+				Entry("HEAD, body is not empty: does not retry", reqBody, true, "HEAD", nil, false),
+				Entry("HEAD, body is http.NoBody: does not retry", http.NoBody, true, "HEAD", nil, false),
+				Entry("HEAD, body is not empty and GetBody is non-nil: attempts retry", reqBody, false, "HEAD", nil, true),
+
+				Entry("OPTIONS, body is empty: attempts retry", nil, true, "OPTIONS", nil, true),
+				Entry("OPTIONS, body is not empty and GetBody is non-nil: attempts retry", reqBody, false, "OPTIONS", nil, true),
+				Entry("OPTIONS, body is not empty: does not retry", reqBody, true, "OPTIONS", nil, false),
+				Entry("OPTIONS, body is http.NoBody: does not retry", http.NoBody, true, "OPTIONS", nil, false),
+
+				Entry("<empty method>, body is empty: attempts retry", nil, true, "", nil, true),
+				Entry("<empty method>, body is not empty and GetBody is non-nil: attempts retry", reqBody, false, "", nil, true),
+				Entry("<empty method>, body is not empty: does not retry", reqBody, true, "", nil, false),
+				Entry("<empty method>, body is http.NoBody: does not retry", http.NoBody, true, "", nil, false),
+			)
 
 			Context("when there are no more endpoints available", func() {
 				BeforeEach(func() {


### PR DESCRIPTION
* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite

---

This PR updates gorouter behaviour so that existing retry logic _to the same endpoint_ for idempotent requests is also attempted _accross endpoints_, for the case when the server fails to provide an HTTP response.

The Go standard library default HTTP transport retries requests on encountering certain errors where the request qualifies as being idempotent. [Specifically](https://github.com/golang/go/blob/master/src/net/http/transport.go#L87-L94):

```
// Transport only retries a request upon encountering a network error
// if the request is idempotent and either has no body or has its
// Request.GetBody defined. HTTP requests are considered idempotent if
// they have HTTP methods GET, HEAD, OPTIONS, or TRACE; or if their
// Header map contains an "Idempotency-Key" or "X-Idempotency-Key"
// entry. If the idempotency key value is a zero-length slice, the
// request is treated as idempotent but the header is not sent on the
// wire.
```

This was implemented in [2013](https://github.com/golang/go/commit/5dd372bd1e70949a432d9b7b8b021d13abf584d1) and updated in [2018](https://go-review.googlesource.com/c/go/+/147457/ ) to add support for idempotency key headers. 

Errors which allow retries to take place are an [HTTP2 cached connections issue](https://github.com/golang/go/blob/master/src/net/http/transport.go#L681) and the following [two errors](https://github.com/golang/go/blob/master/src/net/http/transport.go#L713-L723):

```golang
if _, ok := err.(transportReadFromServerError); ok {
  // We got some non-EOF net.Conn.Read failure reading
  // the 1st response byte from the server.
  return true
}
if err == errServerClosedIdle {
  // The server replied with io.EOF while we were trying to
  // read the response. Probably an unfortunately keep-alive
  // timeout, just as the client was writing a request.
  return true
}
```

Retrying when the above two errors occur runs the risk of [mutating non-idempotent requests](https://github.com/cloudfoundry/gorouter/blob/379860daa83a162ffe0b6039eafb7c8bfa1eaccf/proxy/fails/classifier_group.go#L11) causing bad things to happen (eg duplicate charges), which is why the go standard library only attempts to make these requests when the request meet the idempotency criteria. The current Gorouter ProxyRoundTripper delegates backend requests to the dropsondeRoundTripper which itself delegates requests to the standard library default transport. By virtue of delegating to transport.go's RoundTrip method the Gorouter _already_ retries and accepts the risk of retrying potentially mutating non-idempotent requests, when those requests meet the idempotency criteria required by [http.Request.isReplayable()](https://github.com/golang/go/blob/5c489514bc5e61ad9b5b07bd7d8ec65d66a0512a/src/net/http/request.go#L1413-L1427). As this risk is already accepted and acted on by the Gorouter this PR updates behaviour so that:
1. empty server response errors (ie `io.EOF` errors) for qualifying requests are retried
2. retries happen across endpoints

At least [one scenario](https://github.com/cloudfoundry/routing-release/issues/187) where extending idempotent request retry logic to other endpoints would help improve the stability of Cloud Foundry is when route integrity is enabled and the Envoy sidecar is listening but the application is not yet listening, either because it is being started or has crashed or some other reason. In this situation the following happens:

1. The gorouter successfully establishes a TCP connection to the Envoy TCP Proxy
2. Envoy cannot proxy the request so does not respond*
4. The gorouter proxy round tripper gets an `io.EOF` error from the standard library HTTP transport and returns it to the user as an [`endpoint_failure`](https://docs.cloudfoundry.org/adminguide/troubleshooting-router-error-responses.html#app-errors)-type 502 error.

--- 

I was unable to find an implementation I was completely happy but I went with this: I've added a check in `ProxyRoundTripper#RoundTrip` to replace `io.EOF` with a new error type in cases where the request matches the idempotency criteria. This error is then checked by a new classifier added to the `RetriableClassifiers`  group. This avoids having to refactor the `Classifier` interface to add an `http.Request` argument, which would have needed a lot of refactoring to handle other areas in the code where classifier is called, such as when [pruning endpoints](https://github.com/cloudfoundry/gorouter/blob/main/route/pool.go#L398). If you have suggestions for better implementations, please share!

I implemented the unit tests as a table-based test in order to mirror the tests in the standard library's [transport_test.go](https://github.com/golang/go/blob/master/src/net/http/transport_test.go#L5683-L5734), but with some more cases as there were are a few code paths missing coverage in the standard library tests.

~This PR is not yet mergeable because I'm still waiting for some CLA-related admin, which will take about a week, but I'm publishing now to hopefully start a discussion about this change.~

cheers,

Pete

*After a successful three-way TCP handshake between the gorouter and Envoy, the gorouter sends the HTTP request data. Envoy does not respond so the gorouter closes the TCP connection after about half a second. 
