### PR TITLE
Enable HTTP/2 by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -203,7 +203,7 @@ type Config struct {
 	EnableSSL       bool              `yaml:"enable_ssl,omitempty"`
 	SSLPort         uint16            `yaml:"ssl_port,omitempty"`
 	DisableHTTP     bool              `yaml:"disable_http,omitempty"`
-	EnableHTTP2     bool              `yaml:"enable_http2,omitempty"`
+	EnableHTTP2     bool              `yaml:"enable_http2"`
 	SSLCertificates []tls.Certificate `yaml:"-"`
 	TLSPEM          []TLSPem          `yaml:"tls_pem,omitempty"`
 	CACerts         string            `yaml:"ca_certs,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -301,7 +301,7 @@ var defaultConfig = Config{
 	EnableSSL:     false,
 	SSLPort:       443,
 	DisableHTTP:   false,
-	EnableHTTP2:   false,
+	EnableHTTP2:   true,
 	MinTLSVersion: tls.VersionTLS12,
 	MaxTLSVersion: tls.VersionTLS12,
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1455,19 +1455,19 @@ disable_http: true
 		})
 
 		Context("enable_http2", func() {
-			It("defaults to false", func() {
+			It("defaults to true", func() {
 				Expect(config.Process()).To(Succeed())
-				Expect(config.EnableHTTP2).To(BeFalse())
+				Expect(config.EnableHTTP2).To(BeTrue())
 			})
 
 			It("setting enable_http2 succeeds", func() {
 				var b = []byte(fmt.Sprintf(`
-enable_http2: true
+enable_http2: false
 `))
 				err := config.Initialize(b)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Process()).To(Succeed())
-				Expect(config.EnableHTTP2).To(BeTrue())
+				Expect(config.EnableHTTP2).To(BeFalse())
 			})
 		})
 

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -262,6 +262,7 @@ var _ = Describe("Router Integration", func() {
 
 		JustBeforeEach(func() {
 			var err error
+			cfg.EnableHTTP2 = false
 			writeConfig(cfg, cfgFile)
 			mbusClient, err = newMessageBus(cfg)
 			Expect(err).ToNot(HaveOccurred())
@@ -314,7 +315,6 @@ var _ = Describe("Router Integration", func() {
 
 		JustBeforeEach(func() {
 			var err error
-			cfg.EnableHTTP2 = true
 			writeConfig(cfg, cfgFile)
 			mbusClient, err = newMessageBus(cfg)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:
Change `EnableHTTP2` default from `false` to `true`.  Removed `omitempty` since this field will always be populated and golang marshaling says `nil` is the same as `false`

* An explanation of the use cases your change solves
Users now default to using HTTP/2

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
Set `EnableHTTP2` to `true` and see http2 traffic.  Set it to `false` to not allow http2 traffic

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
