### PR TITLE
Enable TLS 1.3 support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -418,8 +418,10 @@ func (c *Config) Process() error {
 			c.MinTLSVersion = tls.VersionTLS11
 		case "TLSv1.2", "":
 			c.MinTLSVersion = tls.VersionTLS12
+		case "TLSv1.3":
+			c.MinTLSVersion = tls.VersionTLS13
 		default:
-			return fmt.Errorf(`router.min_tls_version should be one of "", "TLSv1.2", "TLSv1.1", "TLSv1.0"`)
+			return fmt.Errorf(`router.min_tls_version should be one of "", "TLSv1.3", "TLSv1.2", "TLSv1.1", "TLSv1.0"`)
 		}
 
 		switch c.MaxTLSVersionString {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -959,7 +959,7 @@ route_services_secret_decrypt_only: 1PfbARmvIn6cgyKorA1rqR2d34rBOo+z3qJGz17pi8Y=
 					configBytes := createYMLSnippet(configSnippet)
 					err := config.Initialize(configBytes)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(config.Process()).To(MatchError(`router.min_tls_version should be one of "", "TLSv1.2", "TLSv1.1", "TLSv1.0"`))
+					Expect(config.Process()).To(MatchError(`router.min_tls_version should be one of "", "TLSv1.3", "TLSv1.2", "TLSv1.1", "TLSv1.0"`))
 				})
 			})
 			Context("when min_tls_version is not set", func() {


### PR DESCRIPTION
 * Added 1.3 as one of the supported min tls version

 * A short explanation of the proposed change: Enabling TLS 1.3 support
 * An explanation of the use cases your change solves:  This PR expands support for TLS 1.3
 * Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics) - Is OPS manager under "Networking" - > Minimum version of TLS supported by the Gorouter and **HAProxy** a new 1.3 option will show up.
 * Expected result after the change - Minimum TLS version will show 1.3 as an option
 * Current result before the change - Currently the minimum TLS will not show version 1.3 as an option and default max tls version will be set to 1.2
 * Links to any other associated PRs - https://github.com/cloudfoundry/routing-release/pull/212
 * [x]  I have viewed signed and have submitted the Contributor License Agreement
 * [x]  I have made this pull request to the `main` branch
 * [x]  I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).
 * [ ]  (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite
 * [ ]  (Optional) I have run CF Acceptance Tests on bosh lite