### PR TITLE
Adjust endpoint-not-unregistered log-level to 'info'

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -159,7 +159,7 @@ func (r *RouteRegistry) unregister(uri route.Uri, endpoint *route.Endpoint) {
 		if endpointRemoved {
 			r.logger.Info("endpoint-unregistered", zapData(uri, endpoint)...)
 		} else {
-			r.logger.Debug("endpoint-not-unregistered", zapData(uri, endpoint)...)
+			r.logger.Info("endpoint-not-unregistered", zapData(uri, endpoint)...)
 		}
 
 		if pool.IsEmpty() {


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change: Log on info-level if endpoint-unregisters are failing

* An explanation of the use cases your change solves: have more insights on which endpoints could not be unregistered/trigger a discussion why this was made `debug`

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
