### PR TITLE
Http2 backend support

### DIFF
--- a/mbus/subscriber.go
+++ b/mbus/subscriber.go
@@ -52,11 +52,16 @@ func (rm *RegistryMessage) makeEndpoint() (*route.Endpoint, error) {
 		updatedAt = time.Unix(0, rm.EndpointUpdatedAtNs).UTC()
 	}
 
+	protocol := rm.Protocol
+	if protocol == "" {
+		protocol = "http1"
+	}
+
 	return route.NewEndpoint(&route.EndpointOpts{
 		AppId:                   rm.App,
 		Host:                    rm.Host,
 		Port:                    port,
-		Protocol:                rm.Protocol,
+		Protocol:                protocol,
 		ServerCertDomainSAN:     rm.ServerCertDomainSAN,
 		PrivateInstanceId:       rm.PrivateInstanceID,
 		PrivateInstanceIndex:    rm.PrivateInstanceIndex,

--- a/mbus/subscriber.go
+++ b/mbus/subscriber.go
@@ -28,6 +28,7 @@ import (
 type RegistryMessage struct {
 	Host                    string            `json:"host"`
 	Port                    uint16            `json:"port"`
+	Protocol                string            `json:"protocol"`
 	TLSPort                 uint16            `json:"tls_port"`
 	Uris                    []route.Uri       `json:"uris"`
 	Tags                    map[string]string `json:"tags"`
@@ -55,6 +56,7 @@ func (rm *RegistryMessage) makeEndpoint() (*route.Endpoint, error) {
 		AppId:                   rm.App,
 		Host:                    rm.Host,
 		Port:                    port,
+		Protocol:                rm.Protocol,
 		ServerCertDomainSAN:     rm.ServerCertDomainSAN,
 		PrivateInstanceId:       rm.PrivateInstanceID,
 		PrivateInstanceIndex:    rm.PrivateInstanceIndex,

--- a/mbus/subscriber_easyjson.go
+++ b/mbus/subscriber_easyjson.go
@@ -159,6 +159,8 @@ func easyjson639f989aDecodeCodeCloudfoundryOrgGorouterMbus2(in *jlexer.Lexer, ou
 			out.Host = string(in.String())
 		case "port":
 			out.Port = uint16(in.Uint16())
+		case "protocol":
+			out.Protocol = string(in.String())
 		case "tls_port":
 			out.TLSPort = uint16(in.Uint16())
 		case "uris":
@@ -246,6 +248,12 @@ func easyjson639f989aEncodeCodeCloudfoundryOrgGorouterMbus2(out *jwriter.Writer,
 	first = false
 	out.RawString("\"port\":")
 	out.Uint16(uint16(in.Port))
+	if !first {
+		out.RawByte(',')
+	}
+	first = false
+	out.RawString("\"protocol\":")
+	out.String(string(in.Protocol))
 	if !first {
 		out.RawByte(',')
 	}

--- a/mbus/subscriber_test.go
+++ b/mbus/subscriber_test.go
@@ -349,6 +349,37 @@ var _ = Describe("Subscriber", func() {
 		})
 	})
 
+	Context("when the message does not contain a protocol", func() {
+		BeforeEach(func() {
+			sub = mbus.NewSubscriber(natsClient, registry, cfg, reconnected, l)
+			process = ifrit.Invoke(sub)
+			Eventually(process.Ready()).Should(BeClosed())
+		})
+		It("endpoint is constructed with protocol http1", func() {
+			msg := mbus.RegistryMessage{
+				Host: "host",
+				App:  "app",
+				Uris: []route.Uri{"test.example.com"},
+			}
+
+			data, err := json.Marshal(msg)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = natsClient.Publish("router.register", data)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(registry.RegisterCallCount).Should(Equal(1))
+			_, originalEndpoint := registry.RegisterArgsForCall(0)
+			expectedEndpoint := route.NewEndpoint(&route.EndpointOpts{
+				Host:     "host",
+				AppId:    "app",
+				Protocol: "http1",
+			})
+
+			Expect(originalEndpoint).To(Equal(expectedEndpoint))
+		})
+	})
+
 	Context("when the message contains a protocol", func() {
 		BeforeEach(func() {
 			sub = mbus.NewSubscriber(natsClient, registry, cfg, reconnected, l)
@@ -412,6 +443,7 @@ var _ = Describe("Subscriber", func() {
 				Host:                    "host",
 				AppId:                   "app",
 				Port:                    1999,
+				Protocol:                "http1",
 				UseTLS:                  true,
 				ServerCertDomainSAN:     "san",
 				PrivateInstanceId:       "id",
@@ -445,6 +477,7 @@ var _ = Describe("Subscriber", func() {
 		expectedEndpoint := route.NewEndpoint(&route.EndpointOpts{
 			Host:      "host",
 			Port:      1111,
+			Protocol:  "http1",
 			UpdatedAt: time.Unix(0, 1234).UTC(),
 		})
 
@@ -483,6 +516,7 @@ var _ = Describe("Subscriber", func() {
 				Host:                    "host",
 				AppId:                   "app",
 				Port:                    1111,
+				Protocol:                "http1",
 				UseTLS:                  false,
 				ServerCertDomainSAN:     "san",
 				PrivateInstanceId:       "id",

--- a/proxy/proxy_suite_test.go
+++ b/proxy/proxy_suite_test.go
@@ -144,7 +144,7 @@ var _ = AfterEach(func() {
 })
 
 func shouldEcho(input string, expected string) {
-	ln := test_util.RegisterHandler(r, "encoding", func(x *test_util.HttpConn) {
+	ln := test_util.RegisterConnHandler(r, "encoding", func(x *test_util.HttpConn) {
 		x.CheckLine("GET " + expected + " HTTP/1.1")
 		resp := test_util.NewResponse(http.StatusOK)
 		x.WriteResponse(resp)

--- a/proxy/proxy_suite_test.go
+++ b/proxy/proxy_suite_test.go
@@ -132,8 +132,15 @@ var _ = JustBeforeEach(func() {
 
 	p = proxy.NewProxy(testLogger, al, ew, conf, r, fakeReporter, routeServiceConfig, tlsConfig, tlsConfig, healthStatus, fakeRouteServicesClient)
 
-	server := http.Server{Handler: p}
-	go server.Serve(proxyServer)
+	if conf.EnableHTTP2 {
+		server := http.Server{Handler: p}
+		tlsConfig.NextProtos = []string{"h2", "http/1.1"}
+		tlsListener := tls.NewListener(proxyServer, tlsConfig)
+		go server.Serve(tlsListener)
+	} else {
+		server := http.Server{Handler: p}
+		go server.Serve(proxyServer)
+	}
 })
 
 var _ = AfterEach(func() {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -39,7 +39,7 @@ import (
 var _ = Describe("Proxy", func() {
 	Describe("Supported HTTP Protocol Versions", func() {
 		It("responds to http/1.0", func() {
-			ln := test_util.RegisterHandler(r, "test", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "test", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET / HTTP/1.1")
 
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
@@ -57,7 +57,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("responds to HTTP/1.1", func() {
-			ln := test_util.RegisterHandler(r, "test", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "test", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET / HTTP/1.1")
 
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
@@ -90,14 +90,14 @@ var _ = Describe("Proxy", func() {
 
 	Describe("URL Handling", func() {
 		It("responds transparently to a trailing slash versus no trailing slash", func() {
-			lnWithoutSlash := test_util.RegisterHandler(r, "test/my%20path/your_path", func(conn *test_util.HttpConn) {
+			lnWithoutSlash := test_util.RegisterConnHandler(r, "test/my%20path/your_path", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET /my%20path/your_path/ HTTP/1.1")
 
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
 			})
 			defer lnWithoutSlash.Close()
 
-			lnWithSlash := test_util.RegisterHandler(r, "test/another-path/your_path/", func(conn *test_util.HttpConn) {
+			lnWithSlash := test_util.RegisterConnHandler(r, "test/another-path/your_path/", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET /another-path/your_path HTTP/1.1")
 
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
@@ -121,7 +121,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("does not append ? to the request", func() {
-			ln := test_util.RegisterHandler(r, "test/?", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "test/?", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET /? HTTP/1.1")
 
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
@@ -137,7 +137,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("responds to http/1.0 with path", func() {
-			ln := test_util.RegisterHandler(r, "test/my_path", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "test/my_path", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET /my_path HTTP/1.1")
 
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
@@ -155,7 +155,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("responds to http/1.0 with path/path", func() {
-			ln := test_util.RegisterHandler(r, "test/my%20path/your_path", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "test/my%20path/your_path", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET /my%20path/your_path HTTP/1.1")
 
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
@@ -173,7 +173,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("responds to HTTP/1.1 with absolute-form request target", func() {
-			ln := test_util.RegisterHandler(r, "test.io", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "test.io", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET http://test.io/ HTTP/1.1")
 
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
@@ -192,7 +192,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("responds to http/1.1 with absolute-form request that has encoded characters in the path", func() {
-			ln := test_util.RegisterHandler(r, "test.io/my%20path/your_path", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "test.io/my%20path/your_path", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET http://test.io/my%20path/your_path HTTP/1.1")
 
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
@@ -237,7 +237,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("treats double slashes in request URI as an absolute-form request target", func() {
-			ln := test_util.RegisterHandler(r, "test.io", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "test.io", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET http://test.io//something.io HTTP/1.1")
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
 			})
@@ -254,7 +254,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("handles double slashes in an absolute-form request target correctly", func() {
-			ln := test_util.RegisterHandler(r, "test.io", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "test.io", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET http://test.io//something.io?q=something HTTP/1.1")
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
 			})
@@ -289,7 +289,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		JustBeforeEach(func() {
-			ln = test_util.RegisterHandler(r, "app", func(conn *test_util.HttpConn) {
+			ln = test_util.RegisterConnHandler(r, "app", func(conn *test_util.HttpConn) {
 				tmpReq, err := http.ReadRequest(conn.Reader)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -426,7 +426,7 @@ var _ = Describe("Proxy", func() {
 
 	Describe("Response Handling", func() {
 		It("trace headers added on correct TraceKey", func() {
-			ln := test_util.RegisterHandler(r, "trace-test", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "trace-test", func(conn *test_util.HttpConn) {
 				_, err := http.ReadRequest(conn.Reader)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -450,7 +450,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("trace headers not added on incorrect TraceKey", func() {
-			ln := test_util.RegisterHandler(r, "trace-test", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "trace-test", func(conn *test_util.HttpConn) {
 				_, err := http.ReadRequest(conn.Reader)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -473,7 +473,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("adds X-Vcap-Request-Id if it doesn't already exist in the response", func() {
-			ln := test_util.RegisterHandler(r, "vcap-id-test", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "vcap-id-test", func(conn *test_util.HttpConn) {
 				_, err := http.ReadRequest(conn.Reader)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -494,7 +494,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("does not adds X-Vcap-Request-Id if it already exists in the response", func() {
-			ln := test_util.RegisterHandler(r, "vcap-id-test", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "vcap-id-test", func(conn *test_util.HttpConn) {
 				_, err := http.ReadRequest(conn.Reader)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -516,7 +516,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("Status No Content returns no Transfer Encoding response header", func() {
-			ln := test_util.RegisterHandler(r, "not-modified", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "not-modified", func(conn *test_util.HttpConn) {
 				_, err := http.ReadRequest(conn.Reader)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -540,7 +540,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("transfers chunked encodings", func() {
-			ln := test_util.RegisterHandler(r, "chunk", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "chunk", func(conn *test_util.HttpConn) {
 				r, w := io.Pipe()
 
 				// Write 3 times on a 100ms interval
@@ -592,7 +592,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("disables compression", func() {
-			ln := test_util.RegisterHandler(r, "remote", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "remote", func(conn *test_util.HttpConn) {
 				request, _ := http.ReadRequest(conn.Reader)
 				encoding := request.Header["Accept-Encoding"]
 				var resp *http.Response
@@ -617,7 +617,7 @@ var _ = Describe("Proxy", func() {
 
 	Describe("HTTP Rewrite", func() {
 		mockedHandler := func(host string, headers []string) net.Listener {
-			return test_util.RegisterHandler(r, host, func(conn *test_util.HttpConn) {
+			return test_util.RegisterConnHandler(r, host, func(conn *test_util.HttpConn) {
 				_, err := http.ReadRequest(conn.Reader)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -722,7 +722,7 @@ var _ = Describe("Proxy", func() {
 			})
 
 			It("responds with 503 after conn limit is reached ", func() {
-				ln := test_util.RegisterHandler(r, "sleep", func(x *test_util.HttpConn) {
+				ln := test_util.RegisterConnHandler(r, "sleep", func(x *test_util.HttpConn) {
 					defer GinkgoRecover()
 					_, err := http.ReadRequest(x.Reader)
 					Expect(err).NotTo(HaveOccurred())
@@ -765,7 +765,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("request terminates with slow response", func() {
-			ln := test_util.RegisterHandler(r, "slow-app", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "slow-app", func(conn *test_util.HttpConn) {
 				_, err := http.ReadRequest(conn.Reader)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -792,7 +792,7 @@ var _ = Describe("Proxy", func() {
 
 		It("proxy closes connections with slow apps", func() {
 			serverResult := make(chan error)
-			ln := test_util.RegisterHandler(r, "slow-app", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "slow-app", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET / HTTP/1.1")
 
 				timesToTick := 5
@@ -840,7 +840,7 @@ var _ = Describe("Proxy", func() {
 		It("proxy detects closed client connection", func() {
 			serverResult := make(chan error)
 			readRequest := make(chan struct{})
-			ln := test_util.RegisterHandler(r, "slow-app", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "slow-app", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET / HTTP/1.1")
 
 				readRequest <- struct{}{}
@@ -882,7 +882,7 @@ var _ = Describe("Proxy", func() {
 		It("proxy closes connections to backends when client closes the connection", func() {
 			serverResult := make(chan error)
 			readRequest := make(chan struct{})
-			ln := test_util.RegisterHandler(r, "slow-app", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "slow-app", func(conn *test_util.HttpConn) {
 				conn.CheckLine("GET / HTTP/1.1")
 
 				readRequest <- struct{}{}
@@ -917,7 +917,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("retries when failed endpoints exist", func() {
-			ln := test_util.RegisterHandler(r, "retries", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "retries", func(conn *test_util.HttpConn) {
 				req, _ := conn.ReadRequest()
 				Expect(req.Method).To(Equal("GET"))
 				Expect(req.Host).To(Equal("retries"))
@@ -956,7 +956,7 @@ var _ = Describe("Proxy", func() {
 				caCertPool = x509.NewCertPool()
 				caCertPool.AppendCertsFromPEM(certChain.CACertPEM)
 
-				nl = test_util.RegisterHandler(r, "backend-with-different-instance-id", func(conn *test_util.HttpConn) {
+				nl = test_util.RegisterConnHandler(r, "backend-with-different-instance-id", func(conn *test_util.HttpConn) {
 					_, err := http.ReadRequest(conn.Reader)
 					Expect(err).To(HaveOccurred())
 					resp := test_util.NewResponse(http.StatusServiceUnavailable)
@@ -1106,7 +1106,7 @@ var _ = Describe("Proxy", func() {
 
 	Describe("Access Logging", func() {
 		It("logs a request", func() {
-			ln := test_util.RegisterHandler(r, "test", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "test", func(conn *test_util.HttpConn) {
 				req, body := conn.ReadRequest()
 				Expect(req.Method).To(Equal("POST"))
 				Expect(req.URL.Path).To(Equal("/"))
@@ -1155,7 +1155,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("logs a request when X-Forwarded-Proto and X-Forwarded-For are provided", func() {
-			ln := test_util.RegisterHandler(r, "test", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "test", func(conn *test_util.HttpConn) {
 				conn.ReadRequest()
 				conn.WriteResponse(test_util.NewResponse(http.StatusOK))
 			})
@@ -1227,12 +1227,12 @@ var _ = Describe("Proxy", func() {
 				uuid1, _ = uuid.NewV4()
 				uuid2, _ = uuid.NewV4()
 
-				ln = test_util.RegisterHandler(r, "app."+test_util.LocalhostDNS, func(conn *test_util.HttpConn) {
+				ln = test_util.RegisterConnHandler(r, "app."+test_util.LocalhostDNS, func(conn *test_util.HttpConn) {
 					Fail("App should not have received request")
 				}, test_util.RegisterConfig{AppId: uuid1.String()})
 				defer ln.Close()
 
-				ln2 = test_util.RegisterHandler(r, "app."+test_util.LocalhostDNS, func(conn *test_util.HttpConn) {
+				ln2 = test_util.RegisterConnHandler(r, "app."+test_util.LocalhostDNS, func(conn *test_util.HttpConn) {
 					req, err := http.ReadRequest(conn.Reader)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1280,7 +1280,7 @@ var _ = Describe("Proxy", func() {
 
 			It("x_b3_traceid does show up in the access log", func() {
 				done := make(chan string)
-				ln := test_util.RegisterHandler(r, "app", func(conn *test_util.HttpConn) {
+				ln := test_util.RegisterConnHandler(r, "app", func(conn *test_util.HttpConn) {
 					req, err := http.ReadRequest(conn.Reader)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1386,7 +1386,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("responds to misbehaving host with 502", func() {
-			ln := test_util.RegisterHandler(r, "enfant-terrible", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "enfant-terrible", func(conn *test_util.HttpConn) {
 				conn.Close()
 			})
 			defer ln.Close()
@@ -1414,7 +1414,7 @@ var _ = Describe("Proxy", func() {
 			}
 
 			nilEndpointsTest := func(expectedStatusCode int) {
-				ln := test_util.RegisterHandler(r, "nil-endpoint", func(conn *test_util.HttpConn) {
+				ln := test_util.RegisterConnHandler(r, "nil-endpoint", func(conn *test_util.HttpConn) {
 					conn.CheckLine("GET / HTTP/1.1")
 					resp := test_util.NewResponse(http.StatusOK)
 					conn.WriteResponse(resp)
@@ -1460,7 +1460,7 @@ var _ = Describe("Proxy", func() {
 
 		Context("when the round trip errors and original client has disconnected", func() {
 			It("response code is always 499", func() {
-				ln := test_util.RegisterHandler(r, "post-some-data", func(conn *test_util.HttpConn) {
+				ln := test_util.RegisterConnHandler(r, "post-some-data", func(conn *test_util.HttpConn) {
 					req, err := http.ReadRequest(conn.Reader)
 					if err != nil {
 						fmt.Println(err)
@@ -1534,7 +1534,7 @@ var _ = Describe("Proxy", func() {
 			It("responds with 503", func() {
 				done := make(chan bool)
 
-				ln := test_util.RegisterHandler(r, "ws", func(conn *test_util.HttpConn) {
+				ln := test_util.RegisterConnHandler(r, "ws", func(conn *test_util.HttpConn) {
 					req, err := http.ReadRequest(conn.Reader)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1580,7 +1580,7 @@ var _ = Describe("Proxy", func() {
 		It("upgrades for a WebSocket request", func() {
 			done := make(chan bool)
 
-			ln := test_util.RegisterHandler(r, "ws", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "ws", func(conn *test_util.HttpConn) {
 				req, err := http.ReadRequest(conn.Reader)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1625,7 +1625,7 @@ var _ = Describe("Proxy", func() {
 		It("upgrades for a WebSocket request with comma-separated Connection header", func() {
 			done := make(chan bool)
 
-			ln := test_util.RegisterHandler(r, "ws-cs-header", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "ws-cs-header", func(conn *test_util.HttpConn) {
 				req, err := http.ReadRequest(conn.Reader)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1671,7 +1671,7 @@ var _ = Describe("Proxy", func() {
 		It("upgrades for a WebSocket request with multiple Connection headers", func() {
 			done := make(chan bool)
 
-			ln := test_util.RegisterHandler(r, "ws-cs-header", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "ws-cs-header", func(conn *test_util.HttpConn) {
 				req, err := http.ReadRequest(conn.Reader)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1718,7 +1718,7 @@ var _ = Describe("Proxy", func() {
 
 		It("logs the response time and status code 101 in the access logs", func() {
 			done := make(chan bool)
-			ln := test_util.RegisterHandler(r, "ws", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "ws", func(conn *test_util.HttpConn) {
 				req, err := http.ReadRequest(conn.Reader)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1777,7 +1777,7 @@ var _ = Describe("Proxy", func() {
 		})
 
 		It("emits a xxx metric", func() {
-			ln := test_util.RegisterHandler(r, "ws-cs-header", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "ws-cs-header", func(conn *test_util.HttpConn) {
 				resp := test_util.NewResponse(http.StatusSwitchingProtocols)
 				resp.Header.Set("Upgrade", "Websocket")
 				resp.Header.Set("Connection", "Upgrade")
@@ -1808,7 +1808,7 @@ var _ = Describe("Proxy", func() {
 
 		It("does not emit a latency metric", func() {
 			var wg sync.WaitGroup
-			ln := test_util.RegisterHandler(r, "ws-cs-header", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "ws-cs-header", func(conn *test_util.HttpConn) {
 				defer conn.Close()
 				defer wg.Done()
 				resp := test_util.NewResponse(http.StatusSwitchingProtocols)
@@ -1891,7 +1891,7 @@ var _ = Describe("Proxy", func() {
 
 	Describe("Metrics", func() {
 		It("captures the routing response", func() {
-			ln := test_util.RegisterHandler(r, "reporter-test", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "reporter-test", func(conn *test_util.HttpConn) {
 				_, err := http.ReadRequest(conn.Reader)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1931,7 +1931,7 @@ var _ = Describe("Proxy", func() {
 
 		It("emits HTTP startstop events", func() {
 			var vcapHeader string
-			ln := test_util.RegisterHandler(r, "app", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "app", func(conn *test_util.HttpConn) {
 				req, _ := conn.ReadRequest()
 				vcapHeader = req.Header.Get(handlers.VcapRequestIdHeader)
 				resp := test_util.NewResponse(http.StatusOK)
@@ -1975,7 +1975,7 @@ var _ = Describe("Proxy", func() {
 			}
 
 			metricsNilEndpointsTest := func(expectedStatusCode, expectedBadRequestCallCount int) {
-				ln := test_util.RegisterHandler(r, "nil-endpoint", func(conn *test_util.HttpConn) {
+				ln := test_util.RegisterConnHandler(r, "nil-endpoint", func(conn *test_util.HttpConn) {
 					conn.CheckLine("GET / HTTP/1.1")
 					resp := test_util.NewResponse(http.StatusOK)
 					conn.WriteResponse(resp)

--- a/proxy/round_tripper/dropsonde_round_tripper.go
+++ b/proxy/round_tripper/dropsonde_round_tripper.go
@@ -33,7 +33,7 @@ type FactoryImpl struct {
 	IsInstrumented       bool
 }
 
-func (t *FactoryImpl) New(expectedServerName string, isRouteService bool) ProxyRoundTripper {
+func (t *FactoryImpl) New(expectedServerName string, isRouteService bool, isHttp2 bool) ProxyRoundTripper {
 	var template *http.Transport
 	if isRouteService {
 		template = t.RouteServiceTemplate
@@ -52,6 +52,7 @@ func (t *FactoryImpl) New(expectedServerName string, isRouteService bool) ProxyR
 		DisableCompression:  template.DisableCompression,
 		TLSClientConfig:     customTLSConfig,
 		TLSHandshakeTimeout: template.TLSHandshakeTimeout,
+		ForceAttemptHTTP2:   isHttp2,
 	}
 	if t.IsInstrumented {
 		return NewDropsondeRoundTripper(newTransport)

--- a/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/proxy/round_tripper/proxy_round_tripper_test.go
@@ -48,13 +48,21 @@ func (t *testBody) Close() error {
 	return nil
 }
 
-type FakeRoundTripperFactory struct {
-	ReturnValue                round_tripper.ProxyRoundTripper
-	RequestedRoundTripperTypes []bool
+type RequestedRoundTripperType struct {
+	IsRouteService bool
+	IsHttp2        bool
 }
 
-func (f *FakeRoundTripperFactory) New(expectedServerName string, isRouteService bool) round_tripper.ProxyRoundTripper {
-	f.RequestedRoundTripperTypes = append(f.RequestedRoundTripperTypes, isRouteService)
+type FakeRoundTripperFactory struct {
+	ReturnValue                round_tripper.ProxyRoundTripper
+	RequestedRoundTripperTypes []RequestedRoundTripperType
+}
+
+func (f *FakeRoundTripperFactory) New(expectedServerName string, isRouteService bool, isHttp2 bool) round_tripper.ProxyRoundTripper {
+	f.RequestedRoundTripperTypes = append(f.RequestedRoundTripperTypes, RequestedRoundTripperType{
+		IsRouteService: isRouteService,
+		IsHttp2:        isHttp2,
+	})
 	return f.ReturnValue
 }
 
@@ -648,11 +656,15 @@ var _ = Describe("ProxyRoundTripper", func() {
 				It("re-uses transports for the same endpoint", func() {
 					_, err := proxyRoundTripper.RoundTrip(req)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]bool{false}))
+					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]RequestedRoundTripperType{
+						{IsRouteService: false, IsHttp2: false},
+					}))
 
 					_, err = proxyRoundTripper.RoundTrip(req)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]bool{false}))
+					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]RequestedRoundTripperType{
+						{IsRouteService: false, IsHttp2: false},
+					}))
 				})
 
 				It("does not re-use transports between endpoints", func() {
@@ -664,15 +676,43 @@ var _ = Describe("ProxyRoundTripper", func() {
 
 					_, err := proxyRoundTripper.RoundTrip(req)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]bool{false}))
+					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]RequestedRoundTripperType{
+						{IsRouteService: false, IsHttp2: false},
+					}))
 
 					_, err = proxyRoundTripper.RoundTrip(req)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]bool{false, false}))
+					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]RequestedRoundTripperType{
+						{IsRouteService: false, IsHttp2: false},
+						{IsRouteService: false, IsHttp2: false},
+					}))
 
 					_, err = proxyRoundTripper.RoundTrip(req)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]bool{false, false}))
+					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]RequestedRoundTripperType{
+						{IsRouteService: false, IsHttp2: false},
+						{IsRouteService: false, IsHttp2: false},
+					}))
+				})
+			})
+
+			Context("forcing HTTP/2", func() {
+				It("uses HTTP/2 when endpoint's Protocol is set to http2", func() {
+					endpoint.Protocol = "http2"
+					_, err := proxyRoundTripper.RoundTrip(req)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]RequestedRoundTripperType{
+						{IsRouteService: false, IsHttp2: true},
+					}))
+				})
+
+				It("does not use HTTP/2 when endpoint's Protocol is not set to http2", func() {
+					endpoint.Protocol = ""
+					_, err := proxyRoundTripper.RoundTrip(req)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]RequestedRoundTripperType{
+						{IsRouteService: false, IsHttp2: false},
+					}))
 				})
 			})
 

--- a/proxy/route_service_test.go
+++ b/proxy/route_service_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Route Services", func() {
 		})
 
 		It("return 502 Bad Gateway", func() {
-			ln := test_util.RegisterHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
 				defer GinkgoRecover()
 				Fail("Should not get here into the app")
 			}, test_util.RegisterConfig{RouteServiceUrl: routeServiceURL})
@@ -142,7 +142,7 @@ var _ = Describe("Route Services", func() {
 
 		Context("when a request does not have a valid Route service signature header", func() {
 			It("redirects the request to the route service url", func() {
-				ln := test_util.RegisterHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
+				ln := test_util.RegisterConnHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
 					defer GinkgoRecover()
 					Fail("Should not get here")
 				}, test_util.RegisterConfig{RouteServiceUrl: routeServiceURL})
@@ -163,7 +163,7 @@ var _ = Describe("Route Services", func() {
 
 			Context("when the route service is not available", func() {
 				It("returns a 502 bad gateway error", func() {
-					ln := test_util.RegisterHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
+					ln := test_util.RegisterConnHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
 						defer GinkgoRecover()
 						Fail("Should not get here")
 					}, test_util.RegisterConfig{RouteServiceUrl: "https://bad-route-service"})
@@ -192,7 +192,7 @@ var _ = Describe("Route Services", func() {
 			})
 
 			It("routes to the backend instance and strips headers", func() {
-				ln := test_util.RegisterHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
+				ln := test_util.RegisterConnHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
 					req, _ := conn.ReadRequest()
 					Expect(req.Header.Get(routeservice.HeaderKeySignature)).To(Equal(""))
 					Expect(req.Header.Get(routeservice.HeaderKeyMetadata)).To(Equal(""))
@@ -226,7 +226,7 @@ var _ = Describe("Route Services", func() {
 
 			Context("when request has Host header with a port", func() {
 				It("routes to backend instance and disregards port in Host header", func() {
-					ln := test_util.RegisterHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
+					ln := test_util.RegisterConnHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
 						conn.ReadRequest()
 						out := &bytes.Buffer{}
 						out.WriteString("backend instance")
@@ -258,7 +258,7 @@ var _ = Describe("Route Services", func() {
 
 			Context("and is forwarding to a route service on CF", func() {
 				It("does not strip the signature header", func() {
-					ln := test_util.RegisterHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
+					ln := test_util.RegisterConnHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
 						req, _ := conn.ReadRequest()
 						Expect(req.Header.Get(routeservice.HeaderKeySignature)).To(Equal("some-signature"))
 
@@ -319,7 +319,7 @@ var _ = Describe("Route Services", func() {
 			})
 
 			It("routes to backend over http scheme", func() {
-				ln := test_util.RegisterHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
+				ln := test_util.RegisterConnHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
 					defer GinkgoRecover()
 					Fail("Should not get here")
 				}, test_util.RegisterConfig{RouteServiceUrl: routeServiceURL})
@@ -346,7 +346,7 @@ var _ = Describe("Route Services", func() {
 		})
 
 		It("returns a 526", func() {
-			ln := test_util.RegisterHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
 				defer GinkgoRecover()
 				Fail("Should not get here")
 			}, test_util.RegisterConfig{RouteServiceUrl: routeServiceURL})
@@ -372,7 +372,7 @@ var _ = Describe("Route Services", func() {
 		})
 
 		It("returns a 200 when we route to a route service", func() {
-			ln := test_util.RegisterHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
+			ln := test_util.RegisterConnHandler(r, "my_host.com", func(conn *test_util.HttpConn) {
 				defer GinkgoRecover()
 				Fail("Should not get here")
 			}, test_util.RegisterConfig{RouteServiceUrl: routeServiceURL})
@@ -419,8 +419,8 @@ var _ = Describe("Route Services", func() {
 					conn.WriteResponse(resp)
 				}
 
-				rsListener := test_util.RegisterHandler(r, "route_service.com", routeServiceHandler, test_util.RegisterConfig{AppId: "my-route-service-app-id"})
-				appListener := test_util.RegisterHandler(r, "my_app.com", func(conn *test_util.HttpConn) {
+				rsListener := test_util.RegisterConnHandler(r, "route_service.com", routeServiceHandler, test_util.RegisterConfig{AppId: "my-route-service-app-id"})
+				appListener := test_util.RegisterConnHandler(r, "my_app.com", func(conn *test_util.HttpConn) {
 					conn.Close()
 				}, test_util.RegisterConfig{RouteServiceUrl: "https://route_service.com"})
 
@@ -481,14 +481,14 @@ var _ = Describe("Route Services", func() {
 					conn.WriteResponse(resp)
 				}
 
-				rsListener := test_util.RegisterHandler(r, "route_service.com", routeServiceHandler, test_util.RegisterConfig{
+				rsListener := test_util.RegisterConnHandler(r, "route_service.com", routeServiceHandler, test_util.RegisterConfig{
 					ServerCertDomainSAN: "route-service-san", InstanceId: "rs-instance", AppId: "my-route-service-app-id",
 					TLSConfig: &tls.Config{
 						Certificates: []tls.Certificate{rsTLSCert},
 					},
 				})
 
-				appListener := test_util.RegisterHandler(r, "my_app.com", func(conn *test_util.HttpConn) {
+				appListener := test_util.RegisterConnHandler(r, "my_app.com", func(conn *test_util.HttpConn) {
 					conn.Close()
 				}, test_util.RegisterConfig{RouteServiceUrl: "https://route_service.com"})
 				defer func() {

--- a/proxy/session_affinity_test.go
+++ b/proxy/session_affinity_test.go
@@ -52,9 +52,9 @@ var _ = Describe("Session Affinity", func() {
 	Context("context paths", func() {
 		Context("when two requests have the same context paths", func() {
 			It("responds with the same instance id", func() {
-				ln := test_util.RegisterHandler(r, "app.com/path1", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "instance-id-1"})
+				ln := test_util.RegisterConnHandler(r, "app.com/path1", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "instance-id-1"})
 				defer ln.Close()
-				ln2 := test_util.RegisterHandler(r, "app.com/path2/context/path", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "instance-id-2"})
+				ln2 := test_util.RegisterConnHandler(r, "app.com/path2/context/path", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "instance-id-2"})
 				defer ln2.Close()
 
 				conn := dialProxy(proxyServer)
@@ -84,9 +84,9 @@ var _ = Describe("Session Affinity", func() {
 
 		Context("when two requests have different context paths", func() {
 			It("responds with different instance ids", func() {
-				ln := test_util.RegisterHandler(r, "app.com/path1", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "instance-id-1"})
+				ln := test_util.RegisterConnHandler(r, "app.com/path1", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "instance-id-1"})
 				defer ln.Close()
-				ln2 := test_util.RegisterHandler(r, "app.com/path2/context/path", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "instance-id-2"})
+				ln2 := test_util.RegisterConnHandler(r, "app.com/path2/context/path", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "instance-id-2"})
 				defer ln2.Close()
 
 				conn := dialProxy(proxyServer)
@@ -116,9 +116,9 @@ var _ = Describe("Session Affinity", func() {
 
 		Context("when only one request has a context path", func() {
 			It("responds with different instance ids", func() {
-				ln := test_util.RegisterHandler(r, "app.com/path1", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "instance-id-1"})
+				ln := test_util.RegisterConnHandler(r, "app.com/path1", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "instance-id-1"})
 				defer ln.Close()
-				ln2 := test_util.RegisterHandler(r, "app.com", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "instance-id-2"})
+				ln2 := test_util.RegisterConnHandler(r, "app.com", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "instance-id-2"})
 				defer ln2.Close()
 
 				conn := dialProxy(proxyServer)
@@ -151,7 +151,7 @@ var _ = Describe("Session Affinity", func() {
 	Context("first request", func() {
 		Context("when the response does not contain a JSESSIONID cookie", func() {
 			It("does not respond with a VCAP_ID cookie", func() {
-				ln := test_util.RegisterHandler(r, "app", responseNoCookies, test_util.RegisterConfig{InstanceId: "my-id"})
+				ln := test_util.RegisterConnHandler(r, "app", responseNoCookies, test_util.RegisterConfig{InstanceId: "my-id"})
 				defer ln.Close()
 
 				x := dialProxy(proxyServer)
@@ -168,7 +168,7 @@ var _ = Describe("Session Affinity", func() {
 		Context("when the response contains a JSESSIONID cookie", func() {
 
 			It("responds with a VCAP_ID cookie scoped to the session", func() {
-				ln := test_util.RegisterHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
+				ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
 				defer ln.Close()
 
 				x := dialProxy(proxyServer)
@@ -198,7 +198,7 @@ var _ = Describe("Session Affinity", func() {
 				})
 
 				It("responds with a VCAP_ID cookie that has the same expiry", func() {
-					ln := test_util.RegisterHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
+					ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
 					defer ln.Close()
 
 					x := dialProxy(proxyServer)
@@ -224,7 +224,7 @@ var _ = Describe("Session Affinity", func() {
 				})
 
 				It("responds with a VCAP_ID cookie that is also Secure ", func() {
-					ln := test_util.RegisterHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
+					ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
 					defer ln.Close()
 
 					x := dialProxy(proxyServer)
@@ -251,7 +251,7 @@ var _ = Describe("Session Affinity", func() {
 				})
 
 				It("marks the cookie as secure only", func() {
-					ln := test_util.RegisterHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
+					ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
 					defer ln.Close()
 
 					x := dialProxy(proxyServer)
@@ -280,7 +280,7 @@ var _ = Describe("Session Affinity", func() {
 				})
 
 				It("responds with a VCAP_ID cookie that has the same SameSite attribute", func() {
-					ln := test_util.RegisterHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
+					ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
 					defer ln.Close()
 
 					x := dialProxy(proxyServer)
@@ -329,7 +329,7 @@ var _ = Describe("Session Affinity", func() {
 
 		Context("when the response does not contain a JSESSIONID cookie", func() {
 			It("does not respond with a VCAP_ID cookie", func() {
-				ln := test_util.RegisterHandler(r, host, responseNoCookies, test_util.RegisterConfig{InstanceId: "my-id"})
+				ln := test_util.RegisterConnHandler(r, host, responseNoCookies, test_util.RegisterConfig{InstanceId: "my-id"})
 				defer ln.Close()
 
 				x := dialProxy(proxyServer)
@@ -345,7 +345,7 @@ var _ = Describe("Session Affinity", func() {
 
 			Context("when the preferred server is gone", func() {
 				It("updates the VCAP_ID with the new server", func() {
-					ln := test_util.RegisterHandler(r, host, responseNoCookies, test_util.RegisterConfig{InstanceId: "other-id"})
+					ln := test_util.RegisterConnHandler(r, host, responseNoCookies, test_util.RegisterConfig{InstanceId: "other-id"})
 					defer ln.Close()
 
 					x := dialProxy(proxyServer)
@@ -367,7 +367,7 @@ var _ = Describe("Session Affinity", func() {
 
 		Context("when the response contains a JSESSIONID cookie", func() {
 			It("responds with a VCAP_ID cookie", func() {
-				ln := test_util.RegisterHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "some-id"})
+				ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "some-id"})
 				defer ln.Close()
 
 				x := dialProxy(proxyServer)
@@ -394,7 +394,7 @@ var _ = Describe("Session Affinity", func() {
 				})
 
 				It("expires the VCAP_ID", func() {
-					ln := test_util.RegisterHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
+					ln := test_util.RegisterConnHandler(r, "app", responseWithJSessionID, test_util.RegisterConfig{InstanceId: "my-id"})
 					defer ln.Close()
 
 					x := dialProxy(proxyServer)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -376,6 +376,7 @@ func zapData(uri route.Uri, endpoint *route.Endpoint) []zap.Field {
 	return []zap.Field{
 		zap.Stringer("uri", uri),
 		zap.String("backend", endpoint.CanonicalAddr()),
+		zap.String("protocol", endpoint.Protocol),
 		zap.Object("modification_tag", endpoint.ModificationTag),
 		isoSegField,
 		zap.Bool("isTLS", endpoint.IsTLS()),

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1229,6 +1229,7 @@ var _ = Describe("RouteRegistry", func() {
 		m := route.NewEndpoint(&route.EndpointOpts{
 			Host:                    "192.168.1.1",
 			Port:                    1234,
+			Protocol:                "http2",
 			RouteServiceUrl:         "https://my-routeService.com",
 			StaleThresholdInSeconds: -1,
 		})
@@ -1237,7 +1238,7 @@ var _ = Describe("RouteRegistry", func() {
 
 		marshalled, err := json.Marshal(r)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(marshalled)).To(Equal(`{"foo":[{"address":"192.168.1.1:1234","tls":false,"ttl":-1,"route_service_url":"https://my-routeService.com","tags":null}]}`))
+		Expect(string(marshalled)).To(Equal(`{"foo":[{"address":"192.168.1.1:1234","protocol":"http2","tls":false,"ttl":-1,"route_service_url":"https://my-routeService.com","tags":null}]}`))
 		r.Unregister("foo", m)
 		marshalled, err = json.Marshal(r)
 		Expect(err).NotTo(HaveOccurred())

--- a/route/pool.go
+++ b/route/pool.go
@@ -61,6 +61,7 @@ type ProxyRoundTripper interface {
 type Endpoint struct {
 	ApplicationId        string
 	addr                 string
+	Protocol             string
 	Tags                 map[string]string
 	ServerCertDomainSAN  string
 	PrivateInstanceId    string
@@ -138,6 +139,7 @@ type EndpointOpts struct {
 	AppId                   string
 	Host                    string
 	Port                    uint16
+	Protocol                string
 	ServerCertDomainSAN     string
 	PrivateInstanceId       string
 	PrivateInstanceIndex    string
@@ -154,6 +156,7 @@ func NewEndpoint(opts *EndpointOpts) *Endpoint {
 	return &Endpoint{
 		ApplicationId:        opts.AppId,
 		addr:                 fmt.Sprintf("%s:%d", opts.Host, opts.Port),
+		Protocol:             opts.Protocol,
 		Tags:                 opts.Tags,
 		useTls:               opts.UseTLS,
 		ServerCertDomainSAN:  opts.ServerCertDomainSAN,
@@ -446,6 +449,7 @@ func (e *endpointElem) isOverloaded() bool {
 func (e *Endpoint) MarshalJSON() ([]byte, error) {
 	var jsonObj struct {
 		Address             string            `json:"address"`
+		Protocol            string            `json:"protocol"`
 		TLS                 bool              `json:"tls"`
 		TTL                 int               `json:"ttl"`
 		RouteServiceUrl     string            `json:"route_service_url,omitempty"`
@@ -456,6 +460,7 @@ func (e *Endpoint) MarshalJSON() ([]byte, error) {
 	}
 
 	jsonObj.Address = e.addr
+	jsonObj.Protocol = e.Protocol
 	jsonObj.TLS = e.IsTLS()
 	jsonObj.RouteServiceUrl = e.RouteServiceUrl
 	jsonObj.TTL = int(e.StaleThreshold.Seconds())

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -666,6 +666,7 @@ var _ = Describe("EndpointPool", func() {
 		e := route.NewEndpoint(&route.EndpointOpts{
 			Host:                    "1.2.3.4",
 			Port:                    5678,
+			Protocol:                "http1",
 			RouteServiceUrl:         "https://my-rs.com",
 			StaleThresholdInSeconds: -1,
 		})
@@ -686,7 +687,7 @@ var _ = Describe("EndpointPool", func() {
 		json, err := pool.MarshalJSON()
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(string(json)).To(Equal(`[{"address":"1.2.3.4:5678","protocol":"","tls":false,"ttl":-1,"route_service_url":"https://my-rs.com","tags":null},{"address":"5.6.7.8:5678","protocol":"http2","tls":true,"ttl":-1,"tags":null,"private_instance_id":"pvt_test_instance_id","server_cert_domain_san":"pvt_test_san"}]`))
+		Expect(string(json)).To(Equal(`[{"address":"1.2.3.4:5678","protocol":"http1","tls":false,"ttl":-1,"route_service_url":"https://my-rs.com","tags":null},{"address":"5.6.7.8:5678","protocol":"http2","tls":true,"ttl":-1,"tags":null,"private_instance_id":"pvt_test_instance_id","server_cert_domain_san":"pvt_test_san"}]`))
 	})
 
 	Context("when endpoints do not have empty tags", func() {

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -673,6 +673,7 @@ var _ = Describe("EndpointPool", func() {
 		e2 := route.NewEndpoint(&route.EndpointOpts{
 			Host:                    "5.6.7.8",
 			Port:                    5678,
+			Protocol:                "http2",
 			StaleThresholdInSeconds: -1,
 			ServerCertDomainSAN:     "pvt_test_san",
 			PrivateInstanceId:       "pvt_test_instance_id",
@@ -685,7 +686,7 @@ var _ = Describe("EndpointPool", func() {
 		json, err := pool.MarshalJSON()
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(string(json)).To(Equal(`[{"address":"1.2.3.4:5678","tls":false,"ttl":-1,"route_service_url":"https://my-rs.com","tags":null},{"address":"5.6.7.8:5678","tls":true,"ttl":-1,"tags":null,"private_instance_id":"pvt_test_instance_id","server_cert_domain_san":"pvt_test_san"}]`))
+		Expect(string(json)).To(Equal(`[{"address":"1.2.3.4:5678","protocol":"","tls":false,"ttl":-1,"route_service_url":"https://my-rs.com","tags":null},{"address":"5.6.7.8:5678","protocol":"http2","tls":true,"ttl":-1,"tags":null,"private_instance_id":"pvt_test_instance_id","server_cert_domain_san":"pvt_test_san"}]`))
 	})
 
 	Context("when endpoints do not have empty tags", func() {
@@ -696,6 +697,7 @@ var _ = Describe("EndpointPool", func() {
 			e = route.NewEndpoint(&route.EndpointOpts{
 				Host:                    "1.2.3.4",
 				Port:                    5678,
+				Protocol:                "http2",
 				RouteServiceUrl:         "https://my-rs.com",
 				StaleThresholdInSeconds: -1,
 				Tags:                    sample_tags,
@@ -706,7 +708,7 @@ var _ = Describe("EndpointPool", func() {
 			pool.Put(e)
 			json, err := pool.MarshalJSON()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(string(json)).To(Equal(`[{"address":"1.2.3.4:5678","tls":false,"ttl":-1,"route_service_url":"https://my-rs.com","tags":{"some-key":"some-value"}}]`))
+			Expect(string(json)).To(Equal(`[{"address":"1.2.3.4:5678","protocol":"http2","tls":false,"ttl":-1,"route_service_url":"https://my-rs.com","tags":{"some-key":"some-value"}}]`))
 		})
 	})
 
@@ -717,6 +719,7 @@ var _ = Describe("EndpointPool", func() {
 			e = route.NewEndpoint(&route.EndpointOpts{
 				Host:                    "1.2.3.4",
 				Port:                    5678,
+				Protocol:                "http2",
 				RouteServiceUrl:         "https://my-rs.com",
 				StaleThresholdInSeconds: -1,
 				Tags:                    sample_tags,
@@ -728,7 +731,7 @@ var _ = Describe("EndpointPool", func() {
 			pool.Put(e)
 			json, err := pool.MarshalJSON()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(string(json)).To(Equal(`[{"address":"1.2.3.4:5678","tls":false,"ttl":-1,"route_service_url":"https://my-rs.com","tags":{}}]`))
+			Expect(string(json)).To(Equal(`[{"address":"1.2.3.4:5678","protocol":"http2","tls":false,"ttl":-1,"route_service_url":"https://my-rs.com","tags":{}}]`))
 		})
 	})
 })

--- a/test_util/helpers.go
+++ b/test_util/helpers.go
@@ -39,6 +39,7 @@ func RegisterAddr(reg *registry.RouteRegistry, path string, addr string, cfg Reg
 		route.NewEndpoint(&route.EndpointOpts{
 			AppId:                   cfg.AppId,
 			Host:                    host,
+			Protocol:                cfg.Protocol,
 			Port:                    uint16(port),
 			ServerCertDomainSAN:     cfg.ServerCertDomainSAN,
 			PrivateInstanceIndex:    cfg.InstanceIndex,
@@ -109,6 +110,7 @@ type RegisterConfig struct {
 	StaleThreshold      int
 	TLSConfig           *tls.Config
 	IgnoreTLSConfig     bool
+	Protocol            string
 }
 
 func runBackendInstance(ln net.Listener, handler connHandler) {


### PR DESCRIPTION
* A short explanation of the proposed change:
Adding support for protocol in route.registrar messages, and having the connections between gorouter and the backend use http2 if it is set in the registration message.

See routing-release issue for more context: [cloudfoundry/routing-release#200]

* An explanation of the use cases your change solves
This is most important for cases where we need end to end http2 traffic to an app, e.g. supporting grpc endpoints with app running on CF.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

This functionality is easiest to test with the other pieces of this change. To test in isolation deploy [the branch of diego with the necessary executor changes](https://github.com/cloudfoundry/executor/pull/54), push [an app which supports h2](https://github.com/Gerg/envoy_h2_to_h2c_example/tree/main/h2c_app) and then  publish a message on the nats bus manually with the appropriate protocol:

```nats pub 'router.register' '{"host":"10.244.0.138","port":61004,"protocol":"http2","tls_port":61006,"uris":["h2c.mud-rabbit.capi.land"],"app":"dd33ca1b-829e-4eb4-9d8e-052c550ab0b8","private_instance_id":"bd460be2-5184-41ba-635b-9abb","private_instance_index":"0","server_cert_domain_san":"bd460be2-5184-41ba-635b-9abb","tags":{"app_id":"dd33ca1b-829e-4eb4-9d8e-052c550ab0b8","app_name":"h2c","component":"route-emitter","instance_id":"0","organization_id":"36f14cc0-5097-4f30-b2bb-14668cb085cd","organization_name":"org","process_id":"dd33ca1b-829e-4eb4-9d8e-052c550ab0b8","process_instance_id":"bd460be2-5184-41ba-635b-9abb","process_type":"web","source_id":"dd33ca1b-829e-4eb4-9d8e-052c550ab0b8","space_id":"dc467951-2878-4243-9f76-fd61573f4120","space_name":"cadet"}}'```

* Expected result after the change

Make a request to the app and see that h2 is working. We instrumented the sample app to tell us which protocol was being used. 

* Current result before the change

Traffic will be over http1.1 or will 500 if the app only supports h2.

* Links to any other associated PRs

TBD

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite