### PR TITLE
Include request URL in route-service error message

### DIFF
--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -194,7 +194,11 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 
 			res, err = rt.timedRoundTrip(roundTripper, request, logger)
 			if err != nil {
-				logger.Error("route-service-connection-failed", zap.Error(err))
+				logger.Error(
+					"route-service-connection-failed",
+					zap.String("route-service-endpoint", request.URL.String()),
+					zap.Error(err),
+				)
 
 				if rt.retriableClassifier.Classify(err) {
 					continue
@@ -204,7 +208,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 			if res != nil && (res.StatusCode < 200 || res.StatusCode >= 300) {
 				logger.Info(
 					"route-service-response",
-					zap.String("endpoint", request.URL.String()),
+					zap.String("route-service-endpoint", request.URL.String()),
 					zap.Int("status-code", res.StatusCode),
 				)
 			}

--- a/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/proxy/round_tripper/proxy_round_tripper_test.go
@@ -816,7 +816,9 @@ var _ = Describe("ProxyRoundTripper", func() {
 
 						Expect(logger.Buffer()).ToNot(gbytes.Say(`backend-endpoint-failed`))
 						for i := 0; i < 3; i++ {
-							Expect(logger.Buffer()).To(gbytes.Say(`route-service-connection-failed`))
+							logOutput := logger.Buffer()
+							Expect(logOutput).To(gbytes.Say(`route-service-connection-failed`))
+							Expect(logOutput).To(gbytes.Say(`foo.com`))
 						}
 					})
 
@@ -842,8 +844,9 @@ var _ = Describe("ProxyRoundTripper", func() {
 						It("logs the error", func() {
 							_, err := proxyRoundTripper.RoundTrip(req)
 							Expect(err).To(MatchError("banana"))
-
-							Expect(logger.Buffer()).To(gbytes.Say(`route-service-connection-failed`))
+							logOutput := logger.Buffer()
+							Expect(logOutput).To(gbytes.Say(`route-service-connection-failed`))
+							Expect(logOutput).To(gbytes.Say(`foo.com`))
 						})
 					})
 				})


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* _A short explanation of the proposed change:_
Adds the request URL to the error message of route-service requests.

* _An explanation of the use cases your change solves_
As a platform operator, I want to be able to correlate failing route-service requests with the endpoints that we redirect to. We see tons of such error logs but have a hard time correlating them with actual route-service targets, examples:
  
    ```
    {"log_level":3,"timestamp":"2021-11-26T10:28:24.582627500Z","message":"route-service-connection-failed","source":"vcap.gorouter","data":{"error":"context canceled"}}
    {"log_level":3,"timestamp":"2021-11-26T10:28:24.158946148Z","message":"route-service-connection-failed","source":"vcap.gorouter","data":{"error":"unexpected EOF"}}
    ```

* _Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)_
Can be tested with a failing route-service. Was not done here as I'd consider the change small enough and test-effort rather high - the same is done for `route-service-response` in the proxy round tripper just below.

* _Expected result after the change_
We log:
    ```
    {"log_level":3,"timestamp":"2021-11-26T16:36:09.580724866Z","message":"route-service-connection- failed","source":"vcap.gorouter","data":{"endpoint":"https://<URL>","error":"context deadline exceeded"}}
    ```

* _Current result before the change_
We log:
    ```
    {"log_level":3,"timestamp":"2021-11-26T16:36:09.580724866Z","message":"route-service-connection-failed","source":"vcap.gorouter","data":{"error":"context deadline exceeded"}}
    ```

* _Links to any other associated PRs_

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
