### PR TITLE
fix: provide meaningful error message for rs error

### DIFF
--- a/handlers/routeservice_test.go
+++ b/handlers/routeservice_test.go
@@ -494,10 +494,10 @@ var _ = Describe("Route Service Handler", func() {
 					req.Header.Set(routeservice.HeaderKeySignature, reqArgs.Signature)
 				})
 
-				It("returns a 400 bad request response", func() {
+				It("returns a 502 bad gateway response", func() {
 					handler.ServeHTTP(resp, req)
 
-					Expect(resp.Code).To(Equal(http.StatusBadRequest))
+					Expect(resp.Code).To(Equal(http.StatusBadGateway))
 					Expect(resp.Body.String()).To(ContainSubstring("Failed to validate Route Service Signature"))
 					Expect(logger.ErrorCallCount()).To(Equal(2))
 					errMsg, _ := logger.ErrorArgsForCall(1)
@@ -520,10 +520,10 @@ var _ = Describe("Route Service Handler", func() {
 					req.Header.Set(routeservice.HeaderKeyMetadata, metadataHeader)
 				})
 
-				It("returns a 400 bad request response", func() {
+				It("returns a 504 gateway timeout response", func() {
 					handler.ServeHTTP(resp, req)
 
-					Expect(resp.Code).To(Equal(http.StatusBadRequest))
+					Expect(resp.Code).To(Equal(http.StatusGatewayTimeout))
 					Expect(resp.Body.String()).To(ContainSubstring("Failed to validate Route Service Signature"))
 					Expect(logger.ErrorCallCount()).To(Equal(2))
 					errMsg, _ := logger.ErrorArgsForCall(1)
@@ -550,10 +550,10 @@ var _ = Describe("Route Service Handler", func() {
 					routeMap["my_host.com/original_path"] = rsPool
 				})
 
-				It("returns a 400 bad request response", func() {
+				It("returns a 502 bad gateway response", func() {
 					handler.ServeHTTP(resp, req)
 
-					Expect(resp.Code).To(Equal(http.StatusBadRequest))
+					Expect(resp.Code).To(Equal(http.StatusBadGateway))
 					Expect(resp.Body.String()).To(ContainSubstring("Failed to validate Route Service Signature"))
 					Expect(logger.ErrorCallCount()).To(Equal(1))
 					errMsg, _ := logger.ErrorArgsForCall(0)
@@ -579,10 +579,10 @@ var _ = Describe("Route Service Handler", func() {
 					req.Header.Set(routeservice.HeaderKeyMetadata, metadataHeader)
 				})
 
-				It("returns a 400 bad request response", func() {
+				It("returns a 502 bad gateway response", func() {
 					handler.ServeHTTP(resp, req)
 
-					Expect(resp.Code).To(Equal(http.StatusBadRequest))
+					Expect(resp.Code).To(Equal(http.StatusBadGateway))
 					Expect(resp.Body.String()).To(ContainSubstring("Failed to validate Route Service Signature"))
 					Expect(logger.ErrorCallCount()).To(Equal(2))
 					errMsg, _ := logger.ErrorArgsForCall(1)
@@ -645,10 +645,10 @@ var _ = Describe("Route Service Handler", func() {
 						req.Header.Set(routeservice.HeaderKeyMetadata, metadataHeader)
 					})
 
-					It("returns a 400 bad request response", func() {
+					It("returns a 504 gateway timeout response", func() {
 						handler.ServeHTTP(resp, req)
 
-						Expect(resp.Code).To(Equal(http.StatusBadRequest))
+						Expect(resp.Code).To(Equal(http.StatusGatewayTimeout))
 						Expect(resp.Body.String()).To(ContainSubstring("Failed to validate Route Service Signature"))
 						Expect(logger.ErrorCallCount()).To(Equal(2))
 
@@ -678,7 +678,7 @@ var _ = Describe("Route Service Handler", func() {
 					It("returns a 400 bad request response", func() {
 						handler.ServeHTTP(resp, req)
 
-						Expect(resp.Code).To(Equal(http.StatusBadRequest))
+						Expect(resp.Code).To(Equal(http.StatusBadGateway))
 						Expect(resp.Body.String()).To(ContainSubstring("Failed to validate Route Service Signature"))
 
 						Expect(nextCalled).To(BeFalse())


### PR DESCRIPTION
* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `main` branch
* [X] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).
* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite
* [ ] (Optional) I have run CF Acceptance Tests on bosh lite


If a route-service violates the route-service timeout, the previous
error message was `400 Bad Request: Failed to validate Route Service
Signature for x-forwarded-client-cert` which is not indicative of the
underlying failure. This change does two things:
1. If the route-service validation failed because of a route-service
   timeout, respond with the proper error message and 504 GW timeout
2. If the route-service validation failed because of something else,
   respond with a 502 Bad GW since the error is most likely not on
   user side, but in the intermediate server.
I know that the status codes do not match 100%, but IMHO they are more
appropriate then the previous 400 Bad Request, and the route-service is,
in some sense, a upstream server to the gorouter, just not to the one
giving the error message.

Resolves: cloudfoundry/routing-release#272
