### PR TITLE
Use lsof to monitor fds on MacOS

### DIFF
--- a/metrics/monitor/fd_monitor.go
+++ b/metrics/monitor/fd_monitor.go
@@ -1,8 +1,12 @@
 package monitor
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
+	"runtime"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/gorouter/logger"
@@ -31,15 +35,28 @@ func (f *FileDescriptor) Run(signals <-chan os.Signal, ready chan<- struct{}) er
 	for {
 		select {
 		case <-f.ticker.C:
-			fdInfo, err := ioutil.ReadDir(f.path)
-			if err != nil {
-				f.logger.Error("error-reading-filedescriptor-path", zap.Error(err))
-				break
+			numFds := 0
+			if runtime.GOOS == "linux" {
+				fdInfo, err := ioutil.ReadDir(f.path)
+				if err != nil {
+					f.logger.Error("error-reading-filedescriptor-path", zap.Error(err))
+					break
+				}
+				numFds = symlinks(fdInfo)
+			} else if runtime.GOOS == "darwin" {
+				// no /proc on MacOS, falling back to lsof
+				out, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("lsof -p %v", os.Getpid())).Output()
+				if err != nil {
+					f.logger.Error("error-running-lsof", zap.Error(err))
+					break
+				}
+				lines := strings.Split(string(out), "\n")
+				numFds = len(lines) - 1 //cut the table header
 			}
-
-			if err = f.sender.SendValue("file_descriptors", float64(symlinks(fdInfo)), "file"); err != nil {
+			if err := f.sender.SendValue("file_descriptors", float64(numFds), "file"); err != nil {
 				f.logger.Error("error-sending-file-descriptor-metric", zap.Error(err))
 			}
+
 		case <-signals:
 			f.logger.Info("exited")
 			return nil


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:
This is just a small fix to be able to run gorouter under MacOS for development purposes.
The PR changes the fd_monitor so that it distinguishes between Linux (which has `/proc`) and MacOS (which has not).

As a result, this annoying error message will be gone:
```
{"log_level":3,"timestamp":1645613724.0060532,"message":"error-reading-filedescriptor-path","source":"gorouter.stdout.FileDescriptor","data":{"error":"open /proc/<pid>/fd: no such file or directory"}}
(repeats every 5s)
```

Instead of outright removing the fd_monitor functionality, I've opted to make it work under MacOS by shelling out to `lsof` to count the open file descriptors. Since gorouter will be deployed to Linux in production scenarios, this may be overkill but I wanted to retain the original functionality and not just turn it off. However, I can also just put in a no-op to turn off the error message instead.

* An explanation of the use cases your change solves
It allows to develop gorouter under MacOS without breaking the fd_monitor

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
1.  `go build` on MacOS
2. `nats-server &`
3. `./gorouter`

* Expected result after the change
Gorouter starts up, connects to natsd and shows no error messages

* Current result before the change
Gorouter starts up, connects to natsd and keeps logging the above error message every 5s

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
