### PR TITLE
Introduce separate setting for web socket upgrade dial timeout

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -246,6 +246,7 @@ type Config struct {
 	StartResponseDelayInterval      time.Duration `yaml:"start_response_delay_interval,omitempty"`
 	EndpointTimeout                 time.Duration `yaml:"endpoint_timeout,omitempty"`
 	EndpointDialTimeout             time.Duration `yaml:"endpoint_dial_timeout,omitempty"`
+	WebsocketDialTimeout            time.Duration `yaml:"websocket_dial_timeout,omitempty"`
 	EndpointKeepAliveProbeInterval  time.Duration `yaml:"endpoint_keep_alive_probe_interval,omitempty"`
 	RouteServiceTimeout             time.Duration `yaml:"route_services_timeout,omitempty"`
 	FrontendIdleTimeout             time.Duration `yaml:"frontend_idle_timeout,omitempty"`
@@ -390,6 +391,10 @@ func (c *Config) Process() error {
 
 	if c.DrainTimeout == 0 {
 		c.DrainTimeout = c.EndpointTimeout
+	}
+
+	if c.WebsocketDialTimeout == 0 {
+		c.WebsocketDialTimeout = c.EndpointDialTimeout
 	}
 
 	var localIPErr error

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -128,6 +128,32 @@ endpoint_dial_timeout: 6s
 			Expect(config.EndpointDialTimeout).To(Equal(6 * time.Second))
 		})
 
