### PR TITLE
Enhance registry logs with appId, instanceId and domainSans

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -376,6 +376,9 @@ func zapData(uri route.Uri, endpoint *route.Endpoint) []zap.Field {
 	return []zap.Field{
 		zap.Stringer("uri", uri),
 		zap.String("backend", endpoint.CanonicalAddr()),
+		zap.String("application_id", endpoint.ApplicationId),
+		zap.String("instance_id", endpoint.PrivateInstanceId),
+		zap.String("server_cert_domain_san", endpoint.ServerCertDomainSAN),
 		zap.Object("modification_tag", endpoint.ModificationTag),
 		isoSegField,
 		zap.Bool("isTLS", endpoint.IsTLS()),

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -255,6 +255,17 @@ var _ = Describe("RouteRegistry", func() {
 				Expect(logger).To(gbytes.Say(`"isolation_segment":"is1"`))
 			})
 
+			It("logs register message with application_id,instance_id,domain_san when it's provided", func() {
+				endpointWithAppId := route.NewEndpoint(&route.EndpointOpts{
+					AppId:               "app_id1",
+					PrivateInstanceId:   "instance_id1",
+					ServerCertDomainSAN: "san1",
+				})
+
+				r.Register("b.route", endpointWithAppId)
+				Expect(logger).To(gbytes.Say(`b\.route.*.*app_id1.*instance_id.*instance_id1.*server_cert_domain_san.*san1`))
+			})
+
 			Context("when routing table sharding mode is `segments`", func() {
 				BeforeEach(func() {
 					configObj.RoutingTableShardingMode = config.SHARD_SEGMENTS


### PR DESCRIPTION
* A short explanation of the proposed change:
Log out the appId, instanceId and domainSans at (un)registrations for debugging and correlation of different log entries. Similar to #293 

* An explanation of the use cases your change solves
We face currently some issues (`x509: certificate is valid for <instance_guid>, not <instance_guid>`) during landscape update. We would like to correlate exactly the endpoint registration logs with some logs from the runtime logs (i.e. BBS,REP,CC). This change enable us to search for the instanceId or applicationId and find the starting/stopping/crashing container, accesslogs (with PR #293) and also the endpoint-(un)registration logs of the gorouter. 
This would help us a lot.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
Deploy the change and have a look at the logs.

* Expected result after the change
The log entries "endpoint-registered" and "endpoint-unregistered" should have know the fields application_id, instance_id and server_cert_domain_san.
`{"log_level":1,"timestamp":1627540143.12727,"message":"endpoint-registered","source":"test","data":{"uri":"b.route","backend":":0","application_id":"app_id1","instance_id":"instance_id1","server_cert_domain_san":"san1","modification_tag":{"guid":"","index":0},"isolation_segment":"-","isTLS":false}}`

* Current result before the change
`{"log_level":1,"timestamp":1627540143.12727,"message":"endpoint-registered","source":"test","data":{"uri":"b.route","backend":":0","modification_tag":{"guid":"","index":0},"isolation_segment":"-","isTLS":false}}`

* links to any other associated PRs
#293

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [x]  I have build an routing release and deployed it on our devlandscape

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
