### PR TITLE
Add X-Vcap-Request-Id to stderr logging output

### DIFF
--- a/proxy/handler/request_handler.go
+++ b/proxy/handler/request_handler.go
@@ -83,6 +83,7 @@ func setupLogger(disableXFFLogging, disableSourceIPLogging bool, request *http.R
 		zap.String("Path", request.URL.Path),
 		zap.Object("X-Forwarded-For", request.Header["X-Forwarded-For"]),
 		zap.Object("X-Forwarded-Proto", request.Header["X-Forwarded-Proto"]),
+		zap.Object("X-Vcap-Request-Id", request.Header["X-Vcap-Request-Id"]),
 	}
 	// Specific indexes below is to preserve the schema in the log line
 	if disableSourceIPLogging {


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:
  * `X-Vcap-Request-Id` is now included in `stderr` output to make correlation with access log entries easier

* An explanation of the use cases your change solves
Easier analysis of websocket connection issues

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

`stderr`:
```
{"log_level":3,"timestamp":1652447228.7253733,"message":"websocket-forwardio","source":"gorouter.stdout.request-handler","data":{"RemoteAddr":"172.19.0.4:44124","Host":"js-ws.cf.local","Path":"/slow","X-Forwarded-For":["172.19.0.1"],"X-Forwarded-Proto":["https"],"X-Vcap-Request-Id":["3688e056-611f-49c8-7d16-3b1b2b2fbc0d"],"error":"timeout waiting for http response from backend"}}
```


* Current result before the change

`stderr`:
```
{"log_level":3,"timestamp":1652447458.127469,"message":"websocket-forwardio","source":"gorouter.stdout.request-handler","data":{"RemoteAddr":"172.19.0.4:44842","Host":"js-ws.cf.local","Path":"/slow","X-Forwarded-For":["172.19.0.1"],"X-Forwarded-Proto":["https"],"error":"timeout waiting for http response from backend"}}
```

* Links to any other associated PRs
https://github.com/cloudfoundry/gorouter/pull/317 - (original PR)

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
