### PR TITLE
Make EndpointDialTimeout configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -237,7 +237,7 @@ type Config struct {
 	PublishActiveAppsInterval       time.Duration `yaml:"publish_active_apps_interval,omitempty"`
 	StartResponseDelayInterval      time.Duration `yaml:"start_response_delay_interval,omitempty"`
 	EndpointTimeout                 time.Duration `yaml:"endpoint_timeout,omitempty"`
-	EndpointDialTimeout             time.Duration `yaml:"-"`
+	EndpointDialTimeout             time.Duration `yaml:"endpoint_dial_timeout,omitempty"`
 	EndpointKeepAliveProbeInterval  time.Duration `yaml:"endpoint_keep_alive_probe_interval,omitempty"`
 	RouteServiceTimeout             time.Duration `yaml:"route_services_timeout,omitempty"`
 	FrontendIdleTimeout             time.Duration `yaml:"frontend_idle_timeout,omitempty"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -100,6 +100,17 @@ endpoint_timeout: 10s
 			Expect(config.EndpointTimeout).To(Equal(10 * time.Second))
 		})
 
+		It("sets endpoint dial timeout", func() {
+			var b = []byte(`
+endpoint_dial_timeout: 6s
+`)
+
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(config.EndpointDialTimeout).To(Equal(6 * time.Second))
+		})
+
 		It("defaults keep alive probe interval to 1 second", func() {
 			Expect(config.FrontendIdleTimeout).To(Equal(900 * time.Second))
 			Expect(config.EndpointKeepAliveProbeInterval).To(Equal(1 * time.Second))
@@ -1590,6 +1601,7 @@ enable_http2: false
 			It("converts timeouts to a duration", func() {
 				var b = []byte(`
 endpoint_timeout: 10s
+endpoint_dial_timeout: 6s
 route_services_timeout: 10s
 drain_timeout: 15s
 tls_handshake_timeout: 9s
@@ -1601,6 +1613,7 @@ tls_handshake_timeout: 9s
 				Expect(config.Process()).To(Succeed())
 
 				Expect(config.EndpointTimeout).To(Equal(10 * time.Second))
+				Expect(config.EndpointDialTimeout).To(Equal(6 * time.Second))
 				Expect(config.RouteServiceTimeout).To(Equal(10 * time.Second))
 				Expect(config.DrainTimeout).To(Equal(15 * time.Second))
 				Expect(config.TLSHandshakeTimeout).To(Equal(9 * time.Second))
@@ -1617,6 +1630,7 @@ endpoint_timeout: 10s
 				Expect(config.Process()).To(Succeed())
 
 				Expect(config.EndpointTimeout).To(Equal(10 * time.Second))
+				Expect(config.EndpointDialTimeout).To(Equal(5 * time.Second))
 				Expect(config.DrainTimeout).To(Equal(10 * time.Second))
 			})
 


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:
Make EndpointDialTimeout configurable. It is currently hard-coded at 5s.

* An explanation of the use cases your change solves
Some of our customers have apps that need to restart frequently and have thousands of clients connected. After the restart all those clients try to reconnect at once which temporarily puts the app under pressure such that the underlying OS can't keep up with accepting connections quick enough to not hit the 5s timeout. Being able to increase the timeout gives the app more time to eventually accept all connections without disruption clients with a 502.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
1. Provide a config.yml for gorouter
2. Change `endpoint_dial_timeout` to some arbitrary time duration e.g. `1m`
3. Deploy gorouter
4. Connect NATS
5. Register route to an app that takes more than 5s to accept a connection (the default)

**Hints on making the app slow**
It's actually difficult to induce a DialTimeout on purpose, because the connection handling (tcp handshake) is done at the OS level even before user code is executed. So to make an app slow we can use `tc` (traffic control) to add some delay on egress packets at the NIC level.

1. `cf app MYAPP --guid` - make note of the APP_GUID
2. `cf curl "/v2/apps/${APP_GUID}/stats" | jq -r ".[0].stats.host"` - this will print the cell IP_ADDRESS
3. `bosh -d cf vms | grep $IP_ADDRESS` - this will print the CELL where your app is running on
4. `bosh -d cf ssh $CELL`
5. `cat /var/vcap/data/container-metadata/store.json | /var/vcap/packages/cfdot/bin/jq -r '.[] | select(.metadata.app_id == "$APP_GUID") | .handle'` - this will give us the runc CONTAINER_ID for the APP_GUID
6. `/var/vcap/packages/runc/bin/runc --root /run/containerd/runc/garden state $CONTAINER_ID | /var/vcap/packages/cfdot/bin/jq -r '.pid'` - this will give us the PID of the app container
7. `nsenter -t $PID -a tc qdisc add dev eth0 root netem delay 8s` - this will add a 8s delay on all egress traffic
8. After testing you can reset the delay using `nsenter -t $PID -a tc qdisc del dev eth0 root`


* Expected result after the change
The app should eventually respond with a 200 OK

* Current result before the change
Gorouter responds with a 502 endpoint_failure with `x-cf-routererror: endpoint_failure (dial tcp 10.0.73.0:61065: i/o timeout)`

* Links to any other associated PRs
https://github.com/cloudfoundry/routing-release/pull/249

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
