### PR TITLE
Don't return empty pool if fallback exists

### DIFF
--- a/registry/container/trie.go
+++ b/registry/container/trie.go
@@ -44,7 +44,7 @@ func (r *Trie) Find(uri route.Uri) *route.EndpointPool {
 	return nil
 }
 
-// MatchUri returns the longest route that matches the URI parameter, nil if nothing matches.
+// MatchUri returns the longest route that matches the URI parameter and has endpoints, nil if nothing matches.
 func (r *Trie) MatchUri(uri route.Uri) *route.EndpointPool {
 	key := strings.TrimPrefix(uri.String(), "/")
 	node := r
@@ -61,7 +61,8 @@ func (r *Trie) MatchUri(uri route.Uri) *route.EndpointPool {
 
 		node = matchingChild
 
-		if nil != node.Pool {
+		// Matching pools with endpoints is what we want
+		if nil != node.Pool && !node.Pool.IsEmpty() {
 			lastPool = node.Pool
 		}
 
@@ -72,15 +73,12 @@ func (r *Trie) MatchUri(uri route.Uri) *route.EndpointPool {
 		key = pathParts[1]
 	}
 
-	if nil != node.Pool {
+	// Prefer lastPool over node.Pool since we know it must have endpoints
+	if nil != node.Pool && nil == lastPool {
 		return node.Pool
 	}
 
-	if nil != lastPool {
-		return lastPool
-	}
-
-	return nil
+	return lastPool
 }
 
 func (r *Trie) Insert(uri route.Uri, value *route.EndpointPool) *Trie {

--- a/registry/container/trie_test.go
+++ b/registry/container/trie_test.go
@@ -95,6 +95,8 @@ var _ = Describe("Trie", func() {
 		})
 
 		It("returns the longest found match when routes overlap", func() {
+			p1.Put(route.NewEndpoint(&route.EndpointOpts{}))
+			p2.Put(route.NewEndpoint(&route.EndpointOpts{}))
 			r.Insert("/foo", p1)
 			r.Insert("/foo/bar/baz", p2)
 			node := r.MatchUri("/foo/bar")
@@ -102,10 +104,53 @@ var _ = Describe("Trie", func() {
 		})
 
 		It("returns the longest found match when routes overlap and longer path created first", func() {
+			p1.Put(route.NewEndpoint(&route.EndpointOpts{}))
+			p2.Put(route.NewEndpoint(&route.EndpointOpts{}))
 			r.Insert("/foo/bar/baz", p2)
 			r.Insert("/foo", p1)
 			node := r.MatchUri("/foo/bar")
 			Expect(node).To(Equal(p1))
+		})
+
+		It("returns a.b.com if it is not empty", func() {
+			p1.Put(route.NewEndpoint(&route.EndpointOpts{}))
+			r.Insert("a.b.com", p1)
+			node := r.MatchUri("a.b.com")
+			Expect(node).To(Equal(p1))
+			node = r.MatchUri("a.b.com/foo")
+			Expect(node).To(Equal(p1))
+		})
+
+		It("returns a.b.com even if is empty", func() {
+			r.Insert("a.b.com", p1)
+			node := r.MatchUri("a.b.com")
+			Expect(node).To(Equal(p1))
+			node = r.MatchUri("a.b.com/foo")
+			Expect(node).To(Equal(p1))
+		})
+
+		It("returns a.b.com if a.b.com/foo is empty", func() {
+			p1.Put(route.NewEndpoint(&route.EndpointOpts{}))
+			r.Insert("a.b.com", p1)
+			r.Insert("a.b.com/foo", p2)
+			node := r.MatchUri("a.b.com/foo")
+			Expect(node).To(Equal(p1))
+		})
+
+		It("returns a.b.com/foo if both a.b.com and a.b.com/foo are not empty", func() {
+			p1.Put(route.NewEndpoint(&route.EndpointOpts{}))
+			p2.Put(route.NewEndpoint(&route.EndpointOpts{}))
+			r.Insert("a.b.com", p1)
+			r.Insert("a.b.com/foo", p2)
+			node := r.MatchUri("a.b.com/foo")
+			Expect(node).To(Equal(p2))
+		})
+
+		It("returns a.b.com/foo if both a.b.com and a.b.com/foo are empty", func() {
+			r.Insert("a.b.com", p1)
+			r.Insert("a.b.com/foo", p2)
+			node := r.MatchUri("a.b.com/foo")
+			Expect(node).To(Equal(p2))
 		})
 	})
 


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

This PR fixes https://github.com/cloudfoundry/routing-release/issues/279

A regression was introduced with https://github.com/cloudfoundry/gorouter/pull/314 that returns 503 on routes with a path. If the path gets unmapped, gorouter returns 503 instead of falling back to the non-path route.

* An explanation of the use cases your change solves

Mapping a more specific path `/foo` on an app is a valid use case for route services that may be used to rate limit that path only (instead of the whole app).

However, you still want to be able to use the less specific path `/` if you unmap the `/foo` route. Instead, gorouter gives you a 503 if `empty_pool_response_code_503 ` and  `empty_pool_timeout ` are enabled.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
1. `cf push` any app. Make sure it responds 200 OK on `/foo`
2. `cf map-route my-app.cf-app.com --hostname my-app --path foo`
3. `cf unmap-route my-app.cf-app.com --hostname my-app --path foo`
4. `curl https://my-app.cf-app.com/foo`

* Expected result after the change
```
200 OK (coming from my-app.cf-app.com)
```
* Current result before the change
```
503 Service Unavailable: Requested route ('my-app.cf-app.com') has no available endpoints.
```

* Links to any other associated PRs
https://github.com/cloudfoundry/gorouter/pull/314

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
