### PR TITLE
Cause gorouter to fail to start if it cannot listen on its StatusPort

### DIFF
--- a/common/component.go
+++ b/common/component.go
@@ -161,8 +161,7 @@ func (c *VcapComponent) Start() error {
 
 	procStat = NewProcessStatus()
 
-	c.ListenAndServe()
-	return nil
+	return c.ListenAndServe()
 }
 
 func (c *VcapComponent) Register(mbusClient *nats.Conn) error {
@@ -202,7 +201,7 @@ func (c *VcapComponent) Stop() {
 	}
 }
 
-func (c *VcapComponent) ListenAndServe() {
+func (c *VcapComponent) ListenAndServe() error {
 	hs := http.NewServeMux()
 
 	hs.HandleFunc("/health", func(w http.ResponseWriter, req *http.Request) {
@@ -250,7 +249,7 @@ func (c *VcapComponent) ListenAndServe() {
 	l, err := net.Listen("tcp", c.Varz.Host)
 	if err != nil {
 		c.statusCh <- err
-		return
+		return err
 	}
 	c.listener = l
 
@@ -264,4 +263,5 @@ func (c *VcapComponent) ListenAndServe() {
 			c.statusCh <- err
 		}
 	}()
+	return nil
 }

--- a/common/component_test.go
+++ b/common/component_test.go
@@ -47,6 +47,20 @@ var _ = Describe("Component", func() {
 		}
 	})
 
+	It("fails to start when the configured port is in use", func() {
+		component.Logger = test_util.NewTestZapLogger("test")
+		component.Varz.Type = "TestType"
+
+		srv, err := net.Listen("tcp", varz.GenericVarz.Host)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(srv).ToNot(BeNil())
+		err = component.Start()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal(fmt.Sprintf("listen tcp %s: bind: address already in use", varz.GenericVarz.Host)))
+		err = srv.Close()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	It("prevents unauthorized access", func() {
 		path := "/test"
 

--- a/router/router_drain_test.go
+++ b/router/router_drain_test.go
@@ -416,6 +416,7 @@ var _ = Describe("Router", func() {
 				h = &health.Health{}
 				h.SetHealth(health.Healthy)
 				config.HealthCheckUserAgent = "HTTP-Monitor/1.1"
+				config.Status.Port = test_util.NextAvailPort()
 				rt := &sharedfakes.RoundTripper{}
 				p := proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, ew, config, registry, combinedReporter,
 					&routeservice.RouteServiceConfig{}, &tls.Config{}, &tls.Config{}, h, rt)


### PR DESCRIPTION
[#178665581]

* A short explanation of the proposed change:

Cause the gorouter process to exit with an error if it's StatusPort is bound by another process, so that the monit status reflects a state similar to what load balancers using the health check reflect (that the process is down).

* An explanation of the use cases your change solves

In cases where something else has bound to port :8080, the new gorouter process will fail to listen, but continue starting up. This could potentially lead to a deployment succeeding in a way that renders all gorouter instances unavailable from the loadbalancer

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

1. Deploy against a cf-deployment environment
2. SSH into a router instance
3. monit stop gorouter
4. nc -ldk 8080 &
5. monit start gorouter
6. Watch the gorouter fail to start up, with logs emitted indicating that port 8080 is in use

* Expected result after the change

Gorouter will exit on startup and emit a log message for the failure

* Current result before the change

Gorouter starts up, but does not listen on the StatusPort

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).
