### PR TITLE
Add tests to ensure that we support ALPN-enabled HTTP/1.1 clients

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -236,7 +236,7 @@ func (r *Router) serveHTTPS(server *http.Server, errChan chan error) error {
 	}
 
 	if r.config.EnableHTTP2 {
-		tlsConfig.NextProtos = []string{"h2"}
+		tlsConfig.NextProtos = []string{"h2", "http/1.1"}
 	}
 
 	tlsConfig.BuildNameToCertificate()


### PR DESCRIPTION
In golang 1.17, [ALPN handling was altered ](https://github.com/golang/go/issues/46310) in a way that would
break HTTP/1.1 clients using HTTP, if the server only supported 'h2'
in its ALPN protocols. Previously, it would fall back to no-negotiated
mechanism. [Golang later added a short-circuit](https://github.com/golang/go/commit/dc00dc6c6bf3b5554e37f60799aec092276ff807#) specifically for ALPN
clients supporting http/1.1 with servers supporting h2 to fall-back as
if ALPN was not negotiated.

Modifying router.go to include "http/1.1" isn't strictly required
anymore, but is probably a better thing to do anyway, and it allows
us to validate what protocol was negotiated in our tests.
