### PR TITLE
update config to match actual nats server config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ type NatsHost struct {
 }
 
 var defaultNatsConfig = NatsConfig{
-	Hosts: []NatsHost{{Hostname: "localhost", Port: 42222}},
+	Hosts: []NatsHost{{Hostname: "localhost", Port: 4222}},
 	User:  "",
 	Pass:  "",
 }


### PR DESCRIPTION
A default config for nats is created when gorouter is started up. Nats-server runs on port 4222; however it looks like we introduced a typo in our default config for it to start on 42222:
https://github.com/cloudfoundry/gorouter/commit/c69a1e19bd1c14ec8c35b5d074dff7214a5caa6a

In cf-deployment / TAS environments, this [config is overridden](https://github.com/cloudfoundry/gorouter/blob/c69a1e19bd1c14ec8c35b5d074dff7214a5caa6a/config/config.go#L707) with the nats-tls link provided by nats-release.

In our documentation, we give directions for starting gorouter with a local nats server. Gorouter fails with the following error:
`nats: no servers available for connection`

Confirmed that changing the default config port allows the local gorouter process to start.