### PR TITLE
Enhance accesslogs with InstanceId for better debugging

### DIFF
--- a/accesslog/schema/access_log_record.go
+++ b/accesslog/schema/access_log_record.go
@@ -138,12 +138,13 @@ func (r *AccessLogRecord) getRecord() []byte {
 }
 
 func (r *AccessLogRecord) makeRecord() []byte {
-	var appID, destIPandPort, appIndex string
+	var appID, destIPandPort, appIndex, instanceId string
 
 	if r.RouteEndpoint != nil {
 		appID = r.RouteEndpoint.ApplicationId
 		appIndex = r.RouteEndpoint.PrivateInstanceIndex
 		destIPandPort = r.RouteEndpoint.CanonicalAddr()
+		instanceId = r.RouteEndpoint.PrivateInstanceId
 	}
 
 	headers := r.Request.Header
@@ -197,6 +198,9 @@ func (r *AccessLogRecord) makeRecord() []byte {
 
 	b.WriteString(`app_index:`)
 	b.WriteDashOrStringValue(appIndex)
+
+	b.WriteString(`instance_id:`)
+	b.WriteDashOrStringValue(instanceId)
 
 	b.AppendSpaces(false)
 	b.WriteString(`x_cf_routererror:`)

--- a/accesslog/schema/access_log_record_test.go
+++ b/accesslog/schema/access_log_record_test.go
@@ -28,6 +28,7 @@ var _ = Describe("AccessLogRecord", func() {
 			Host:                 "1.2.3.4",
 			Port:                 1234,
 			PrivateInstanceIndex: "3",
+			PrivateInstanceId:    "FakeInstanceId",
 		})
 
 		record = &schema.AccessLogRecord{
@@ -69,6 +70,7 @@ var _ = Describe("AccessLogRecord", func() {
 			Eventually(r).Should(Say(`x_forwarded_proto:"FakeOriginalRequestProto" `))
 			Eventually(r).Should(Say(`vcap_request_id:"abc-123-xyz-pdq" response_time:60.000000 gorouter_time:10.000000 app_id:"FakeApplicationId" `))
 			Eventually(r).Should(Say(`app_index:"3"`))
+			Eventually(r).Should(Say(`instance_id:"FakeInstanceId"`))
 			Eventually(r).Should(Say(`x_cf_routererror:"some-router-error"`))
 		})
 
@@ -212,7 +214,7 @@ var _ = Describe("AccessLogRecord", func() {
 				Eventually(r).Should(Say(`"1.2.3.4:1234" x_forwarded_for:"FakeProxy1, FakeProxy2" `))
 				Eventually(r).Should(Say(`x_forwarded_proto:"FakeOriginalRequestProto" `))
 				Eventually(r).Should(Say(`vcap_request_id:"abc-123-xyz-pdq" response_time:60.000000 gorouter_time:10.000000 app_id:"FakeApplicationId" `))
-				Eventually(r).Should(Say(`app_index:"3" x_cf_routererror:"some-router-error" cache_control:"no-cache" accept_encoding:"gzip, deflate" `))
+				Eventually(r).Should(Say(`app_index:"3" instance_id:"FakeInstanceId" x_cf_routererror:"some-router-error" cache_control:"no-cache" accept_encoding:"gzip, deflate" `))
 				Eventually(r).Should(Say(`if_match:"737060cd8c284d8af7ad3082f209582d" doesnt_exist:"-"`))
 			})
 		})


### PR DESCRIPTION
* A short explanation of the proposed change:
Log out the instanceId at accesslogs for debugging and correlation of different log entries. Similar to #291 

* An explanation of the use cases your change solves
We face currently some issues (x509: certificate is valid for <instance_guid>, not <instance_guid>) during landscape update. We would like to correlate exactly the access logs with some other logs i.e. gorouter error logs or runtime logs (BBS,REP,CC). This change enable us to see exactly what happens at instance. So, we can find all accesslogs, the starting/stopping/crashing containers and also the endpoint-(un)registration logs of the gorouter (with PR #291) .
This would help us a lot.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
Deploy the change and have a look at the logs.

* Expected result after the change
GET /<path> HTTP/1.1" 302 0 0 "-" "-" "-" "10.1.1.65:8443" x_forwarded_for:"-" x_forwarded_proto:"https" vcap_request_id:"<vcap_id>" response_time:0.015406 gorouter_time:0.000088 app_id:"<app_id>" app_index:"1" instance_id:"<instance_id>" x_cf_routererror:"-" ...

* Current result before the change
GET /<path> HTTP/1.1" 302 0 0 "-" "-" "-" "10.1.1.65:8443" x_forwarded_for:"-" x_forwarded_proto:"https" vcap_request_id:"<vcap_id>" response_time:0.015406 gorouter_time:0.000088 app_id:"<app_id>" app_index:"1" x_cf_routererror:"-" ...

* Links to any other associated PRs
#291 

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [x] I have build an routing release and deployed it on our devlandscape 

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