+		It("sets websocket dial timeout", func() {
+			var b = []byte(`
+websocket_dial_timeout: 6s
+`)
+
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(config.WebsocketDialTimeout).To(Equal(6 * time.Second))
+		})
+
+		It("defaults websocket dial timeout to endpoint dial timeout if not set", func() {
+			var b = []byte(`
+endpoint_dial_timeout: 6s
+`)
+
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = config.Process()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(config.EndpointDialTimeout).To(Equal(6 * time.Second))
+			Expect(config.WebsocketDialTimeout).To(Equal(6 * time.Second))
+		})
+
 		It("defaults keep alive probe interval to 1 second", func() {
 			Expect(config.FrontendIdleTimeout).To(Equal(900 * time.Second))
 			Expect(config.EndpointKeepAliveProbeInterval).To(Equal(1 * time.Second))
@@ -1619,6 +1645,7 @@ enable_http2: false
 				var b = []byte(`
 endpoint_timeout: 10s
 endpoint_dial_timeout: 6s
+websocket_dial_timeout: 8s
 route_services_timeout: 10s
 drain_timeout: 15s
 tls_handshake_timeout: 9s
@@ -1631,6 +1658,7 @@ tls_handshake_timeout: 9s
 
 				Expect(config.EndpointTimeout).To(Equal(10 * time.Second))
 				Expect(config.EndpointDialTimeout).To(Equal(6 * time.Second))
+				Expect(config.WebsocketDialTimeout).To(Equal(8 * time.Second))
 				Expect(config.RouteServiceTimeout).To(Equal(10 * time.Second))
 				Expect(config.DrainTimeout).To(Equal(15 * time.Second))
 				Expect(config.TLSHandshakeTimeout).To(Equal(9 * time.Second))

--- a/proxy/handler/request_handler.go
+++ b/proxy/handler/request_handler.go
@@ -35,7 +35,8 @@ type RequestHandler struct {
 	request  *http.Request
 	response utils.ProxyResponseWriter
 
-	endpointDialTimeout time.Duration
+	endpointDialTimeout  time.Duration
+	websocketDialTimeout time.Duration
 
 	tlsConfigTemplate *tls.Config
 
@@ -51,16 +52,18 @@ func NewRequestHandler(
 	logger logger.Logger,
 	errorWriter errorwriter.ErrorWriter,
 	endpointDialTimeout time.Duration,
+	websocketDialTimeout time.Duration,
 	tlsConfig *tls.Config,
 	opts ...func(*RequestHandler),
 ) *RequestHandler {
 	reqHandler := &RequestHandler{
-		errorWriter:         errorWriter,
-		reporter:            r,
-		request:             request,
-		response:            response,
-		endpointDialTimeout: endpointDialTimeout,
-		tlsConfigTemplate:   tlsConfig,
+		errorWriter:          errorWriter,
+		reporter:             r,
+		request:              request,
+		response:             response,
+		endpointDialTimeout:  endpointDialTimeout,
+		websocketDialTimeout: websocketDialTimeout,
+		tlsConfigTemplate:    tlsConfig,
 	}
 
 	for _, option := range opts {
@@ -69,7 +72,7 @@ func NewRequestHandler(
 
 	requestLogger := setupLogger(reqHandler.disableXFFLogging, reqHandler.disableSourceIPLogging, request, logger)
 	reqHandler.forwarder = &Forwarder{
-		BackendReadTimeout: endpointDialTimeout, // TODO: different values?
+		BackendReadTimeout: websocketDialTimeout,
 		Logger:             requestLogger,
 	}
 	reqHandler.logger = requestLogger

--- a/proxy/handler/request_handler_test.go
+++ b/proxy/handler/request_handler_test.go
@@ -48,7 +48,7 @@ var _ = Describe("RequestHandler", func() {
 			rh = handler.NewRequestHandler(
 				req, pr,
 				&metric.FakeProxyReporter{}, logger, ew,
-				time.Second*2, &tls.Config{},
+				time.Second*2, time.Second*2, &tls.Config{},
 				handler.DisableXFFLogging(true),
 			)
 		})
@@ -96,7 +96,7 @@ var _ = Describe("RequestHandler", func() {
 			rh = handler.NewRequestHandler(
 				req, pr,
 				&metric.FakeProxyReporter{}, logger, ew,
-				time.Second*2, &tls.Config{},
+				time.Second*2, time.Second*2, &tls.Config{},
 				handler.DisableSourceIPLogging(true),
 			)
 		})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -54,6 +54,7 @@ type proxy struct {
 	sanitizeForwardedProto   bool
 	defaultLoadBalance       string
 	endpointDialTimeout      time.Duration
+	websocketDialTimeout     time.Duration
 	endpointTimeout          time.Duration
 	bufferPool               httputil.BufferPool
 	backendTLSConfig         *tls.Config
@@ -94,6 +95,7 @@ func NewProxy(
 		sanitizeForwardedProto:   cfg.SanitizeForwardedProto,
 		defaultLoadBalance:       cfg.LoadBalance,
 		endpointDialTimeout:      cfg.EndpointDialTimeout,
+		websocketDialTimeout:     cfg.WebsocketDialTimeout,
 		endpointTimeout:          cfg.EndpointTimeout,
 		bufferPool:               NewBufferPool(),
 		backendTLSConfig:         backendTLSConfig,
@@ -246,6 +248,7 @@ func (p *proxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.Requ
 		p.logger,
 		p.errorWriter,
 		p.endpointDialTimeout,
+		p.websocketDialTimeout,
 		p.backendTLSConfig,
 		handler.DisableXFFLogging(p.disableXFFLogging),
 		handler.DisableSourceIPLogging(p.disableSourceIPLogging),


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

Websocket forwarding is essentially a new connection negotiation. So far the `endpoint_dial_timeout` value was used for websocket upgrades as well.

* An explanation of the use cases your change solves

We have a case where the web socket upgrade takes longer than the default endpoint dial timeout because there is some processing happening before the websocket connection is accepted. Increasing the `endpoint_dial_timeout` can have negative repercussions for the regular use case, e.g. on backend failure retries.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

Set the `websocket_dial_timeout` value to a specific value > 5s (default) and run with an endpoint that does a slow websocket upgrade, which responds in more than 5s (or the value for `endpoint_dial_timeout`) but faster than `websocket_dial_timeout`

* Expected result after the change

The web socket request completes correctly.

* Current result before the change

The web socket request fails with a dial timeout, because the websocket dial timeout was not configurable separately.

* Links to any other associated PRs

https://github.com/cloudfoundry/routing-release/pull/284

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
