### PR TITLE
HTTP/2 traffic to backends is configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The format of the `router.register` message is as follows:
   "host": "127.0.0.1",
   "port": 4567,
   "tls_port": 1234,
+  "protocol": "http1",
   "uris": [
     "my_first_url.localhost.routing.cf-app.com",
     "my_second_url.localhost.routing.cf-app.com"
@@ -650,14 +651,27 @@ header is `1.2.3.4`. You can read more about the PROXY Protocol
 
 ## HTTP/2 Support
 
-The Gorouter supports accepting HTTP/2 connections when the manifest property is
-enabled. Connections made using HTTP/2 will be proxied to backends over
-HTTP/1.1.
+The Gorouter supports ingress and egress HTTP/2 connections when the BOSH
+deployment manifest property is enabled.
 
 ```yaml
 properties:
   router:
     enable_http2: true
+```
+
+By default, connections will be proxied to backends over HTTP/1.1, regardless of
+ingress protocol. Backends can be configured with the `http2` protocol to enable
+end-to-end HTTP/2 routing for use cases like gRPC.
+
+Example `router.register` message with `http2` protocol:
+```json
+{
+  "host": "127.0.0.1",
+  "port": 4567,
+  "protocol": "http2",
+  "...": "..."
+}
 ```
 
 ## Logs

--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -45,10 +45,10 @@ type RoundTripperFactory interface {
 	New(expectedServerName string, isRouteService, isHttp2 bool) ProxyRoundTripper
 }
 
-func GetRoundTripper(endpoint *route.Endpoint, roundTripperFactory RoundTripperFactory, isRouteService bool) ProxyRoundTripper {
+func GetRoundTripper(endpoint *route.Endpoint, roundTripperFactory RoundTripperFactory, isRouteService, http2Enabled bool) ProxyRoundTripper {
 	endpoint.RoundTripperInit.Do(func() {
 		endpoint.SetRoundTripperIfNil(func() route.ProxyRoundTripper {
-			isHttp2 := endpoint.Protocol == HTTP2Protocol
+			isHttp2 := (endpoint.Protocol == HTTP2Protocol) && http2Enabled
 			return roundTripperFactory.New(endpoint.ServerCertDomainSAN, isRouteService, isHttp2)
 		})
 	})
@@ -82,6 +82,7 @@ func NewProxyRoundTripper(
 		routeServicesTransport:   routeServicesTransport,
 		endpointTimeout:          cfg.EndpointTimeout,
 		stickySessionCookieNames: cfg.StickySessionCookieNames,
+		http2Enabled:             cfg.EnableHTTP2,
 	}
 }
 
@@ -96,6 +97,7 @@ type roundTripper struct {
 	routeServicesTransport   http.RoundTripper
 	endpointTimeout          time.Duration
 	stickySessionCookieNames config.StringSet
+	http2Enabled             bool
 }
 
 func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response, error) {
@@ -182,7 +184,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 			*request.URL = *reqInfo.RouteServiceURL
 
 			var roundTripper http.RoundTripper
-			roundTripper = GetRoundTripper(endpoint, rt.roundTripperFactory, true)
+			roundTripper = GetRoundTripper(endpoint, rt.roundTripperFactory, true, rt.http2Enabled)
 			if reqInfo.ShouldRouteToInternalRouteService {
 				roundTripper = rt.routeServicesTransport
 			}
@@ -241,7 +243,7 @@ func (rt *roundTripper) CancelRequest(request *http.Request) {
 		return
 	}
 
-	tr := GetRoundTripper(endpoint, rt.roundTripperFactory, false)
+	tr := GetRoundTripper(endpoint, rt.roundTripperFactory, false, rt.http2Enabled)
 	tr.CancelRequest(request)
 }
 
@@ -260,7 +262,7 @@ func (rt *roundTripper) backendRoundTrip(
 	iter.PreRequest(endpoint)
 
 	rt.combinedReporter.CaptureRoutingRequest(endpoint)
-	tr := GetRoundTripper(endpoint, rt.roundTripperFactory, false)
+	tr := GetRoundTripper(endpoint, rt.roundTripperFactory, false, rt.http2Enabled)
 	res, err := rt.timedRoundTrip(tr, request, logger)
 
 	// decrement connection stats

--- a/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/proxy/round_tripper/proxy_round_tripper_test.go
@@ -696,23 +696,43 @@ var _ = Describe("ProxyRoundTripper", func() {
 				})
 			})
 
-			Context("forcing HTTP/2", func() {
-				It("uses HTTP/2 when endpoint's Protocol is set to http2", func() {
-					endpoint.Protocol = "http2"
-					_, err := proxyRoundTripper.RoundTrip(req)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]RequestedRoundTripperType{
-						{IsRouteService: false, IsHttp2: true},
-					}))
+			Context("using HTTP/2", func() {
+				Context("when HTTP/2 is enabled", func() {
+					BeforeEach(func() {
+						cfg.EnableHTTP2 = true
+					})
+					It("uses HTTP/2 when endpoint's Protocol is set to http2", func() {
+						endpoint.Protocol = "http2"
+						_, err := proxyRoundTripper.RoundTrip(req)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]RequestedRoundTripperType{
+							{IsRouteService: false, IsHttp2: true},
+						}))
+					})
+
+					It("does not use HTTP/2 when endpoint's Protocol is not set to http2", func() {
+						endpoint.Protocol = ""
+						_, err := proxyRoundTripper.RoundTrip(req)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]RequestedRoundTripperType{
+							{IsRouteService: false, IsHttp2: false},
+						}))
+					})
 				})
 
-				It("does not use HTTP/2 when endpoint's Protocol is not set to http2", func() {
-					endpoint.Protocol = ""
-					_, err := proxyRoundTripper.RoundTrip(req)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]RequestedRoundTripperType{
-						{IsRouteService: false, IsHttp2: false},
-					}))
+				Context("when HTTP/2 is disabled", func() {
+					BeforeEach(func() {
+						cfg.EnableHTTP2 = false
+					})
+
+					It("does not use HTTP/2, regardless of the endpoint's protocol", func() {
+						endpoint.Protocol = "http2"
+						_, err := proxyRoundTripper.RoundTrip(req)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(roundTripperFactory.RequestedRoundTripperTypes).To(Equal([]RequestedRoundTripperType{
+							{IsRouteService: false, IsHttp2: false},
+						}))
+					})
 				})
 			})
 


### PR DESCRIPTION
* A short explanation of the proposed change:

> Follow up to #289 that makes the configuration introduced in #285 also apply to Gorouter's communication with its backends.

* An explanation of the use cases your change solves

> Operators that want to fully disable HTTP/2 communication on their deployments can prevent Gorouter from issuing HTTP/2 requests to applications.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

> Set https://bosh.io/jobs/gorouter?source=github.com/cloudfoundry/routing-release&version=0.218.0#p%3drouter.enable_http2 to `false` and follow steps from #289. The app should receive HTTP/1.1 traffic, even when the endpoint is configured with the `http2` protocol.

* Links to any other associated PRs

> #289 & #285

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite

- @Gerg && @belinda-liu 