### PR TITLE
Fix typo in default NATS config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ type NatsHost struct {
 }
 
 var defaultNatsConfig = NatsConfig{
-	Hosts: []NatsHost{{Hostname: "localhost", Port: 42222}},
+	Hosts: []NatsHost{{Hostname: "localhost", Port: 4222}},
 	User:  "",
 	Pass:  "",
 }


### PR DESCRIPTION
Default port is 4222, not 42222

<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:
Get the gorouter to work with a default NATS server as described in readme.me

* An explanation of the use cases your change solves
The default NATS ports in config.go is changed back to 4222, the default port of the NATS server.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change
```
./gorouter
{"log_level":1,"timestamp":1644257829.909318,"message":"starting","source":"gorouter.stdout","data":{}}
{"log_level":1,"timestamp":1644257829.91069,"message":"retrieved-isolation-segments","source":"gorouter.stdout","data":{"isolation_segments":null,"routing_table_sharding_mode":"all"}}
{"log_level":1,"timestamp":1644257829.910762,"message":"setting-up-nats-connection","source":"gorouter.stdout","data":{}}
{"log_level":1,"timestamp":1644257829.912936,"message":"Successfully-connected-to-nats","source":"gorouter.stdout.nats","data":{"host":"localhost:4222"}}
```

* Current result before the change
```
./gorouter
{"log_level":1,"timestamp":1644257371.5475829,"message":"starting","source":"gorouter.stdout","data":{}}
{"log_level":1,"timestamp":1644257371.548629,"message":"retrieved-isolation-segments","source":"gorouter.stdout","data":{"isolation_segments":null,"routing_table_sharding_mode":"all"}}
{"log_level":1,"timestamp":1644257371.5486789,"message":"setting-up-nats-connection","source":"gorouter.stdout","data":{}}
{"log_level":6,"timestamp":1644257371.853358,"message":"nats-connection-error","source":"gorouter.stdout.nats","data":{"error":"nats: no servers available for connection"}}
```
* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
