### PR TITLE
Increment endpoint connection count correctly

### DIFF
--- a/proxy/handler/request_handler.go
+++ b/proxy/handler/request_handler.go
@@ -205,9 +205,11 @@ func (h *RequestHandler) serveTcp(
 			backendConnection, err = net.DialTimeout("tcp", endpoint.CanonicalAddr(), h.endpointDialTimeout)
 		}
 
-		iter.PostRequest(endpoint)
 		if err == nil {
+			defer iter.PostRequest(endpoint)
 			break
+		} else {
+			iter.PostRequest(endpoint)
 		}
 
 		iter.EndpointFailed(err)

--- a/route/fakes/fake_endpoint_iterator.go
+++ b/route/fakes/fake_endpoint_iterator.go
@@ -42,9 +42,10 @@ func (fake *FakeEndpointIterator) EndpointFailed(arg1 error) {
 	fake.endpointFailedArgsForCall = append(fake.endpointFailedArgsForCall, struct {
 		arg1 error
 	}{arg1})
+	stub := fake.EndpointFailedStub
 	fake.recordInvocation("EndpointFailed", []interface{}{arg1})
 	fake.endpointFailedMutex.Unlock()
-	if fake.EndpointFailedStub != nil {
+	if stub != nil {
 		fake.EndpointFailedStub(arg1)
 	}
 }
@@ -73,15 +74,16 @@ func (fake *FakeEndpointIterator) Next() *route.Endpoint {
 	ret, specificReturn := fake.nextReturnsOnCall[len(fake.nextArgsForCall)]
 	fake.nextArgsForCall = append(fake.nextArgsForCall, struct {
 	}{})
+	stub := fake.NextStub
+	fakeReturns := fake.nextReturns
 	fake.recordInvocation("Next", []interface{}{})
 	fake.nextMutex.Unlock()
-	if fake.NextStub != nil {
-		return fake.NextStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nextReturns
 	return fakeReturns.result1
 }
 
@@ -125,9 +127,10 @@ func (fake *FakeEndpointIterator) PostRequest(arg1 *route.Endpoint) {
 	fake.postRequestArgsForCall = append(fake.postRequestArgsForCall, struct {
 		arg1 *route.Endpoint
 	}{arg1})
+	stub := fake.PostRequestStub
 	fake.recordInvocation("PostRequest", []interface{}{arg1})
 	fake.postRequestMutex.Unlock()
-	if fake.PostRequestStub != nil {
+	if stub != nil {
 		fake.PostRequestStub(arg1)
 	}
 }
@@ -156,9 +159,10 @@ func (fake *FakeEndpointIterator) PreRequest(arg1 *route.Endpoint) {
 	fake.preRequestArgsForCall = append(fake.preRequestArgsForCall, struct {
 		arg1 *route.Endpoint
 	}{arg1})
+	stub := fake.PreRequestStub
 	fake.recordInvocation("PreRequest", []interface{}{arg1})
 	fake.preRequestMutex.Unlock()
-	if fake.PreRequestStub != nil {
+	if stub != nil {
 		fake.PreRequestStub(arg1)
 	}
 }

--- a/route/pool.go
+++ b/route/pool.go
@@ -101,6 +101,26 @@ func (e *Endpoint) SetRoundTripperIfNil(roundTripperCtor func() ProxyRoundTrippe
 	}
 }
 
+func (e *Endpoint) Equal(e2 *Endpoint) bool {
+	if e2 == nil {
+		return false
+	}
+	return e.ApplicationId == e2.ApplicationId &&
+		e.addr == e2.addr &&
+		e.Protocol == e2.Protocol &&
+		fmt.Sprint(e.Tags) == fmt.Sprint(e2.Tags) &&
+		e.ServerCertDomainSAN == e2.ServerCertDomainSAN &&
+		e.PrivateInstanceId == e2.PrivateInstanceId &&
+		e.StaleThreshold == e2.StaleThreshold &&
+		e.RouteServiceUrl == e2.RouteServiceUrl &&
+		e.PrivateInstanceIndex == e2.PrivateInstanceIndex &&
+		e.ModificationTag == e2.ModificationTag &&
+		e.IsolationSegment == e2.IsolationSegment &&
+		e.useTls == e2.useTls &&
+		e.UpdatedAt == e2.UpdatedAt
+
+}
+
 //go:generate counterfeiter -o fakes/fake_endpoint_iterator.go . EndpointIterator
 type EndpointIterator interface {
 	Next() *Endpoint
@@ -221,7 +241,7 @@ func (p *EndpointPool) Put(endpoint *Endpoint) PoolPutResult {
 	e, found := p.index[endpoint.CanonicalAddr()]
 	if found {
 		result = UPDATED
-		if e.endpoint != endpoint {
+		if !e.endpoint.Equal(endpoint) {
 			e.Lock()
 			defer e.Unlock()
 
@@ -378,7 +398,7 @@ func (p *EndpointPool) IsEmpty() bool {
 
 func (p *EndpointPool) IsOverloaded() bool {
 	if p.IsEmpty() {
-		return true
+		return false
 	}
 
 	p.Lock()

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -184,7 +184,7 @@ var _ = Describe("EndpointPool", func() {
 
 			Context("when modification_tag is older", func() {
 				BeforeEach(func() {
-					modTag.Increment()
+					modTag2.Increment()
 					endpoint := route.NewEndpoint(&route.EndpointOpts{Host: "1.2.3.4", Port: 5678, ModificationTag: modTag2})
 					pool.Put(endpoint)
 				})
@@ -482,7 +482,7 @@ var _ = Describe("EndpointPool", func() {
 
 		Context("when pool is empty", func() {
 			It("returns true", func() {
-				Expect(pool.IsOverloaded()).To(BeTrue())
+				Expect(pool.IsOverloaded()).To(BeFalse())
 			})
 		})
 
@@ -493,6 +493,11 @@ var _ = Describe("EndpointPool", func() {
 					endpoint.Stats.NumberConnections.Increment()
 					endpoint.Stats.NumberConnections.Increment()
 					pool.Put(endpoint)
+
+					Expect(pool.IsOverloaded()).To(BeTrue())
+
+					newEndpoint := route.NewEndpoint(&route.EndpointOpts{Port: 5678})
+					pool.Put(newEndpoint)
 
 					Expect(pool.IsOverloaded()).To(BeTrue())
 				})


### PR DESCRIPTION
### Fix
- Change request_handler to decrement counter after the request has been returned to the client. This fixes an issue for the endpoint connection limits for a WebSocket request.  
- Endpoints should be compared by their fields as oppose to comparing pointers. This will make sure that registry is not updating Stats object for endpoints when it's not necessary.
- Empty pool should now return false for Overloaded

#### Note
I was surprised to see that we don't have much coverage for happy paths for [request_handler_test package](https://github.com/cloudfoundry/gorouter/blob/65207dc5dafa659d343975216701fb2e29e3992a/proxy/handler/request_handler_test.go). This made it difficult to verify the fix for the issue in our unit tests.  I also wasn't able to find any integration tests that would verify this part of the codebase. I verified this change manually by following the steps below. 

### Issue
### Steps to reproduce
1. Grab a cf-deployment environment
2. Deploy a websocket app (https://github.com/gorilla/websocket/tree/master/examples/chat seems to be reasonable), scale it to 2GB of memory, and only one instance
3. Ensure the gorouter property for router.backends.max_conns is set to 1
4. Use a websocket client to connect to the app (https://github.com/oliver006/ws-client)
5. curl the application from a separate shell while the websocket is still open

### Expected

You should receive a 503 indicating connection limits were exceeded for the endpoint

### Actual

The request succeeds.

### Helpful links:

Websocket app: https://github.com/gorilla/websocket/tree/master/examples/chat
Websocket client: https://github.com/oliver006/ws-client

We ran the websockets in a for loop like this:

```
for i in $(seq 1 2000); do
  ./gen-output | ./ws-client ws://<app>.domain/ws &
done
```

gen-output script (needed to keep the ws-client from stopping in the background do to lack of stdin):
```
#!/bin/bash

while sleep 1; do
  echo sleeping
done
```

