### PR TITLE
Add warnings when requests come into gorouter with unescaped semicolons

### DIFF
--- a/handlers/query_param.go
+++ b/handlers/query_param.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+
+	router_http "code.cloudfoundry.org/gorouter/common/http"
+	"code.cloudfoundry.org/gorouter/logger"
+
+	"github.com/uber-go/zap"
+	"github.com/urfave/negroni"
+)
+
+type queryParam struct {
+	logger logger.Logger
+}
+
+// NewQueryParam creates a new handler that emits warnings if requests came in with semicolons un-escaped
+func NewQueryParam(logger logger.Logger) negroni.Handler {
+	return &queryParam{logger: logger}
+}
+
+func (q *queryParam) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	semicolonInParams := strings.Contains(r.RequestURI, ";")
+	if semicolonInParams {
+		q.logger.Warn("deprecated-semicolon-params", zap.String("vcap_request_id", r.Header.Get(VcapRequestIdHeader)))
+	}
+
+	next(rw, r)
+
+	if semicolonInParams {
+		rw.Header().Add(router_http.CfRouterError, "deprecated-semicolon-params")
+	}
+}

--- a/handlers/query_param_test.go
+++ b/handlers/query_param_test.go
@@ -1,0 +1,116 @@
+package handlers_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+
+	router_http "code.cloudfoundry.org/gorouter/common/http"
+	"code.cloudfoundry.org/gorouter/common/uuid"
+	"code.cloudfoundry.org/gorouter/handlers"
+	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
+	"code.cloudfoundry.org/gorouter/route"
+	"code.cloudfoundry.org/gorouter/test_util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/uber-go/zap"
+	"github.com/urfave/negroni"
+)
+
+var _ = Describe("QueryParamHandler", func() {
+	var (
+		handler *negroni.Negroni
+
+		resp http.ResponseWriter
+		req  *http.Request
+
+		fakeLogger *logger_fakes.FakeLogger
+
+		nextCalled bool
+
+		reqChan chan *http.Request
+	)
+	testEndpoint := route.NewEndpoint(&route.EndpointOpts{
+		Host: "host",
+		Port: 1234,
+	})
+
+	nextHandler := negroni.HandlerFunc(func(rw http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+		_, err := ioutil.ReadAll(req.Body)
+		Expect(err).NotTo(HaveOccurred())
+
+		rw.WriteHeader(http.StatusTeapot)
+		rw.Write([]byte("I'm a little teapot, short and stout."))
+
+		reqInfo, err := handlers.ContextRequestInfo(req)
+		if err == nil {
+			reqInfo.RouteEndpoint = testEndpoint
+		}
+
+		if next != nil {
+			next(rw, req)
+		}
+
+		reqChan <- req
+		nextCalled = true
+	})
+
+	BeforeEach(func() {
+		body := bytes.NewBufferString("What are you?")
+		req = test_util.NewRequest("GET", "example.com", "/", body)
+		resp = httptest.NewRecorder()
+
+		fakeLogger = new(logger_fakes.FakeLogger)
+
+		handler = negroni.New()
+		handler.Use(handlers.NewRequestInfo())
+		handler.Use(handlers.NewProxyWriter(fakeLogger))
+		handler.Use(handlers.NewQueryParam(fakeLogger))
+		handler.Use(nextHandler)
+
+		reqChan = make(chan *http.Request, 1)
+
+		nextCalled = false
+	})
+
+	AfterEach(func() {
+		Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+		close(reqChan)
+	})
+
+	Context("when checking if semicolons are in the request", func() {
+		var id string
+		var err error
+		BeforeEach(func() {
+			id, err = uuid.GenerateUUID()
+			Expect(err).ToNot(HaveOccurred())
+			req.Header.Add(handlers.VcapRequestIdHeader, id)
+		})
+
+		Context("when semicolons are present", func() {
+			It("logs a warning", func() {
+				req.RequestURI = "/example?param1;param2"
+				handler.ServeHTTP(resp, req)
+
+				Expect(fakeLogger.WarnCallCount()).To(Equal(1))
+				msg, fields := fakeLogger.WarnArgsForCall(0)
+				Expect(msg).To(Equal("deprecated-semicolon-params"))
+				Expect(fields).To(Equal([]zap.Field{zap.String("vcap_request_id", id)}))
+
+				Expect(resp.Header().Get(router_http.CfRouterError)).To(Equal("deprecated-semicolon-params"))
+			})
+		})
+		Context("when semicolons are not present", func() {
+			It("does not log a warning", func() {
+				req.RequestURI = "/example?param1&param2"
+				handler.ServeHTTP(resp, req)
+
+				Expect(fakeLogger.WarnCallCount()).To(Equal(0))
+				Expect(resp.Header().Get(router_http.CfRouterError)).To(Equal(""))
+			})
+		})
+	})
+
+})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -169,6 +169,7 @@ func NewProxy(
 		n.Use(handlers.NewHTTPStartStop(dropsonde.DefaultEmitter, logger))
 	}
 	n.Use(handlers.NewAccessLog(accessLogger, headersToLog, logger))
+	n.Use(handlers.NewQueryParam(logger))
 	n.Use(handlers.NewReporter(reporter, logger))
 	n.Use(handlers.NewHTTPRewriteHandler(cfg.HTTPRewrite, headersToAlwaysRemove))
 	n.Use(handlers.NewProxyHealthcheck(cfg.HealthCheckUserAgent, p.health, logger))


### PR DESCRIPTION
Golang 1.17 will no longer accept them when url.Parse() is called.
Gorouter does not look at/modify the request params, however we're
adding warnings to the gorouter log + updating the X-Cf-RouterError
header so app devs + operators will be able to trace back requests
if they have an app performing strangely

Signed-off-by: Geoff Franks <gfranks@vmware.com>

<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
