### PR TITLE
Route service pruning fix

### DIFF
--- a/handlers/routeservice.go
+++ b/handlers/routeservice.go
@@ -142,11 +142,10 @@ func (r *RouteService) ServeHTTP(rw http.ResponseWriter, req *http.Request, next
 	next(rw, req)
 
 	// drop the first endpoint from the pool in the event of route service failure,
-	// because a stale route at index 0 with a bad route-service-url will result in
-	// all other requests failing at the route-service level. (the non-stale routes'
-	// route-services would never be hit)
-	// Using >= 400 here, rather than >= 500, since the route_service_url could
-	// contain auth information that is out of date
+	// to prevent a stale route at index 0 with a bad route-service-url from being
+	// able to prune, and causing all other requests to fail. Using >= 400 here,
+	// rather than >= 500, since the route_service_url could contain authi
+	// information that is out of date
 	if prw.Status() >= http.StatusBadRequest {
 		if reqInfo.RoutePool.NumEndpoints() > 1 && !reqInfo.RoutePool.RemoveByIndex(0) {
 			r.logger.Error("route-service-prune-failed", zap.String("error", "failed to prune endpoint with failing route-service-url"))

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -209,6 +209,16 @@ var _ = Describe("RouteRegistry", func() {
 				Expect(route.PoolsMatch(p1, p2)).To(BeTrue())
 				Expect(route.PoolsMatch(p1, p3)).To(BeFalse())
 			})
+
+			It("sets the route service URL on the pool", func() {
+				m1 := route.NewEndpoint(&route.EndpointOpts{RouteServiceUrl: "https://www.neopets.com"})
+
+				r.Register("dora.app.com/app", m1)
+
+				p1 := r.Lookup("dora.app.com/app")
+
+				Expect(p1.RouteSvcUrl).To(Equal("https://www.neopets.com"))
+			})
 		})
 
 		Context("wildcard routes", func() {

--- a/route/pool.go
+++ b/route/pool.go
@@ -354,17 +354,6 @@ func (p *EndpointPool) Remove(endpoint *Endpoint) bool {
 	return false
 }
 
-func (p *EndpointPool) RemoveByIndex(i int) bool {
-	p.Lock()
-	defer p.Unlock()
-	l := len(p.endpoints)
-	if i >= 0 && i < l {
-		p.removeEndpoint(p.endpoints[i])
-		return true
-	}
-	return false
-}
-
 func (p *EndpointPool) removeEndpoint(e *endpointElem) {
 	i := e.index
 	es := p.endpoints

--- a/route/pool.go
+++ b/route/pool.go
@@ -143,9 +143,9 @@ type EndpointPool struct {
 	endpoints []*endpointElem
 	index     map[string]*endpointElem
 
-	host            string
-	contextPath     string
-	routeServiceUrl string
+	host        string
+	contextPath string
+	RouteSvcUrl string
 
 	retryAfterFailure  time.Duration
 	nextIdx            int
@@ -285,7 +285,7 @@ func (p *EndpointPool) Put(endpoint *Endpoint) PoolPutResult {
 		p.index[endpoint.PrivateInstanceId] = e
 
 	}
-
+	p.RouteSvcUrl = e.endpoint.RouteServiceUrl
 	e.updated = time.Now()
 	// set the update time of the pool
 	p.Update()
@@ -296,13 +296,7 @@ func (p *EndpointPool) Put(endpoint *Endpoint) PoolPutResult {
 func (p *EndpointPool) RouteServiceUrl() string {
 	p.Lock()
 	defer p.Unlock()
-
-	if len(p.endpoints) > 0 {
-		endpt := p.endpoints[0]
-		return endpt.endpoint.RouteServiceUrl
-	} else {
-		return ""
-	}
+	return p.RouteSvcUrl
 }
 
 func (p *EndpointPool) PruneEndpoints() []*Endpoint {

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -2,7 +2,6 @@ package route_test
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -325,50 +324,6 @@ var _ = Describe("EndpointPool", func() {
 
 				Expect(pool.IsEmpty()).To(BeFalse())
 			})
-		})
-	})
-
-	Context("RemoveByIndex", func() {
-		It("removes the requested endpoint", func() {
-			for i := 1; i <= 3; i++ {
-				pool.Put(route.NewEndpoint(&route.EndpointOpts{Host: fmt.Sprintf("host%d", i)}))
-			}
-
-			b := pool.RemoveByIndex(1)
-			Expect(b).To(BeTrue())
-
-			expected := route.NewPool(&route.PoolOpts{
-				Logger:             logger,
-				RetryAfterFailure:  2 * time.Minute,
-				Host:               "",
-				ContextPath:        "",
-				MaxConnsPerBackend: 0,
-			})
-			expected.Put(route.NewEndpoint(&route.EndpointOpts{Host: "host1"}))
-			expected.Put(route.NewEndpoint(&route.EndpointOpts{Host: "host2"}))
-			Expect(route.PoolsMatch(pool, expected)).To(BeTrue())
-		})
-
-		It("removes down to zero endpoints", func() {
-			endpoint := &route.Endpoint{}
-			pool.Put(endpoint)
-
-			b := pool.RemoveByIndex(0)
-			Expect(b).To(BeTrue())
-			Expect(pool.IsEmpty()).To(BeTrue())
-		})
-
-		It("fails when no endpoints exist", func() {
-			b := pool.RemoveByIndex(0)
-			Expect(b).To(BeFalse())
-		})
-
-		It("fails to remove an endpoint that doesn't exist", func() {
-			endpoint := &route.Endpoint{}
-			pool.Put(endpoint)
-
-			b := pool.RemoveByIndex(15)
-			Expect(b).To(BeFalse())
 		})
 	})
 

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -251,6 +251,34 @@ var _ = Describe("EndpointPool", func() {
 				Expect(url).To(Equal(""))
 			})
 		})
+		Context("when any endpoint updates its route_service_url", func() {
+			It("returns the route_service_url most recently updated in the pool", func() {
+				endpointRS1 := route.NewEndpoint(&route.EndpointOpts{Host: "host-1", Port: 1234, RouteServiceUrl: "first-url"})
+				endpointRS2 := route.NewEndpoint(&route.EndpointOpts{Host: "host-2", Port: 2234, RouteServiceUrl: "second-url"})
+				b := pool.Put(endpointRS1)
+				Expect(b).To(Equal(route.ADDED))
+
+				url := pool.RouteServiceUrl()
+				Expect(url).To(Equal("first-url"))
+
+				b = pool.Put(endpointRS2)
+				Expect(b).To(Equal(route.ADDED))
+				url = pool.RouteServiceUrl()
+				Expect(url).To(Equal("second-url"))
+
+				endpointRS1.RouteServiceUrl = "third-url"
+				b = pool.Put(endpointRS1)
+				Expect(b).To(Equal(route.UPDATED))
+				url = pool.RouteServiceUrl()
+				Expect(url).To(Equal("third-url"))
+
+				endpointRS2.RouteServiceUrl = "fourth-url"
+				b = pool.Put(endpointRS2)
+				Expect(b).To(Equal(route.UPDATED))
+				url = pool.RouteServiceUrl()
+				Expect(url).To(Equal("fourth-url"))
+			})
+		})
 	})
 
 	Context("EndpointFailed", func() {


### PR DESCRIPTION
This provides a solution to issues where stale routes containing out of date/failing route-service
information are never detected, and ended up causing errors for all app
instances, when the stale route was at index 0 of an endpoint pool.

This was previously fixed with https://github.com/cloudfoundry/gorouter/pull/298, but
that caused issues with [loadbalancing fairness](https://github.com/cloudfoundry/routing-release/issues/262), and sticky sessions.

Instead of pruning the endpoint with the failing route-service, to force
it to be re-registered with an up-to-date route-service, gorouter now
treats the route-service as an endpoint-pool property, and updates the
route-service whenever a new registration occurs.