### PR TITLE
Update Gorouter `CACerts` property to list

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -214,7 +214,7 @@ type Config struct {
 	EnableHTTP2     bool              `yaml:"enable_http2"`
 	SSLCertificates []tls.Certificate `yaml:"-"`
 	TLSPEM          []TLSPem          `yaml:"tls_pem,omitempty"`
-	CACerts         string            `yaml:"ca_certs,omitempty"`
+	CACerts         []string          `yaml:"ca_certs,omitempty"`
 	CAPool          *x509.CertPool    `yaml:"-"`
 	ClientCACerts   string            `yaml:"client_ca_certs,omitempty"`
 	ClientCAPool    *x509.CertPool    `yaml:"-"`
@@ -644,9 +644,9 @@ func (c *Config) buildCertPool() error {
 		return err
 	}
 
-	if c.CACerts != "" {
-		if ok := certPool.AppendCertsFromPEM([]byte(c.CACerts)); !ok {
-			return fmt.Errorf("Error while adding CACerts to gorouter's cert pool: \n%s\n", c.CACerts)
+	for i, cert := range c.CACerts {
+		if ok := certPool.AppendCertsFromPEM([]byte(cert)); !ok {
+			return fmt.Errorf("Error while adding %d cert in CACerts to gorouter's cert pool", i)
 		}
 	}
 	c.CAPool = certPool

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1096,7 +1096,9 @@ route_services_secret_decrypt_only: 1PfbARmvIn6cgyKorA1rqR2d34rBOo+z3qJGz17pi8Y=
 
 			Context("when a valid CACerts is provided", func() {
 				BeforeEach(func() {
-					configSnippet.CACerts = string(rootRSAPEM) + string(rootECDSAPEM)
+					configSnippet.CACerts = []string{
+						string(rootRSAPEM), string(rootECDSAPEM),
+					}
 				})
 
 				It("populates the CACerts and CAPool property", func() {
@@ -1106,13 +1108,15 @@ route_services_secret_decrypt_only: 1PfbARmvIn6cgyKorA1rqR2d34rBOo+z3qJGz17pi8Y=
 
 					Expect(config.EnableSSL).To(Equal(true))
 					Expect(config.Process()).To(Succeed())
-					Expect(config.CACerts).To(Equal(strings.Join(expectedCAPEMs, "")))
+					Expect(config.CACerts).To(Equal(expectedCAPEMs))
 
-					certDER, _ := pem.Decode([]byte(config.CACerts))
-					Expect(err).NotTo(HaveOccurred())
-					c, err := x509.ParseCertificate(certDER.Bytes)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(config.CAPool.Subjects()).To(ContainElement(c.RawSubject))
+					for _, cert := range config.CACerts {
+						certDER, _ := pem.Decode([]byte(cert))
+						Expect(err).NotTo(HaveOccurred())
+						c, err := x509.ParseCertificate(certDER.Bytes)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(config.CAPool.Subjects()).To(ContainElement(c.RawSubject))
+					}
 				})
 			})
 
@@ -1364,7 +1368,7 @@ route_services_secret_decrypt_only: 1PfbARmvIn6cgyKorA1rqR2d34rBOo+z3qJGz17pi8Y=
 						string(clientRSAPEM),
 					}
 
-					configSnippet.CACerts = string(rootRSAPEM) + string(rootECDSAPEM)
+					configSnippet.CACerts = []string {string(rootRSAPEM), string(rootECDSAPEM)}
 				})
 
 				Context("When only_trust_client_ca_certs is true", func() {
@@ -1382,17 +1386,20 @@ route_services_secret_decrypt_only: 1PfbARmvIn6cgyKorA1rqR2d34rBOo+z3qJGz17pi8Y=
 						Expect(config.ClientCACerts).To(Equal(strings.Join(expectedClientCAPEMs, "")))
 						Expect(config.OnlyTrustClientCACerts).To(BeTrue())
 
-						caCertDER, _ := pem.Decode([]byte(config.CACerts))
-						Expect(err).NotTo(HaveOccurred())
-						c, err := x509.ParseCertificate(caCertDER.Bytes)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(config.ClientCAPool.Subjects()).NotTo(ContainElement(c.Subject.CommonName))
 
-						clientCACertDER, _ := pem.Decode([]byte(config.ClientCACerts))
-						Expect(err).NotTo(HaveOccurred())
-						c, err = x509.ParseCertificate(clientCACertDER.Bytes)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(config.ClientCAPool.Subjects()).To(ContainElement(c.RawSubject))
+						for _, caCert := range config.CACerts {
+							caCertDER, _ := pem.Decode([]byte(caCert))
+							Expect(err).NotTo(HaveOccurred())
+							c, err := x509.ParseCertificate(caCertDER.Bytes)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(config.ClientCAPool.Subjects()).NotTo(ContainElement(c.Subject.CommonName))
+
+							clientCACertDER, _ := pem.Decode([]byte(config.ClientCACerts))
+							Expect(err).NotTo(HaveOccurred())
+							c, err = x509.ParseCertificate(clientCACertDER.Bytes)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(config.ClientCAPool.Subjects()).To(ContainElement(c.RawSubject))
+						}
 
 						certPool, err := x509.SystemCertPool()
 						Expect(err).NotTo(HaveOccurred())
@@ -1421,7 +1428,7 @@ route_services_secret_decrypt_only: 1PfbARmvIn6cgyKorA1rqR2d34rBOo+z3qJGz17pi8Y=
 				Context("When only_trust_client_ca_certs is false", func() {
 					BeforeEach(func() {
 						configSnippet.OnlyTrustClientCACerts = false
-						configSnippet.ClientCACerts = configSnippet.CACerts + string(clientRSAPEM)
+						configSnippet.ClientCACerts = strings.Join(configSnippet.CACerts, "") + string(clientRSAPEM)
 					})
 
 					It("client_ca_pool contains CAs from client_ca_certs, ca_certs, and the system CAs", func() {
@@ -1439,11 +1446,13 @@ route_services_secret_decrypt_only: 1PfbARmvIn6cgyKorA1rqR2d34rBOo+z3qJGz17pi8Y=
 						Expect(err).NotTo(HaveOccurred())
 						Expect(config.ClientCAPool.Subjects()).To(ContainElement(c.RawSubject))
 
-						caCertDER, _ := pem.Decode([]byte(config.CACerts))
-						Expect(err).NotTo(HaveOccurred())
-						c, err = x509.ParseCertificate(caCertDER.Bytes)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(config.ClientCAPool.Subjects()).To(ContainElement(c.RawSubject))
+						for _, caCert := range config.CACerts {
+							caCertDER, _ := pem.Decode([]byte(caCert))
+							Expect(err).NotTo(HaveOccurred())
+							c, err = x509.ParseCertificate(caCertDER.Bytes)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(config.ClientCAPool.Subjects()).To(ContainElement(c.RawSubject))
+						}
 
 						certPool, err := x509.SystemCertPool()
 						Expect(err).NotTo(HaveOccurred())

--- a/integration/common_integration_test.go
+++ b/integration/common_integration_test.go
@@ -91,14 +91,14 @@ func NewTestState() *testState {
 	Expect(err).ToNot(HaveOccurred())
 
 	browserToGorouterClientCertChain := test_util.CreateSignedCertWithRootCA(test_util.CertNames{})
-	cfg.CACerts = cfg.CACerts + string(browserToGorouterClientCertChain.CACertPEM)
-	cfg.CACerts = cfg.CACerts + string(routeServiceCert)
+	cfg.CACerts = append(cfg.CACerts, string(browserToGorouterClientCertChain.CACertPEM))
+	cfg.CACerts = append(cfg.CACerts, string(routeServiceCert))
 	routeServiceToGorouterClientCertChain := test_util.CreateSignedCertWithRootCA(test_util.CertNames{})
-	cfg.CACerts = cfg.CACerts + string(routeServiceToGorouterClientCertChain.CACertPEM)
+	cfg.CACerts = append(cfg.CACerts, string(routeServiceToGorouterClientCertChain.CACertPEM))
 
 	trustedBackendServerCertSAN := "some-trusted-backend.example.net"
 	backendCertChain := test_util.CreateSignedCertWithRootCA(test_util.CertNames{CommonName: trustedBackendServerCertSAN, SANs: test_util.SubjectAltNames{DNS: trustedBackendServerCertSAN}})
-	cfg.CACerts = cfg.CACerts + string(backendCertChain.CACertPEM)
+	cfg.CACerts = append(cfg.CACerts, string(backendCertChain.CACertPEM))
 
 	gorouterToBackendsClientCertChain := test_util.CreateSignedCertWithRootCA(test_util.CertNames{CommonName: "gorouter", SANs: test_util.SubjectAltNames{DNS: "gorouter"}})
 	trustedBackendTLSConfig := backendCertChain.AsTLSConfig()
@@ -107,10 +107,10 @@ func NewTestState() *testState {
 	untrustedBackendServerCertSAN := "some-trusted-backend.example.net"
 	untrustedBackendCLientCertChain := test_util.CreateSignedCertWithRootCA(test_util.CertNames{CommonName: untrustedBackendServerCertSAN, SANs: test_util.SubjectAltNames{DNS: untrustedBackendServerCertSAN}})
 	untrustedBackendTLSConfig := untrustedBackendCLientCertChain.AsTLSConfig()
-	cfg.CACerts = cfg.CACerts + string(untrustedBackendCLientCertChain.CACertPEM)
+	cfg.CACerts = append(cfg.CACerts, string(untrustedBackendCLientCertChain.CACertPEM))
 
 	cfg.OnlyTrustClientCACerts = false
-	cfg.ClientCACerts = cfg.CACerts + string(backendCertChain.CACertPEM)
+	cfg.ClientCACerts = strings.Join(cfg.CACerts, "") + string(backendCertChain.CACertPEM)
 
 	// set Gorouter to use client certs
 	cfg.Backends.TLSPem = config.TLSPem{

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -851,7 +851,7 @@ var _ = Describe("Router Integration", func() {
 				}))
 
 				rsKey, rsCert := test_util.CreateKeyPair("test.routeservice.com")
-				cfg.CACerts = string(rsCert)
+				cfg.CACerts = []string{string(rsCert)}
 				rsTLSCert, err := tls.X509KeyPair(rsCert, rsKey)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1358,7 +1358,7 @@ var _ = Describe("Router", func() {
 		)
 		BeforeEach(func() {
 			certChain := test_util.CreateSignedCertWithRootCA(test_util.CertNames{SANs: test_util.SubjectAltNames{DNS: "test." + test_util.LocalhostDNS}})
-			config.CACerts = string(certChain.CACertPEM)
+			config.CACerts = []string{string(certChain.CACertPEM)}
 			config.SSLCertificates = append(config.SSLCertificates, certChain.TLSCert())
 
 			rootCAs = x509.NewCertPool()
@@ -1405,7 +1405,7 @@ var _ = Describe("Router", func() {
 		)
 		BeforeEach(func() {
 			certChain := test_util.CreateSignedCertWithRootCA(test_util.CertNames{SANs: test_util.SubjectAltNames{DNS: "test." + test_util.LocalhostDNS}})
-			config.CACerts = string(certChain.CACertPEM)
+			config.CACerts = []string{string(certChain.CACertPEM)}
 			config.SSLCertificates = append(config.SSLCertificates, certChain.TLSCert())
 			cert = certChain.CertPEM
 
@@ -1482,7 +1482,7 @@ var _ = Describe("Router", func() {
 
 		Context("when a ca cert is provided", func() {
 			BeforeEach(func() {
-				config.CACerts = string(cert)
+				config.CACerts = []string{string(cert)}
 			})
 			It("add the ca cert to the trusted pool and returns 200", func() {
 				certPool, err := x509.SystemCertPool()

--- a/test_util/helpers.go
+++ b/test_util/helpers.go
@@ -17,6 +17,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -166,7 +167,7 @@ func SpecSSLConfig(statusPort, proxyPort, SSLPort uint16, natsPorts ...uint16) (
 			PrivateKey: string(secondaryCertChain.PrivKeyPEM),
 		},
 	}
-	c.CACerts = string(rootCertChain.CACertPEM)
+	c.CACerts = []string{string(rootCertChain.CACertPEM)}
 	c.SSLPort = SSLPort
 	c.CipherString = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384"
 	c.ClientCertificateValidationString = "none"
@@ -204,13 +205,13 @@ func CustomSpecSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int,
 			PrivateKey: string(secondaryCertChain.PrivKeyPEM),
 		},
 	}
-	c.CACerts = string(rootCertChain.CACertPEM)
+	c.CACerts = []string{string(rootCertChain.CACertPEM)}
 	c.ClientCACerts = string(clientCaCertChain.CACertPEM)
 
 	if onlyTrustClientCACerts == false {
 		clientTrustedCertPool.AppendCertsFromPEM(rootCertChain.CACertPEM)
 		clientTrustedCertPool.AppendCertsFromPEM(secondaryCertChain.CACertPEM)
-		c.ClientCACerts += c.CACerts
+		c.ClientCACerts += strings.Join(c.CACerts, "")
 	}
 	c.SSLPort = SSLPort
 	c.CipherString = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384"


### PR DESCRIPTION
This allows modifying and expanding the CAs in a development using ops-files.

**This is a breaking change in configuration and will require a new major version of CF Deployment!**

<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

`CACerts` in the gorouter configuration is a string, containing concatenated PEM format CA certificates. In order to add new certificates, the default list of CA certificates provided in the `cf-deployment` should be _extended_ with additional certificates. Using `ops-files` in CF this is not possible.

By changing the `CACerts` field to an array, which may still contain PEM certificate chains, additional CA certificates can be added via ops-file without the risk of overwriting updated upstream CAs defined via `cf-deployment`.

* An explanation of the use cases your change solves

See above.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

The configuration allows defining CA Certificates as list of strings in the configuration.

The following ops-file to append an extra CA cert becomes possible:

```yaml
- type: replace
  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs?/-
  value:
     - ((YOUR-CUSTOM-CA-1.ca))
```

* Expected result after the change

New CA Certs can be added via ops-file

* Current result before the change

New CA Certs can only be added by copy&pasting the default CA certs from the `cf-deployment` and adding a new one, risking to lose / overwrite changes introduced in a new `cf-deployment` manifest.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).
      * Some tests unrelated to this change fail in the current `main` branch.

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
