### PR TITLE
Improve Websocket Error Logging

### DIFF
--- a/proxy/handler/request_handler.go
+++ b/proxy/handler/request_handler.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"strconv"
@@ -238,7 +239,14 @@ func (h *RequestHandler) serveTcp(
 
 	// Any status code has already been sent to the client,
 	// but this is the value that gets written to the access logs
-	backendStatusCode := h.forwarder.ForwardIO(client, backendConnection)
+	backendStatusCode, err := h.forwarder.ForwardIO(client, backendConnection)
+
+	// add X-Cf-RouterError header to improve traceability in access log
+	if err != nil {
+		errMsg:= fmt.Sprintf("endpoint_failure (%s)", err.Error())
+		handlers.AddRouterErrorHeader(h.response, errMsg)
+	}
+
 	return backendStatusCode, nil
 }
 


### PR DESCRIPTION
* A short explanation of the proposed change:
  * `x_cf_routererror` is now provided in access logs for failing websocket forwards


 * An explanation of the use cases your change solves
Easier analysis of websocket connection issues

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
  1. cause a websocket timeout, i.e. by deploying a websocket app that takes longer than 5s to upgrade
  2. observe logging

* Expected result after the change

`access_log`:
 ```
js-ws.cf.local - [2022-05-13T13:06:57.725415361Z] "GET /slow HTTP/1.1" 502 0 0 "-" "-" "172.19.0.4:44124" "172.19.0.6:8080" x_forwarded_for:"172.19.0.1, 172.19.0.4" x_forwarded_proto:"https" vcap_request_id:"3688e056-611f-49c8-7d16-3b1b2b2fbc0d" response_time:12.585910 gorouter_time:12.585910 app_id:"-" app_index:"-" instance_id:"52d7d6f4-d32b-4091-5bd6-7cc5ba9142ac" x_cf_routererror:"endpoint_failure (timeout waiting for http response from backend)"
```

* Current result before the change

`access_log`:
 ```
js-ws.cf.local - [2022-05-13T13:10:48.064063585Z] "GET /slow HTTP/1.1" 502 0 0 "-" "-" "172.19.0.4:44842" "172.19.0.5:8080" x_forwarded_for:"172.19.0.1, 172.19.0.4" x_forwarded_proto:"https" vcap_request_id:"311a08de-cb3b-417c-7048-5f00f77c8d72" response_time:10.064082 gorouter_time:10.064082 app_id:"-" app_index:"-" instance_id:"acfab35f-73de-4f8f-4afd-66fd774b9be8" x_cf_routererror:"-"
```

https://github.com/cloudfoundry/gorouter/pull/319 - (was originally part of this PR)
https://github.com/cloudfoundry/gorouter/pull/294 - similar `x_cf_routererror` behaviour for a different `endpoint_failure`

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch
  * Some tests unrelated to this change fail in the current `main` branch.

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
