### PR TITLE
Add error message to CfRouterError for better debugging

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1504,7 +1504,7 @@ var _ = Describe("Proxy", func() {
 
 			resp, body := conn.ReadResponse()
 			Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
-			Expect(resp.Header.Get("X-Cf-RouterError")).To(Equal("endpoint_failure"))
+			Expect(resp.Header.Get("X-Cf-RouterError")).To(Equal("endpoint_failure (http: server closed idle connection)"))
 			Expect(body).To(Equal("502 Bad Gateway: Registered endpoint failed to handle the request.\n"))
 		})
 

--- a/proxy/round_tripper/error_handler.go
+++ b/proxy/round_tripper/error_handler.go
@@ -1,6 +1,7 @@
 package round_tripper
 
 import (
+	"fmt"
 	"net/http"
 
 	router_http "code.cloudfoundry.org/gorouter/common/http"
@@ -43,7 +44,12 @@ type ErrorHandler struct {
 }
 
 func (eh *ErrorHandler) HandleError(responseWriter utils.ProxyResponseWriter, err error) {
-	responseWriter.Header().Set(router_http.CfRouterError, "endpoint_failure")
+	msg := "endpoint_failure"
+	if err != nil {
+		msg = fmt.Sprintf("%s (%s)", msg, err)
+	}
+
+	responseWriter.Header().Set(router_http.CfRouterError, msg)
 
 	eh.writeErrorCode(err, responseWriter)
 	responseWriter.Header().Del("Connection")

--- a/proxy/round_tripper/error_handler_test.go
+++ b/proxy/round_tripper/error_handler_test.go
@@ -62,7 +62,7 @@ var _ = Describe("HandleError", func() {
 
 	It("sets a header to describe the endpoint_failure", func() {
 		errorHandler.HandleError(responseWriter, errors.New("potato"))
-		Expect(responseWriter.Header().Get(router_http.CfRouterError)).To(Equal("endpoint_failure"))
+		Expect(responseWriter.Header().Get(router_http.CfRouterError)).To(Equal("endpoint_failure (potato)"))
 	})
 
 	Context("when the error does not match any of the classifiers", func() {


### PR DESCRIPTION
Based on the Idea of @46bit and the [Draft Commit](https://github.com/46bit/gorouter/commit/cbe1c083d288be14885fe9be890c9a650e559826). I took over the topic and created this PR.

* A short explanation of the proposed change:
Add the error message to the header X-Cf-RouterError.

* An explanation of the use cases your change solves
This change enables the CF Users to debug better their application in case of 502 status codes. In the most cases it is very helpful to see the error message if an `endpoint_failure` occurs. Currently, when the CF User doesn't know why this happens they usually opens a ticket for help. We want to prevent this and add the error message to the header `X-Cf-RouterError`. 
Also @domdom82 provided [here](https://github.com/46bit/gorouter/commit/cbe1c083d288be14885fe9be890c9a650e559826#commitcomment-53572511) some motivation for this PR. 

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
Provoke an app crash and check the returning header `X-Cf-RouterError`.

* Expected result after the change
Header should be i.e. `endpoint_failure (EOF)` or `endpoint_failure (http: server closed idle connection)`. 
This message can be also found at the accesslog property "RouterError"

* Current result before the change
Only `endpoint_failure` without error message

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
