### PR TITLE
Fix default config initialization for websocket dial timeout value

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -805,9 +805,11 @@ var _ = Describe("Router Integration", func() {
 				req, err := http.NewRequest("GET", fmt.Sprintf("http://%s:%d", localIP, proxyPort), nil)
 				Expect(err).ToNot(HaveOccurred())
 				req.Host = "demo." + test_util.LocalhostDNS
-				res, err := client.Do(req)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(res.StatusCode).To(Equal(TEST_STATUS_CODE))
+				Eventually(func() int {
+					res, err := client.Do(req)
+					Expect(err).ToNot(HaveOccurred())
+					return res.StatusCode
+				}, 5*time.Second).Should(Equal(TEST_STATUS_CODE))
 			})
 
 			Context("when the client connects with HTTPS", func() {
@@ -819,9 +821,11 @@ var _ = Describe("Router Integration", func() {
 					req, err := http.NewRequest("GET", fmt.Sprintf("https://%s:%d", localIP, sslPort), nil)
 					Expect(err).ToNot(HaveOccurred())
 					req.Host = "demo." + test_util.LocalhostDNS
-					res, err := client.Do(req)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(res.StatusCode).To(Equal(TEST_STATUS_CODE))
+					Eventually(func() int {
+						res, err := client.Do(req)
+						Expect(err).ToNot(HaveOccurred())
+						return res.StatusCode
+					}, 5*time.Second).Should(Equal(TEST_STATUS_CODE))
 				})
 
 				Context("when the gorouter has http disabled", func() {
@@ -837,9 +841,11 @@ var _ = Describe("Router Integration", func() {
 						req, err := http.NewRequest("GET", fmt.Sprintf("https://%s:%d", localIP, sslPort), nil)
 						Expect(err).ToNot(HaveOccurred())
 						req.Host = "demo." + test_util.LocalhostDNS
-						res, err := client.Do(req)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(res.StatusCode).To(Equal(TEST_STATUS_CODE))
+						Eventually(func() int {
+							res, err := client.Do(req)
+							Expect(err).ToNot(HaveOccurred())
+							return res.StatusCode
+						}, 5*time.Second).Should(Equal(TEST_STATUS_CODE))
 					})
 				})
 			})

--- a/proxy/proxy_suite_test.go
+++ b/proxy/proxy_suite_test.go
@@ -79,6 +79,7 @@ var _ = BeforeEach(func() {
 	conf.TLSHandshakeTimeout = 900 * time.Millisecond
 	conf.EndpointTimeout = 1 * time.Second
 	conf.EndpointDialTimeout = 50 * time.Millisecond
+	conf.WebsocketDialTimeout = 50 * time.Millisecond
 	conf.EnableHTTP2 = false
 	fakeReporter = &fakes.FakeCombinedReporter{}
 	fakeRegistry = fake_registry.NewMetricsRegistry()

--- a/test_util/helpers.go
+++ b/test_util/helpers.go
@@ -255,6 +255,7 @@ func generateConfig(statusPort, proxyPort uint16, natsPorts ...uint16) *config.C
 	c.Zone = "z1"
 
 	c.EndpointTimeout = 500 * time.Millisecond
+	c.WebsocketDialTimeout = c.EndpointDialTimeout
 
 	c.Status = config.StatusConfig{
 		Port: statusPort,


### PR DESCRIPTION
The value is either defined explicitly in the configuration, or derived from the `endpoint_dial_timeout`.
Because the config read from file is applied on top of the values in `Config.defaultConfig`, the
`WebsocketDialTimeout` must not be defined there yet, as it would disable the automatic derivation of the value from a configured `endpoint_dial_timeout` and would change behavor.

The gorouter tests use the `defaultConfig` without `Process()`, so the value was never derived and `WebsocketDialTimeout` remained at `0`, failing some tests.

Where needed, the value is now set explicitly in the test harness, but for regular operation it is derived if not set, as described above.

Also fixes long-standing flaky tests `Router Integration route services when the route service is hosted on the platform (internal, has a route as an app)`, which seems to have been a timing issue.

* Links to any other associated PRs

Fix for #325, which broke some tests due to missing config value propagation for a new property. `websocket_dial_timeout` falls back to the configured value of `endpoint_dial_timeout` when `websocket_dial_timeout` is not configured. The logic for setting the value when it was not configured was not called in tests.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
