### PR TITLE
fix config property format bug

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -301,7 +301,7 @@ type Config struct {
 	// Old metric, to eventually be replaced by prometheus reporting
 	SendHttpStartStopClientEvent bool `yaml:"send_http_start_stop_client_event,omitempty"`
 
-	PerAppPrometheusHttpMetricsReporting bool `yaml:"per_app_prometheus_http_metrics_reporting",omitempty`
+	PerAppPrometheusHttpMetricsReporting bool `yaml:"per_app_prometheus_http_metrics_reporting,omitempty"`
 
 	HealthCheckPollInterval time.Duration `yaml:"healthcheck_poll_interval"`
 	HealthCheckTimeout      time.Duration `yaml:"healthcheck_timeout"`

--- a/handlers/zipkin.go
+++ b/handlers/zipkin.go
@@ -50,7 +50,7 @@ func (z *Zipkin) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 
 		r.Header.Set(b3.TraceID, trace.String())
 		r.Header.Set(b3.SpanID, span)
-		r.Header.Set(b3.Context,  trace.String()+"-"+span)
+		r.Header.Set(b3.Context, trace.String()+"-"+span)
 	} else {
 		sc, err := b3.ParseHeaders(
 			existingTraceID,


### PR DESCRIPTION
related to [this PR](https://github.com/cloudfoundry/gorouter/pull/307).

It was failing to run units with the following error:
```
+ go vet ./...
# code.cloudfoundry.org/gorouter/config
config/config.go:304:2: struct field tag `yaml:"per_app_prometheus_http_metrics_reporting",omitempty` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
```