### PR TITLE
Fix intermittent test panicking due to a sleep being too long

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1598,11 +1598,12 @@ var _ = Describe("Proxy", func() {
 					conn.SetDeadline(time.Now().Add(500 * time.Millisecond))
 					writer := bufio.NewWriter(conn)
 					go func(req *http.Request, writer *bufio.Writer) {
+						defer GinkgoRecover()
 						err = req.Write(writer)
 						Expect(err).To(HaveOccurred())
 						writer.Flush()
 					}(req, writer)
-					time.Sleep(100 * time.Millisecond) // give time for the data to start transmitting
+					time.Sleep(10 * time.Millisecond) // give time for the data to start transmitting
 
 					// need to shutdown the writer first or conn.Close will block until the large payload finishes sending.
 					// Another way to do this is to get syscall.rawconn and use control to syscall.SetNonblock on the


### PR DESCRIPTION
Signed-off-by: Chris Selzo <cselzo@vmware.com>
Signed-off-by: Geoff Franks <gfranks@vmware.com>
Signed-off-by: Chris Selzo <cselzo@vmware.com>

<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
