### PR TITLE
Let zipkip handler adhere to w3 spec

### DIFF
--- a/handlers/zipkin.go
+++ b/handlers/zipkin.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/openzipkin/zipkin-go/idgenerator"
@@ -45,11 +46,13 @@ func (z *Zipkin) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 	existingTraceID := r.Header.Get(b3.TraceID)
 	existingSpanID := r.Header.Get(b3.SpanID)
 	if existingTraceID == "" || existingSpanID == "" {
-		traceID := idgenerator.NewRandom128().TraceID().String()
+		trace := idgenerator.NewRandom128().TraceID()
 
-		r.Header.Set(b3.TraceID, traceID)
-		r.Header.Set(b3.SpanID, traceID)
-		r.Header.Set(b3.Context, traceID+"-"+traceID)
+		span := fmt.Sprintf("%016x", trace.Low)
+
+		r.Header.Set(b3.TraceID, trace.String())
+		r.Header.Set(b3.SpanID, span)
+		r.Header.Set(b3.Context,  trace.String()+"-"+span)
 	} else {
 		sc, err := b3.ParseHeaders(
 			existingTraceID,

--- a/handlers/zipkin.go
+++ b/handlers/zipkin.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/openzipkin/zipkin-go/idgenerator"
@@ -47,8 +46,7 @@ func (z *Zipkin) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 	existingSpanID := r.Header.Get(b3.SpanID)
 	if existingTraceID == "" || existingSpanID == "" {
 		trace := idgenerator.NewRandom128().TraceID()
-
-		span := fmt.Sprintf("%016x", trace.Low)
+		span := idgenerator.NewRandom128().SpanID(trace).String()
 
 		r.Header.Set(b3.TraceID, trace.String())
 		r.Header.Set(b3.SpanID, span)

--- a/handlers/zipkin_test.go
+++ b/handlers/zipkin_test.go
@@ -1,6 +1,7 @@
 package handlers_test
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 
@@ -16,9 +17,10 @@ import (
 // 64-bit random hexadecimal string
 const (
 	b3IDRegex      = `^[[:xdigit:]]{32}$`
-	b3Regex        = `^[[:xdigit:]]{32}-[[:xdigit:]]{32}(-[01d](-[[:xdigit:]]{32})?)?$`
+	b3Regex        = `^[[:xdigit:]]{32}-[[:xdigit:]]{16}(-[01d](-[[:xdigit:]]{16})?)?$`
 	b3TraceID      = "7f46165474d11ee5836777d85df2cdab"
 	b3SpanID       = "54ebcb82b14862d9"
+	b3SpanRegex    = `[[:xdigit:]]{16}$`
 	b3ParentSpanID = "e56b75d6af463476"
 	b3Single       = "1g56165474d11ee5836777d85df2cdab-32ebcb82b14862d9-1-ab6b75d6af463476"
 )
@@ -53,7 +55,7 @@ var _ = Describe("Zipkin", func() {
 
 		It("sets zipkin headers", func() {
 			handler.ServeHTTP(resp, req, nextHandler)
-			Expect(req.Header.Get(b3.SpanID)).ToNot(BeEmpty())
+			Expect(req.Header.Get(b3.SpanID)).To(MatchRegexp(b3SpanRegex))
 			Expect(req.Header.Get(b3.TraceID)).ToNot(BeEmpty())
 			Expect(req.Header.Get(b3.ParentSpanID)).To(BeEmpty())
 			Expect(req.Header.Get(b3.Context)).ToNot(BeEmpty())
@@ -157,7 +159,7 @@ var _ = Describe("Zipkin", func() {
 			It("adds the B3TraceIdHeader and overwrites the SpanId", func() {
 				handler.ServeHTTP(resp, req, nextHandler)
 				Expect(req.Header.Get(b3.TraceID)).To(MatchRegexp(b3IDRegex))
-				Expect(req.Header.Get(b3.SpanID)).To(MatchRegexp(b3IDRegex))
+				Expect(req.Header.Get(b3.SpanID)).To(MatchRegexp(b3SpanRegex))
 				Expect(req.Header.Get(b3.ParentSpanID)).To(BeEmpty())
 				Expect(req.Header.Get(b3.Context)).To(MatchRegexp(b3Regex))
 
@@ -173,7 +175,7 @@ var _ = Describe("Zipkin", func() {
 			It("overwrites the B3TraceIdHeader and adds a SpanId", func() {
 				handler.ServeHTTP(resp, req, nextHandler)
 				Expect(req.Header.Get(b3.TraceID)).To(MatchRegexp(b3IDRegex))
-				Expect(req.Header.Get(b3.SpanID)).To(MatchRegexp(b3IDRegex))
+				Expect(req.Header.Get(b3.SpanID)).To(MatchRegexp(b3SpanRegex))
 				Expect(req.Header.Get(b3.ParentSpanID)).To(BeEmpty())
 				Expect(req.Header.Get(b3.Context)).To(MatchRegexp(b3Regex))
 

--- a/handlers/zipkin_test.go
+++ b/handlers/zipkin_test.go
@@ -1,7 +1,6 @@
 package handlers_test
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

We run our own custom API gateway (based on spring-cloud-gateway) as a downstream service of the gorouter. Therefore, our software redirects all incoming requests to downstream services. So we pass along x-b3 headers (via spring-cloud-sleuth-zipkin) to our downstream services. With the latest change, we noticed that we can no longer correlate gorouter requests with outgoing requests to downsteam services, since the incoming x-b3 headers are incorrect. 

This change will generating trace and span headers according to the w3 standard. With the previous update, the span-id was generated as a string of 32 characters, but according to the standard, it should be of a length of 16 characters. Currently, traces and spans generated by the gorouter will not be able to be picked up by downstream services using libraries like zipkin for java, since it's invalid.

* An explanation of the use cases your change solves

Continue to trace requests coming from the gorouter to downstream services.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

Start a gorouter instance with a downstream service running (for example anything that can print request headers). Do a curl via the gorouter to this service and see that the value of the x-b3-spanid header is 32 characters in length.
If the downstream service is running anything with the zipkin library, notice that outgoing requests of the downstream service will have different trace ids.

* Expected result after the change

a x-b3-spanid header with a random 16 character value.

* Current result before the change

a x-b3-spanid header with a random 32 character value.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
