### PR TITLE
Use min/max (tls) version for route service tls config

### DIFF
--- a/integration/common_integration_test.go
+++ b/integration/common_integration_test.go
@@ -67,7 +67,7 @@ func NewTestState() *testState {
 	cfg, clientTLSConfig := test_util.SpecSSLConfig(test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort())
 	cfg.SkipSSLValidation = false
 	cfg.RouteServicesHairpinning = false
-	cfg.CipherSuites = []uint16{tls.TLS_RSA_WITH_AES_256_CBC_SHA}
+	cfg.CipherString = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384"
 
 	// TODO: why these magic numbers?
 	cfg.PruneStaleDropletsInterval = 2 * time.Second

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -752,6 +752,9 @@ var _ = Describe("Router Integration", func() {
 				}))
 				routeServiceURL = fmt.Sprintf("https://some-route-service.%s:%d/rs", test_util.LocalhostDNS, cfg.SSLPort)
 			})
+			AfterEach(func() {
+				routeSvcApp.Unregister()
+			})
 
 			It("successfully connects to the route service", func() {
 				routeSvcApp.Register()

--- a/integration/route_services_test.go
+++ b/integration/route_services_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -14,64 +15,68 @@ var _ = Describe("Route services", func() {
 
 	var testState *testState
 
+	const (
+		appHostname = "app-with-route-service.some.domain"
+	)
+
+	var (
+		testApp      *httptest.Server
+		routeService *httptest.Server
+	)
+
 	BeforeEach(func() {
 		testState = NewTestState()
+		testApp = httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(200)
+				_, err := w.Write([]byte("I'm the app"))
+				Expect(err).ToNot(HaveOccurred())
+			}))
 
-		testState.StartGorouterOrFail()
+		routeService = httptest.NewUnstartedServer(
+			http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					defer GinkgoRecover()
+
+					forwardedURL := r.Header.Get("X-CF-Forwarded-Url")
+					sigHeader := r.Header.Get("X-Cf-Proxy-Signature")
+					metadata := r.Header.Get("X-Cf-Proxy-Metadata")
+
+					req := testState.newRequest(forwardedURL)
+
+					req.Header.Add("X-CF-Forwarded-Url", forwardedURL)
+					req.Header.Add("X-Cf-Proxy-Metadata", metadata)
+					req.Header.Add("X-Cf-Proxy-Signature", sigHeader)
+
+					res, err := testState.routeServiceClient.Do(req)
+					Expect(err).ToNot(HaveOccurred())
+					defer res.Body.Close()
+					Expect(res.StatusCode).To(Equal(http.StatusOK))
+
+					body, err := ioutil.ReadAll(res.Body)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(body).To(Equal([]byte("I'm the app")))
+
+					w.WriteHeader(res.StatusCode)
+					_, err = w.Write([]byte("I'm the route service"))
+					Expect(err).ToNot(HaveOccurred())
+				}))
+
 	})
 
 	AfterEach(func() {
 		if testState != nil {
 			testState.StopAndCleanup()
 		}
+		routeService.Close()
+		testApp.Close()
 	})
 
 	Context("Happy Path", func() {
-		const (
-			appHostname = "app-with-route-service.some.domain"
-		)
-
 		Context("When an app is registered with a simple route service", func() {
-			var (
-				testApp      *httptest.Server
-				routeService *httptest.Server
-			)
 			BeforeEach(func() {
-				testApp = httptest.NewServer(http.HandlerFunc(
-					func(w http.ResponseWriter, r *http.Request) {
-						w.WriteHeader(200)
-						_, err := w.Write([]byte("I'm the app"))
-						Expect(err).ToNot(HaveOccurred())
-					}))
-
-				routeService = httptest.NewServer(
-					http.HandlerFunc(
-						func(w http.ResponseWriter, r *http.Request) {
-							defer GinkgoRecover()
-
-							forwardedURL := r.Header.Get("X-CF-Forwarded-Url")
-							sigHeader := r.Header.Get("X-Cf-Proxy-Signature")
-							metadata := r.Header.Get("X-Cf-Proxy-Metadata")
-
-							req := testState.newRequest(forwardedURL)
-
-							req.Header.Add("X-CF-Forwarded-Url", forwardedURL)
-							req.Header.Add("X-Cf-Proxy-Metadata", metadata)
-							req.Header.Add("X-Cf-Proxy-Signature", sigHeader)
-
-							res, err := testState.routeServiceClient.Do(req)
-							Expect(err).ToNot(HaveOccurred())
-							defer res.Body.Close()
-							Expect(res.StatusCode).To(Equal(http.StatusOK))
-
-							body, err := ioutil.ReadAll(res.Body)
-							Expect(err).ToNot(HaveOccurred())
-							Expect(body).To(Equal([]byte("I'm the app")))
-
-							w.WriteHeader(res.StatusCode)
-							_, err = w.Write([]byte("I'm the route service"))
-							Expect(err).ToNot(HaveOccurred())
-						}))
+				testState.StartGorouterOrFail()
+				routeService.Start()
 
 				testState.registerWithInternalRouteService(
 					testApp,
@@ -79,12 +84,6 @@ var _ = Describe("Route services", func() {
 					appHostname,
 					testState.cfg.SSLPort,
 				)
-
-			})
-
-			AfterEach(func() {
-				routeService.Close()
-				testApp.Close()
 			})
 
 			It("succeeds", func() {
@@ -103,6 +102,122 @@ var _ = Describe("Route services", func() {
 			It("properly URL-encodes and decodes", func() {
 				req := testState.newRequest(
 					fmt.Sprintf("https://%s?%s", appHostname, "param=a%0Ab"),
+				)
+
+				res, err := testState.client.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				body, err := ioutil.ReadAll(res.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(body).To(Equal([]byte("I'm the route service")))
+			})
+		})
+	})
+
+	Context("when the route service only uses TLS 1.3", func() {
+		BeforeEach(func() {
+			routeService.TLS = testState.trustedExternalServiceTLS
+			routeService.TLS.MaxVersion = tls.VersionTLS13
+			routeService.TLS.MinVersion = tls.VersionTLS13
+			routeService.StartTLS()
+		})
+
+		JustBeforeEach(func() {
+			testState.registerWithExternalRouteService(
+				testApp,
+				routeService,
+				testState.trustedExternalServiceHostname,
+				appHostname,
+			)
+		})
+
+		Context("when the client has MaxVersion of TLS 1.2", func() {
+			BeforeEach(func() {
+				testState.cfg.MaxTLSVersionString = "TLSv1.2"
+				testState.cfg.MinTLSVersionString = "TLSv1.2"
+				testState.StartGorouterOrFail()
+			})
+
+			It("fails with a 502", func() {
+				req := testState.newRequest(
+					fmt.Sprintf("https://%s", appHostname),
+				)
+
+				res, err := testState.client.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(502))
+				Expect(res.Header.Get("X-Cf-RouterError")).To(ContainSubstring("protocol version not supported"))
+			})
+		})
+
+		Context("when the client has MaxVersion of TLS 1.3", func() {
+			BeforeEach(func() {
+				testState.cfg.MaxTLSVersionString = "TLSv1.3"
+				testState.StartGorouterOrFail()
+			})
+
+			It("succeeds", func() {
+				req := testState.newRequest(
+					fmt.Sprintf("https://%s", appHostname),
+				)
+
+				res, err := testState.client.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				body, err := ioutil.ReadAll(res.Body)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(body).To(Equal([]byte("I'm the route service")))
+			})
+		})
+	})
+
+	Context("when the route service has a MaxVersion of TLS 1.1", func() {
+		BeforeEach(func() {
+			routeService.TLS = testState.trustedExternalServiceTLS
+			routeService.TLS.CipherSuites = []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA}
+			routeService.TLS.MaxVersion = tls.VersionTLS11
+			routeService.TLS.MinVersion = tls.VersionTLS11
+			routeService.StartTLS()
+		})
+
+		JustBeforeEach(func() {
+			testState.registerWithExternalRouteService(
+				testApp,
+				routeService,
+				testState.trustedExternalServiceHostname,
+				appHostname,
+			)
+		})
+
+		Context("when the client has MinVersion of TLS 1.2", func() {
+			BeforeEach(func() {
+				testState.cfg.MinTLSVersionString = "TLSv1.2"
+				testState.cfg.MaxTLSVersionString = "TLSv1.2"
+				testState.StartGorouterOrFail()
+			})
+
+			It("fails with a 502", func() {
+				req := testState.newRequest(
+					fmt.Sprintf("https://%s", appHostname),
+				)
+
+				res, err := testState.client.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(502))
+				Expect(res.Header.Get("X-Cf-RouterError")).To(ContainSubstring("protocol version not supported"))
+			})
+		})
+
+		Context("when the client has MinVersion of TLS 1.1", func() {
+			BeforeEach(func() {
+				testState.cfg.MinTLSVersionString = "TLSv1.1"
+				testState.cfg.CipherString = "TLS_RSA_WITH_AES_128_CBC_SHA"
+				testState.StartGorouterOrFail()
+			})
+
+			It("succeeds", func() {
+				req := testState.newRequest(
+					fmt.Sprintf("https://%s", appHostname),
 				)
 
 				res, err := testState.client.Do(req)

--- a/main.go
+++ b/main.go
@@ -163,6 +163,8 @@ func main() {
 		c.RouteServiceRecommendHttps,
 	)
 
+	// These TLS configs are just tempaltes. If you add other keys you will
+	// also need to edit proxy/utils/tls_config.go
 	backendTLSConfig := &tls.Config{
 		CipherSuites: c.CipherSuites,
 		RootCAs:      c.CAPool,
@@ -174,6 +176,8 @@ func main() {
 		InsecureSkipVerify: c.SkipSSLValidation,
 		RootCAs:            c.CAPool,
 		Certificates:       []tls.Certificate{c.RouteServiceConfig.ClientAuthCertificate},
+		MinVersion:         c.MinTLSVersion,
+		MaxVersion:         c.MaxTLSVersion,
 	}
 
 	rss, err := router.NewRouteServicesServer()

--- a/proxy/handler/request_handler.go
+++ b/proxy/handler/request_handler.go
@@ -199,7 +199,7 @@ func (h *RequestHandler) serveTcp(
 		iter.PreRequest(endpoint)
 
 		if endpoint.IsTLS() {
-			tlsConfigLocal := utils.TLSConfigWithServerName(endpoint.ServerCertDomainSAN, h.tlsConfigTemplate)
+			tlsConfigLocal := utils.TLSConfigWithServerName(endpoint.ServerCertDomainSAN, h.tlsConfigTemplate, false)
 			backendConnection, err = tls.DialWithDialer(dialer, "tcp", endpoint.CanonicalAddr(), tlsConfigLocal)
 		} else {
 			backendConnection, err = net.DialTimeout("tcp", endpoint.CanonicalAddr(), h.endpointDialTimeout)

--- a/proxy/round_tripper/dropsonde_round_tripper.go
+++ b/proxy/round_tripper/dropsonde_round_tripper.go
@@ -41,7 +41,7 @@ func (t *FactoryImpl) New(expectedServerName string, isRouteService bool, isHttp
 		template = t.BackendTemplate
 	}
 
-	customTLSConfig := utils.TLSConfigWithServerName(expectedServerName, template.TLSClientConfig)
+	customTLSConfig := utils.TLSConfigWithServerName(expectedServerName, template.TLSClientConfig, isRouteService)
 
 	newTransport := &http.Transport{
 		Dial:                template.Dial,

--- a/proxy/utils/tls_config.go
+++ b/proxy/utils/tls_config.go
@@ -2,12 +2,18 @@ package utils
 
 import "crypto/tls"
 
-func TLSConfigWithServerName(newServerName string, template *tls.Config) *tls.Config {
-	return &tls.Config{
+func TLSConfigWithServerName(newServerName string, template *tls.Config, isRouteService bool) *tls.Config {
+	config := &tls.Config{
 		CipherSuites:       template.CipherSuites,
 		InsecureSkipVerify: template.InsecureSkipVerify,
 		RootCAs:            template.RootCAs,
 		ServerName:         newServerName,
 		Certificates:       template.Certificates,
 	}
+
+	if isRouteService {
+		config.MinVersion = template.MinVersion
+		config.MaxVersion = template.MaxVersion
+	}
+	return config
 }


### PR DESCRIPTION
With golang 1.17 tls 1.0 and 1.1 will not longer we supported by default.

