### PR TITLE
Add a optional prometheus endpoint to record app latency

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -77,6 +77,13 @@ var defaultStatusConfig = StatusConfig{
 	Pass: "",
 }
 
+type PrometheusConfig struct {
+	Port     uint16 `yaml:"port"`
+	CertPath string `yaml:"cert_path"`
+	KeyPath  string `yaml:"key_path"`
+	CAPath   string `yaml:"ca_path"`
+}
+
 type NatsConfig struct {
 	Hosts                 []NatsHost       `yaml:"hosts"`
 	User                  string           `yaml:"user"`
@@ -192,6 +199,7 @@ type Config struct {
 	Nats            NatsConfig        `yaml:"nats,omitempty"`
 	Logging         LoggingConfig     `yaml:"logging,omitempty"`
 	Port            uint16            `yaml:"port,omitempty"`
+	Prometheus      PrometheusConfig  `yaml:"prometheus,omitempty"`
 	Index           uint              `yaml:"index,omitempty"`
 	Zone            string            `yaml:"zone,omitempty"`
 	GoMaxProcs      int               `yaml:"go_max_procs,omitempty"`
@@ -283,11 +291,17 @@ type Config struct {
 
 	HTMLErrorTemplateFile string `yaml:"html_error_template_file,omitempty"`
 
+	// Old metric, to eventually be replaced by prometheus reporting
+	// reports latency under gorouter sourceid, and with and without component name
 	PerRequestMetricsReporting bool `yaml:"per_request_metrics_reporting,omitempty"`
 
+	// Old metric, to eventually be replaced by prometheus reporting
 	SendHttpStartStopServerEvent bool `yaml:"send_http_start_stop_server_event,omitempty"`
 
+	// Old metric, to eventually be replaced by prometheus reporting
 	SendHttpStartStopClientEvent bool `yaml:"send_http_start_stop_client_event,omitempty"`
+
+	PerAppPrometheusHttpMetricsReporting bool `yaml:"per_app_prometheus_http_metrics_reporting",omitempty`
 
 	HealthCheckPollInterval time.Duration `yaml:"healthcheck_poll_interval"`
 	HealthCheckTimeout      time.Duration `yaml:"healthcheck_timeout"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -73,6 +73,24 @@ status:
 
 		})
 
+		It("sets prometheus endpoint config", func() {
+			var b = []byte(`
+prometheus:
+  port: 1234
+  cert_path: /some-cert-path
+  key_path: /some-key-path
+  ca_path: /some-ca-path
+`)
+
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(config.Prometheus.Port).To(Equal(uint16(1234)))
+			Expect(config.Prometheus.CertPath).To(Equal("/some-cert-path"))
+			Expect(config.Prometheus.KeyPath).To(Equal("/some-key-path"))
+			Expect(config.Prometheus.CAPath).To(Equal("/some-ca-path"))
+		})
+
 		It("defaults frontend idle timeout to 900", func() {
 			Expect(config.FrontendIdleTimeout).To(Equal(900 * time.Second))
 		})

--- a/handlers/httplatencyprometheus.go
+++ b/handlers/httplatencyprometheus.go
@@ -16,8 +16,7 @@ type httpLatencyPrometheusHandler struct {
 	registry Registry
 }
 
-// NewHTTPStartStop creates a new handler that handles emitting frontent
-// HTTP StartStop events
+// NewHTTPLatencyPrometheus creates a new handler that handles prometheus metrics for latency
 func NewHTTPLatencyPrometheus(r Registry) negroni.Handler {
 	return &httpLatencyPrometheusHandler{
 		registry: r,

--- a/handlers/httplatencyprometheus.go
+++ b/handlers/httplatencyprometheus.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	metrics "code.cloudfoundry.org/go-metric-registry"
+	"github.com/urfave/negroni"
+)
+
+type Registry interface {
+	NewHistogram(name, helpText string, buckets []float64, opts ...metrics.MetricOption) metrics.Histogram
+}
+
+type httpLatencyPrometheusHandler struct {
+	registry Registry
+}
+
+// NewHTTPStartStop creates a new handler that handles emitting frontent
+// HTTP StartStop events
+func NewHTTPLatencyPrometheus(r Registry) negroni.Handler {
+	return &httpLatencyPrometheusHandler{
+		registry: r,
+	}
+}
+
+// ServeHTTP handles emitting a StartStop event after the request has been completed
+func (hl *httpLatencyPrometheusHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	start := time.Now()
+	next(rw, r)
+	stop := time.Now()
+
+	latency := stop.Sub(start) / time.Second
+
+	sourceId := "gorouter"
+	endpoint, err := GetEndpoint(r.Context())
+	if err == nil {
+		if endpoint.Tags["source_id"] != "" {
+			sourceId = endpoint.Tags["source_id"]
+		}
+	}
+
+	h := hl.registry.NewHistogram("http_latency_seconds", "the latency of http requests from gorouter and back",
+		[]float64{0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6},
+		metrics.WithMetricLabels(map[string]string{"source_id": sourceId}))
+	h.Observe(float64(latency))
+}

--- a/handlers/httplatencyprometheus_test.go
+++ b/handlers/httplatencyprometheus_test.go
@@ -1,0 +1,131 @@
+package handlers_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+
+	"code.cloudfoundry.org/gorouter/route"
+
+	fake_registry "code.cloudfoundry.org/go-metric-registry/testhelpers"
+	"code.cloudfoundry.org/gorouter/handlers"
+	"code.cloudfoundry.org/gorouter/test_util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/urfave/negroni"
+)
+
+var _ = Describe("Http Prometheus Latency", func() {
+	var (
+		handler     *negroni.Negroni
+		nextHandler http.HandlerFunc
+
+		resp http.ResponseWriter
+		req  *http.Request
+
+		fakeRegistry *fake_registry.SpyMetricsRegistry
+
+		nextCalled bool
+	)
+
+	BeforeEach(func() {
+		body := bytes.NewBufferString("What are you?")
+		req = test_util.NewRequest("GET", "example.com", "/", body)
+		resp = httptest.NewRecorder()
+
+		fakeRegistry = fake_registry.NewMetricsRegistry()
+
+		nextHandler = http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			_, err := ioutil.ReadAll(req.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			rw.WriteHeader(http.StatusTeapot)
+			rw.Write([]byte("I'm a little teapot, short and stout."))
+
+			requestInfo, err := handlers.ContextRequestInfo(req)
+			Expect(err).ToNot(HaveOccurred())
+			requestInfo.RouteEndpoint = route.NewEndpoint(&route.EndpointOpts{
+				Tags: map[string]string{
+					"source_id": "some-source-id",
+				},
+			})
+
+			nextCalled = true
+		})
+		nextCalled = false
+	})
+	Context("when the request info is set", func() {
+		JustBeforeEach(func() {
+			handler = negroni.New()
+			handler.Use(handlers.NewRequestInfo())
+			handler.Use(handlers.NewHTTPLatencyPrometheus(fakeRegistry))
+			handler.UseHandlerFunc(nextHandler)
+		})
+		It("forwards the request", func() {
+			handler.ServeHTTP(resp, req)
+
+			Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+		})
+
+		It("records http latency", func() {
+			handler.ServeHTTP(resp, req)
+
+			metric := fakeRegistry.GetMetric("http_latency_seconds", map[string]string{"source_id": "some-source-id"})
+			Expect(metric.Value()).ToNot(Equal(0))
+		})
+
+		It("http metric has help text", func() {
+			handler.ServeHTTP(resp, req)
+
+			metric := fakeRegistry.GetMetric("http_latency_seconds", map[string]string{"source_id": "some-source-id"})
+			Expect(metric.HelpText()).To(Equal("the latency of http requests from gorouter and back"))
+		})
+		It("http metrics have expotential buckets", func() {
+			handler.ServeHTTP(resp, req)
+
+			metric := fakeRegistry.GetMetric("http_latency_seconds", map[string]string{"source_id": "some-source-id"})
+			Expect(metric.Buckets()).To(Equal([]float64{
+				0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6,
+			}))
+		})
+	})
+
+	Context("when the request info is not set", func() {
+		It("sets source id to gorouter", func() {
+			handler = negroni.New()
+			handler.Use(handlers.NewHTTPLatencyPrometheus(fakeRegistry))
+			handler.ServeHTTP(resp, req)
+
+			metric := fakeRegistry.GetMetric("http_latency_seconds", map[string]string{"source_id": "gorouter"})
+			Expect(metric.Value()).ToNot(Equal(0))
+		})
+
+		It("sets source id to gorouter", func() {
+			nextHandler = http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				_, err := ioutil.ReadAll(req.Body)
+				Expect(err).NotTo(HaveOccurred())
+
+				rw.WriteHeader(http.StatusTeapot)
+				rw.Write([]byte("I'm a little teapot, short and stout."))
+
+				requestInfo, err := handlers.ContextRequestInfo(req)
+				Expect(err).ToNot(HaveOccurred())
+				requestInfo.RouteEndpoint = route.NewEndpoint(&route.EndpointOpts{
+					Tags: map[string]string{
+						"source_id": "",
+					},
+				})
+			})
+			handler = negroni.New()
+			handler.Use(handlers.NewRequestInfo())
+			handler.Use(handlers.NewHTTPLatencyPrometheus(fakeRegistry))
+			handler.UseHandlerFunc(nextHandler)
+			handler.ServeHTTP(resp, req)
+
+			metric := fakeRegistry.GetMetric("http_latency_seconds", map[string]string{"source_id": "gorouter"})
+			Expect(metric.Value()).ToNot(Equal(0))
+		})
+	})
+})

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -574,7 +574,7 @@ var _ = Describe("Router Integration", func() {
 		Eventually(gorouterSession.Out.Contents).Should(ContainSubstring("Component Router registered successfully"))
 	})
 
-	Describe("metrics emitted", func() {
+	Describe("loggregator metrics emitted", func() {
 		var (
 			fakeMetron test_util.FakeMetron
 		)
@@ -650,6 +650,46 @@ var _ = Describe("Router Integration", func() {
 
 			Expect(measuredLatency_ms).To(BeNumerically(">=", 10000))
 			Expect(measuredLatency_ms).To(BeNumerically("<=", 14000))
+		})
+	})
+
+	Describe("prometheus metrics", func() {
+		It("starts a prometheus https server", func() {
+			c := createConfig(statusPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			metricsPort := test_util.NextAvailPort()
+			serverCAPath, serverCertPath, serverKeyPath, clientCert := tls_helpers.GenerateCaAndMutualTlsCerts()
+
+			c.Prometheus.Port = metricsPort
+			c.Prometheus.CertPath = serverCertPath
+			c.Prometheus.KeyPath = serverKeyPath
+			c.Prometheus.CAPath = serverCAPath
+
+			writeConfig(c, cfgFile)
+
+			gorouterSession = startGorouterSession(cfgFile)
+
+			tlsConfig, err := tlsconfig.Build(
+				tlsconfig.WithInternalServiceDefaults(),
+				tlsconfig.WithIdentity(clientCert),
+			).Client(
+				tlsconfig.WithAuthorityFromFile(serverCAPath),
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			client := &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: tlsConfig,
+				},
+			}
+
+			metricsURL := fmt.Sprintf("https://127.0.0.1:%d/metrics", metricsPort)
+			r, err := client.Get(metricsURL)
+			Expect(err).ToNot(HaveOccurred())
+
+			response, err := ioutil.ReadAll(r.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(string(response)).To(ContainSubstring("process_resident_memory_bytes"))
 		})
 	})
 

--- a/integration/perf_test.go
+++ b/integration/perf_test.go
@@ -45,7 +45,7 @@ var _ = Describe("AccessLogRecord", func() {
 		rss, err := router.NewRouteServicesServer()
 		Expect(err).ToNot(HaveOccurred())
 		var h *health.Health
-		proxy.NewProxy(logger, accesslog, ew, c, r, combinedReporter, &routeservice.RouteServiceConfig{},
+		proxy.NewProxy(logger, accesslog, nil, ew, c, r, combinedReporter, &routeservice.RouteServiceConfig{},
 			&tls.Config{}, &tls.Config{}, h, rss.GetRoundTripper())
 
 		b.Time("RegisterTime", func() {

--- a/main.go
+++ b/main.go
@@ -5,18 +5,17 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"runtime"
 	"syscall"
 	"time"
 
-	"code.cloudfoundry.org/gorouter/common/health"
-
-	"code.cloudfoundry.org/tlsconfig"
-
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/debugserver"
+	mr "code.cloudfoundry.org/go-metric-registry"
 	"code.cloudfoundry.org/gorouter/accesslog"
+	"code.cloudfoundry.org/gorouter/common/health"
 	"code.cloudfoundry.org/gorouter/common/schema"
 	"code.cloudfoundry.org/gorouter/common/secure"
 	"code.cloudfoundry.org/gorouter/config"
@@ -33,6 +32,7 @@ import (
 	rvarz "code.cloudfoundry.org/gorouter/varz"
 	"code.cloudfoundry.org/lager"
 	routing_api "code.cloudfoundry.org/routing-api"
+	"code.cloudfoundry.org/tlsconfig"
 	uaa_client "code.cloudfoundry.org/uaa-go-client"
 	uaa_config "code.cloudfoundry.org/uaa-go-client/config"
 	"github.com/cloudfoundry/dropsonde"
@@ -181,10 +181,17 @@ func main() {
 		logger.Fatal("new-route-services-server", zap.Error(err))
 	}
 
+	var metricsRegistry *mr.Registry
+	if c.Prometheus.Port != 0 {
+		metricsRegistry = mr.NewRegistry(log.Default(),
+			mr.WithTLSServer(int(c.Prometheus.Port), c.Prometheus.CertPath, c.Prometheus.KeyPath, c.Prometheus.CAPath))
+	}
+
 	h = &health.Health{}
 	proxy := proxy.NewProxy(
 		logger,
 		accessLogger,
+		metricsRegistry,
 		ew,
 		c,
 		registry,

--- a/proxy/proxy_suite_test.go
+++ b/proxy/proxy_suite_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	fake_registry "code.cloudfoundry.org/go-metric-registry/testhelpers"
 	fakelogsender "code.cloudfoundry.org/gorouter/accesslog/schema/fakes"
 	sharedfakes "code.cloudfoundry.org/gorouter/fakes"
 	"code.cloudfoundry.org/gorouter/metrics/fakes"
@@ -36,6 +37,7 @@ import (
 //go:generate counterfeiter -o ../fakes/round_tripper.go --fake-name RoundTripper net/http.RoundTripper
 
 var (
+	fakeRegistry            *fake_registry.SpyMetricsRegistry
 	r                       *registry.RouteRegistry
 	p                       http.Handler
 	f                       *os.File
@@ -79,6 +81,7 @@ var _ = BeforeEach(func() {
 	conf.EndpointDialTimeout = 50 * time.Millisecond
 	conf.EnableHTTP2 = false
 	fakeReporter = &fakes.FakeCombinedReporter{}
+	fakeRegistry = fake_registry.NewMetricsRegistry()
 	skipSanitization = func(*http.Request) bool { return false }
 })
 
@@ -131,7 +134,7 @@ var _ = JustBeforeEach(func() {
 
 	fakeRouteServicesClient = &sharedfakes.RoundTripper{}
 
-	p = proxy.NewProxy(testLogger, al, ew, conf, r, fakeReporter, routeServiceConfig, tlsConfig, tlsConfig, healthStatus, fakeRouteServicesClient)
+	p = proxy.NewProxy(testLogger, al, fakeRegistry, ew, conf, r, fakeReporter, routeServiceConfig, tlsConfig, tlsConfig, healthStatus, fakeRouteServicesClient)
 
 	if conf.EnableHTTP2 {
 		server := http.Server{Handler: p}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -2070,6 +2070,48 @@ var _ = Describe("Proxy", func() {
 			Expect(findStartStopEvent().RequestId).To(Equal(factories.NewUUID(u2)))
 		})
 
+		Context("when http prometheus metrics are turned on", func() {
+			BeforeEach(func() {
+				conf.PerAppPrometheusHttpMetricsReporting = true
+			})
+			It("records http prometheus metrics", func() {
+				ln := test_util.RegisterConnHandler(r, "app", func(conn *test_util.HttpConn) {
+					resp := test_util.NewResponse(http.StatusOK)
+					conn.WriteResponse(resp)
+					conn.Close()
+				}, test_util.RegisterConfig{InstanceId: "fake-instance-id"})
+				defer ln.Close()
+				conn := dialProxy(proxyServer)
+
+				req := test_util.NewRequest("GET", "app", "/", nil)
+				conn.WriteRequest(req)
+
+				resp, _ := conn.ReadResponse()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				metric := fakeRegistry.GetMetric("http_latency_seconds", map[string]string{"source_id": "gorouter"})
+				Expect(metric.Value()).ToNot(Equal(0))
+			})
+		})
+
+		It("does not register http prometheus metrics", func() {
+			ln := test_util.RegisterConnHandler(r, "app", func(conn *test_util.HttpConn) {
+				resp := test_util.NewResponse(http.StatusOK)
+				conn.WriteResponse(resp)
+				conn.Close()
+			}, test_util.RegisterConfig{InstanceId: "fake-instance-id"})
+			defer ln.Close()
+			conn := dialProxy(proxyServer)
+
+			req := test_util.NewRequest("GET", "app", "/", nil)
+			conn.WriteRequest(req)
+
+			resp, _ := conn.ReadResponse()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			Expect(func() { fakeRegistry.GetMetric("http_latency_seconds", map[string]string{"source_id": "gorouter"}) }).To(Panic())
+		})
+
 		Context("when the endpoint is nil", func() {
 			removeAllEndpoints := func(pool *route.EndpointPool) {
 				endpoints := make([]*route.Endpoint, 0)

--- a/proxy/proxy_unit_test.go
+++ b/proxy/proxy_unit_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Proxy Unit tests", func() {
 			conf.HealthCheckUserAgent = "HTTP-Monitor/1.1"
 
 			skipSanitization = func(req *http.Request) bool { return false }
-			proxyObj = proxy.NewProxy(logger, fakeAccessLogger, ew, conf, r, combinedReporter,
+			proxyObj = proxy.NewProxy(logger, fakeAccessLogger, fakeRegistry, ew, conf, r, combinedReporter,
 				routeServiceConfig, tlsConfig, tlsConfig, &health.Health{}, rt)
 
 			r.Register(route.Uri("some-app"), &route.Endpoint{Stats: route.NewStats()})

--- a/router/router_drain_test.go
+++ b/router/router_drain_test.go
@@ -185,7 +185,7 @@ var _ = Describe("Router", func() {
 		config.HealthCheckUserAgent = "HTTP-Monitor/1.1"
 
 		rt := &sharedfakes.RoundTripper{}
-		p = proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, ew, config, registry, combinedReporter,
+		p = proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, nil, ew, config, registry, combinedReporter,
 			&routeservice.RouteServiceConfig{}, &tls.Config{}, &tls.Config{}, healthStatus, rt)
 
 		errChan := make(chan error, 2)
@@ -418,7 +418,7 @@ var _ = Describe("Router", func() {
 				config.HealthCheckUserAgent = "HTTP-Monitor/1.1"
 				config.Status.Port = test_util.NextAvailPort()
 				rt := &sharedfakes.RoundTripper{}
-				p := proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, ew, config, registry, combinedReporter,
+				p := proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, nil, ew, config, registry, combinedReporter,
 					&routeservice.RouteServiceConfig{}, &tls.Config{}, &tls.Config{}, h, rt)
 
 				errChan = make(chan error, 2)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -2047,7 +2047,7 @@ func initializeRouter(config *cfg.Config, backendIdleTimeout, requestTimeout tim
 	proxyConfig := *config
 	proxyConfig.EndpointTimeout = requestTimeout
 	routeServicesTransport := &sharedfakes.RoundTripper{}
-	p := proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, ew, &proxyConfig, registry, combinedReporter,
+	p := proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, nil, ew, &proxyConfig, registry, combinedReporter,
 		routeServiceConfig, &tls.Config{}, &tls.Config{}, &health.Health{}, routeServicesTransport)
 
 	h := &health.Health{}


### PR DESCRIPTION
Signed-off-by: Rebecca Roberts <robertsre@vmware.com>
Signed-off-by: Ben Fuller <benjaminf@vmware.com>
Signed-off-by: Andrew Crump <crumpan@vmware.com>

Note on necessary changes that will have to be made before making this a default feature:

* Possibly add more metadata, including app data, but also possibly success/failure outcome as well
* expire metrics after a period of time. 
*  There's a released change in loggregator-agent-release/metrics-discovery to handle bugs discovered to do with this change.

<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

Add a optional Prometheus endpoint to record app latency

* An explanation of the use cases your change solves

Prometheus latency should usually produce less metrics per application, but should also be easier to parse and resolve. It should also be more accurate. 

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

should be able to deploy with
```
  router:
       per_request_metrics_reporting: false
       send_http_start_stop_server_event: false
       send_http_start_stop_client_event: false
       per_app_prometheus_http_metrics_reporting: true
       prometheus:
         ca_cert: ((gorouter_metrics_tls.ca))
         cert: ((gorouter_metrics_tls.certificate))
         key: ((gorouter_metrics_tls.private_key))
         port: 18000
         server_name: gorouter_metrics
```
```
- name: gorouter_metrics_tls
  options:
    alternative_names:
    - gorouter_metrics
    ca: metric_scraper_ca
    common_name: gorouter_metrics
    extended_key_usage:
    - server_auth
  type: certificate
  update_mode: converge
```
* Expected result after the change

prometheus metrics come out and the old latency metrics and start stops don't. 

* Current result before the change

prometheus metrics don't come out and old latency metrics and start stops do. 

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
