### PR TITLE
Add a feature flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -195,6 +195,7 @@ type Config struct {
 	EnableSSL       bool              `yaml:"enable_ssl,omitempty"`
 	SSLPort         uint16            `yaml:"ssl_port,omitempty"`
 	DisableHTTP     bool              `yaml:"disable_http,omitempty"`
+	EnableHTTP2     bool              `yaml:"enable_http2,omitempty"`
 	SSLCertificates []tls.Certificate `yaml:"-"`
 	TLSPEM          []TLSPem          `yaml:"tls_pem,omitempty"`
 	CACerts         string            `yaml:"ca_certs,omitempty"`
@@ -292,6 +293,7 @@ var defaultConfig = Config{
 	EnableSSL:     false,
 	SSLPort:       443,
 	DisableHTTP:   false,
+	EnableHTTP2:   false,
 	MinTLSVersion: tls.VersionTLS12,
 	MaxTLSVersion: tls.VersionTLS12,
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1399,6 +1399,23 @@ disable_http: true
 			})
 		})
 
+		Context("enable_http2", func() {
+			It("defaults to false", func() {
+				Expect(config.Process()).To(Succeed())
+				Expect(config.EnableHTTP2).To(BeFalse())
+			})
+
+			It("setting enable_http2 succeeds", func() {
+				var b = []byte(fmt.Sprintf(`
+enable_http2: true
+`))
+				err := config.Initialize(b)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(config.Process()).To(Succeed())
+				Expect(config.EnableHTTP2).To(BeTrue())
+			})
+		})
+
 		Context("When given a routing_table_sharding_mode that is supported ", func() {
 			Context("sharding mode `all`", func() {
 				It("succeeds", func() {

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -255,12 +255,14 @@ var _ = Describe("Router Integration", func() {
 			clientTLSConfig *tls.Config
 			mbusClient      *nats.Conn
 		)
+
 		BeforeEach(func() {
 			cfg, clientTLSConfig = createSSLConfig(statusPort, proxyPort, sslPort, natsPort)
-
 		})
+
 		JustBeforeEach(func() {
 			var err error
+			cfg.EnableHTTP2 = true
 			writeConfig(cfg, cfgFile)
 			mbusClient, err = newMessageBus(cfg)
 			Expect(err).ToNot(HaveOccurred())
@@ -297,7 +299,6 @@ var _ = Describe("Router Integration", func() {
 	})
 
 	Context("Drain", func() {
-
 		BeforeEach(func() {
 			cfg = createConfig(statusPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 1, false, 0, natsPort)
 		})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -174,7 +174,7 @@ func NewProxy(
 	n.Use(handlers.NewProxyHealthcheck(cfg.HealthCheckUserAgent, p.health, logger))
 	n.Use(zipkinHandler)
 	n.Use(w3cHandler)
-	n.Use(handlers.NewProtocolCheck(logger, errorWriter))
+	n.Use(handlers.NewProtocolCheck(logger, errorWriter, cfg.EnableHTTP2))
 	n.Use(handlers.NewLookup(registry, reporter, logger, errorWriter, cfg.EmptyPoolResponseCode503))
 	n.Use(handlers.NewClientCert(
 		SkipSanitize(routeServiceHandler.(*handlers.RouteService)),


### PR DESCRIPTION
- added EnableHTTP2 to config, which defaults to false
- passes to protocolcheck handler

[cloudfoundry/routing-release#200]

Co-authored-by: Weyman Fung <weymanf@vmware.com>