### PR TITLE
Log more backend endpoint info

### DIFF
--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -155,9 +155,11 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 				}
 
 				iter.EndpointFailed(err)
-				logger.Error("backend-endpoint-failed", zap.Error(err), zap.Int("attempt", retry+1), zap.String("vcap_request_id", request.Header.Get(handlers.VcapRequestIdHeader)))
 
-				if rt.retriableClassifier.Classify(err) {
+				retriable := rt.retriableClassifier.Classify(err)
+				logger.Error("backend-endpoint-failed", zap.Error(err), zap.Int("attempt", retry+1), zap.String("vcap_request_id", request.Header.Get(handlers.VcapRequestIdHeader)), zap.Bool("retriable", retriable))
+
+				if retriable {
 					logger.Debug("retriable-error", zap.Object("error", err))
 					continue
 				}

--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -124,6 +124,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 	}
 
 	stickyEndpointID := getStickySession(request, rt.stickySessionCookieNames)
+	numberOfEndpoints := reqInfo.RoutePool.NumEndpoints()
 	iter := reqInfo.RoutePool.Endpoints(rt.defaultLoadBalance, stickyEndpointID)
 
 	var selectEndpointErr error
@@ -157,7 +158,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 				iter.EndpointFailed(err)
 
 				retriable := rt.retriableClassifier.Classify(err)
-				logger.Error("backend-endpoint-failed", zap.Error(err), zap.Int("attempt", retry+1), zap.String("vcap_request_id", request.Header.Get(handlers.VcapRequestIdHeader)), zap.Bool("retriable", retriable))
+				logger.Error("backend-endpoint-failed", zap.Error(err), zap.Int("attempt", retry+1), zap.String("vcap_request_id", request.Header.Get(handlers.VcapRequestIdHeader)), zap.Bool("retriable", retriable), zap.Int("num-endpoints", numberOfEndpoints))
 
 				if retriable {
 					logger.Debug("retriable-error", zap.Object("error", err))

--- a/route/pool.go
+++ b/route/pool.go
@@ -342,6 +342,12 @@ func (p *EndpointPool) Endpoints(defaultLoadBalance, initial string) EndpointIte
 	}
 }
 
+func (p *EndpointPool) NumEndpoints() int {
+	p.Lock()
+	defer p.Unlock()
+	return len(p.endpoints)
+}
+
 func (p *EndpointPool) findById(id string) *endpointElem {
 	p.Lock()
 	defer p.Unlock()


### PR DESCRIPTION
* A short explanation of the proposed change: log a little more information when backend endpoints fail

* An explanation of the use cases your change solves: we are experiencing a small number of backend failures during platform updates. We would like a little more information in the logs, as provided by this PR

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics): can trigger this log by stopping a traffic-receiving VM with `bosh stop --skip-drain diego-cell/N`

* Expected result after the change: extra context in the logs, like can be seen here and in the PR:`{"log_level":3,"timestamp":"2021-07-13T15:01:30.452379948Z","message":"backend-endpoint-failed","source":"vcap.gorouter","data":{"retriable":true,"num-endpoints":1, [...]}}`

* Current result before the change: the `retriable` and `num-endpoints` fields aren't present, which makes it a little harder to follow what behaviour Gorouter will do next

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [x] I have deployed this in a CF environment and checked the new log fields print as expected

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
