### PR TITLE
Enable Access Logging for requests exceeding max_header_bytes, when that value is changed from the default

### DIFF
--- a/handlers/max_request_size.go
+++ b/handlers/max_request_size.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	router_http "code.cloudfoundry.org/gorouter/common/http"
+	"code.cloudfoundry.org/gorouter/logger"
+	"github.com/uber-go/zap"
+)
+
+type MaxRequestSize struct {
+	MaxSize int
+	logger  logger.Logger
+}
+
+const ONE_MB = 1024 * 1024 // bytes * kb
+
+// NewAccessLog creates a new handler that handles logging requests to the
+// access log
+func NewMaxRequestSize(maxSize int, logger logger.Logger) *MaxRequestSize {
+	if maxSize < 1 {
+		maxSize = ONE_MB
+	}
+
+	if maxSize > ONE_MB {
+		logger.Warn("innefectual-max-header-bytes-value", zap.String("error", fmt.Sprintf("Values over %d are limited by http.Server", maxSize)))
+		maxSize = ONE_MB
+	}
+
+	return &MaxRequestSize{
+		MaxSize: maxSize,
+		logger:  logger,
+	}
+}
+
+func (m *MaxRequestSize) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	reqSize := len(r.Method) + len(r.URL.RequestURI()) + len(r.Proto) + 5 // add 5 bytes for space-separation of method, URI, protocol, and /r/n
+
+	for k, v := range r.Header {
+		reqSize += len(k) + len(v) + 4 // add two bytes for ": " delimiting, and 2 more for \r\n
+	}
+	reqSize += len(r.Host) + 4 // add two bytes for ": " delimiting, and 2 more for \r\n
+
+	if reqSize >= m.MaxSize {
+		rw.Header().Set(router_http.CfRouterError, "max-request-size-exceeded")
+		rw.WriteHeader(http.StatusRequestHeaderFieldsTooLarge)
+		r.Close = true
+		return
+	}
+	next(rw, r)
+}

--- a/handlers/max_request_size_test.go
+++ b/handlers/max_request_size_test.go
@@ -1,0 +1,201 @@
+package handlers_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+
+	"code.cloudfoundry.org/gorouter/handlers"
+	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
+	"code.cloudfoundry.org/gorouter/route"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/urfave/negroni"
+)
+
+var _ = Describe("MaxRequestSize", func() {
+	var (
+		handler *negroni.Negroni
+
+		resp         http.ResponseWriter
+		req          *http.Request
+		rawPath      string
+		header       http.Header
+		result       *http.Response
+		responseBody []byte
+		requestBody  *bytes.Buffer
+
+		maxSize    int
+		fakeLogger *logger_fakes.FakeLogger
+
+		nextCalled bool
+		reqChan    chan *http.Request
+	)
+	testEndpoint := route.NewEndpoint(&route.EndpointOpts{
+		Host: "host",
+		Port: 1234,
+	})
+
+	nextHandler := negroni.HandlerFunc(func(rw http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+		_, err := ioutil.ReadAll(req.Body)
+		Expect(err).NotTo(HaveOccurred())
+
+		rw.WriteHeader(http.StatusTeapot)
+		rw.Write([]byte("I'm a little teapot, short and stout."))
+
+		reqInfo, err := handlers.ContextRequestInfo(req)
+		if err == nil {
+			reqInfo.RouteEndpoint = testEndpoint
+		}
+
+		if next != nil {
+			next(rw, req)
+		}
+
+		reqChan <- req
+		nextCalled = true
+	})
+
+	handleRequest := func() {
+		var err error
+		handler.ServeHTTP(resp, req)
+
+		result = resp.(*httptest.ResponseRecorder).Result()
+		responseBody, err = ioutil.ReadAll(result.Body)
+		Expect(err).NotTo(HaveOccurred())
+		result.Body.Close()
+	}
+
+	BeforeEach(func() {
+		requestBody = bytes.NewBufferString("What are you?")
+		rawPath = "/"
+		header = http.Header{}
+		resp = httptest.NewRecorder()
+
+		maxSize = 40
+		fakeLogger = new(logger_fakes.FakeLogger)
+	})
+
+	JustBeforeEach(func() {
+		handler = negroni.New()
+		handler.Use(handlers.NewMaxRequestSize(maxSize, fakeLogger))
+		handler.Use(nextHandler)
+
+		reqChan = make(chan *http.Request, 1)
+
+		nextCalled = false
+
+		var err error
+		req, err = http.NewRequest("GET", "http://example.com"+rawPath, requestBody)
+		req.Header = header
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		close(reqChan)
+	})
+
+	Context("when request size is under the limit", func() {
+		It("lets the message pass", func() {
+			handleRequest()
+			Expect(result.StatusCode).To(Equal(http.StatusTeapot))
+			Expect(result.Status).To(Equal("418 I'm a teapot"))
+			Expect(string(responseBody)).To(Equal("I'm a little teapot, short and stout."))
+
+		})
+		It("calls the next handler", func() {
+			handleRequest()
+			Expect(nextCalled).To(BeTrue())
+		})
+	})
+	Context("when request URI is over the limit", func() {
+		BeforeEach(func() {
+			rawPath = "/thisIsAReallyLongRequestURIThatWillExceedThirtyTwoBytes"
+		})
+		It("throws an http 431", func() {
+			handleRequest()
+			Expect(result.StatusCode).To(Equal(http.StatusRequestHeaderFieldsTooLarge))
+		})
+	})
+	Context("when query params are over the limit", func() {
+		BeforeEach(func() {
+			rawPath = "/?queryParams=reallyLongValuesThatWillExceedThirtyTwoBytes"
+		})
+		It("throws an http 431", func() {
+			handleRequest()
+			Expect(result.StatusCode).To(Equal(http.StatusRequestHeaderFieldsTooLarge))
+		})
+	})
+	Context("when a single header key is over the limit", func() {
+		BeforeEach(func() {
+			header.Add("thisHeaderKeyIsOverThirtyTwoBytesAndWillFail", "doesntmatter")
+		})
+		It("throws an http 431", func() {
+			handleRequest()
+			Expect(result.StatusCode).To(Equal(http.StatusRequestHeaderFieldsTooLarge))
+		})
+	})
+	Context("when a single header value is over the limit", func() {
+		BeforeEach(func() {
+			header.Add("doesntmatter", "thisHeaderValueIsOverThirtyTwoBytesAndWillFail")
+		})
+		It("throws an http 431", func() {
+			handleRequest()
+			Expect(result.StatusCode).To(Equal(http.StatusRequestHeaderFieldsTooLarge))
+		})
+	})
+	Context("when enough normally-sized headers put the request over the limit", func() {
+		BeforeEach(func() {
+			header.Add("header1", "smallRequest")
+			header.Add("header2", "smallRequest")
+			header.Add("header3", "smallRequest")
+		})
+		It("throws an http 431", func() {
+			handleRequest()
+			Expect(result.StatusCode).To(Equal(http.StatusRequestHeaderFieldsTooLarge))
+		})
+	})
+	Context("when any combination of things makes the request over the limit", func() {
+		BeforeEach(func() {
+			rawPath = "/?q=v"
+			header.Add("header1", "smallRequest")
+			header.Add("header2", "smallRequest")
+		})
+		It("throws an http 431", func() {
+			handleRequest()
+			Expect(result.StatusCode).To(Equal(http.StatusRequestHeaderFieldsTooLarge))
+		})
+		It("doesn't call the next handler", func() {
+			handleRequest()
+			Expect(nextCalled).To(BeFalse())
+		})
+	})
+
+	Describe("NewMaxRequestSize()", func() {
+		It("returns a new requestSizeHandler using the provided size", func() {
+			rh := handlers.NewMaxRequestSize(1234, fakeLogger)
+			Expect(rh.MaxSize).To(Equal(1234))
+		})
+
+		It("defaults to 1mb if the provided size is negative", func() {
+			rh := handlers.NewMaxRequestSize(-1, fakeLogger)
+			Expect(rh.MaxSize).To(Equal(1024 * 1024))
+		})
+
+		It("defaults to 1mb if the provided size is 0", func() {
+			rh := handlers.NewMaxRequestSize(0, fakeLogger)
+			Expect(rh.MaxSize).To(Equal(1024 * 1024))
+		})
+
+		It("defaults  to 1mb if the provided size is greater than 1mb and logs a warning", func() {
+			rh := handlers.NewMaxRequestSize(2*1024*1024, fakeLogger)
+			Expect(rh.MaxSize).To(Equal(1024 * 1024))
+		})
+		It("logs a warning if the provided size is greater than 1mb and logs a warning", func() {
+			handlers.NewMaxRequestSize(2*1024*1024, fakeLogger)
+			Expect(fakeLogger.WarnCallCount()).To(Equal(1))
+		})
+	})
+})

--- a/integration/common_integration_test.go
+++ b/integration/common_integration_test.go
@@ -297,11 +297,27 @@ func (s *testState) StopAndCleanup() {
 		s.natsRunner.Stop()
 	}
 
+	if s.AccessLogFilePath() != "" {
+		err := os.Remove(s.AccessLogFilePath())
+		Expect(err).NotTo(HaveOccurred())
+	}
+
 	os.RemoveAll(s.tmpdir)
 
 	if s.gorouterSession != nil && s.gorouterSession.ExitCode() == -1 {
 		Eventually(s.gorouterSession.Terminate(), 5).Should(Exit(0))
 	}
+}
+
+func (s *testState) EnableAccessLog() {
+	file, err := os.CreateTemp("", "RTR-ACCESS-LOG")
+	Expect(err).NotTo(HaveOccurred())
+
+	s.cfg.AccessLog = config.AccessLog{File: file.Name()}
+}
+
+func (s *testState) AccessLogFilePath() string {
+	return s.cfg.AccessLog.File
 }
 
 func assertRequestSucceeds(client *http.Client, req *http.Request) {

--- a/integration/common_integration_test.go
+++ b/integration/common_integration_test.go
@@ -137,6 +137,8 @@ func NewTestState() *testState {
 	}
 	cfg.OAuth.TokenEndpoint, cfg.OAuth.Port = hostnameAndPort(oauthServer.Addr())
 
+	cfg.MaxHeaderBytes = 1024 //1kb
+
 	return &testState{
 		cfg: cfg,
 		client: &http.Client{

--- a/integration/large_request_test.go
+++ b/integration/large_request_test.go
@@ -1,0 +1,60 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"code.cloudfoundry.org/gorouter/route"
+	"code.cloudfoundry.org/gorouter/test/common"
+	"code.cloudfoundry.org/gorouter/test_util"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Large requests", func() {
+	var (
+		testState *testState
+		appURL    string
+		echoApp   *common.TestApp
+	)
+
+	BeforeEach(func() {
+		testState = NewTestState()
+		testState.EnableAccessLog()
+		testState.StartGorouterOrFail()
+
+		appURL = "echo-app." + test_util.LocalhostDNS
+
+		echoApp = newEchoApp([]route.Uri{route.Uri(appURL)}, testState.cfg.Port, testState.mbusClient, time.Millisecond, "")
+		echoApp.TlsRegister(testState.trustedBackendServerCertSAN)
+		echoApp.TlsListen(testState.trustedBackendTLSConfig)
+	})
+
+	AfterEach(func() {
+		if testState != nil {
+			testState.StopAndCleanup()
+		}
+	})
+
+	It("logs requests that exceed the MaxHeaderBytes configuration (but are lower than 1MB)", func() {
+		pathSize := 2 * 1024 // 2kb
+		path := strings.Repeat("a", pathSize)
+
+		req := testState.newRequest(fmt.Sprintf("http://%s/%s", appURL, path))
+
+		resp, err := testState.client.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(resp.StatusCode).To(Equal(431))
+
+		getAccessLogContents := func() string {
+			accessLogContents, err := os.ReadFile(testState.AccessLogFilePath())
+			Expect(err).NotTo(HaveOccurred())
+			return string(accessLogContents)
+		}
+
+		Eventually(getAccessLogContents).Should(MatchRegexp("echo-app.*/aaaaaaaa.*431.*x_cf_routererror:\"max-request-size-exceeded\""))
+	})
+})

--- a/integration/web_socket_test.go
+++ b/integration/web_socket_test.go
@@ -2,11 +2,8 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
-	"os"
-	"path/filepath"
 	"time"
 
 	"code.cloudfoundry.org/gorouter/route"
@@ -20,23 +17,16 @@ import (
 var _ = Describe("Websockets", func() {
 	var (
 		testState *testState
-		accessLog string
 	)
 
 	BeforeEach(func() {
-		var err error
-		accessLog, err = ioutil.TempDir("", "accesslog")
-		Expect(err).NotTo(HaveOccurred())
-
 		testState = NewTestState()
-		testState.cfg.AccessLog.File = filepath.Join(accessLog, "access.log")
 		testState.StartGorouterOrFail()
 	})
 
 	AfterEach(func() {
 		if testState != nil {
 			testState.StopAndCleanup()
-			os.RemoveAll(accessLog)
 		}
 	})
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -179,6 +179,7 @@ func NewProxy(
 		}
 	}
 	n.Use(handlers.NewAccessLog(accessLogger, headersToLog, logger))
+	n.Use(handlers.NewMaxRequestSize(cfg.MaxHeaderBytes, logger))
 	n.Use(handlers.NewQueryParam(logger))
 	n.Use(handlers.NewReporter(reporter, logger))
 	n.Use(handlers.NewHTTPRewriteHandler(cfg.HTTPRewrite, headersToAlwaysRemove))

--- a/router/router.go
+++ b/router/router.go
@@ -138,6 +138,9 @@ func NewRouter(
 	return router, nil
 }
 
+// golang's default was 1mb. We want to make this explicit, so that we're able to create access logs via our own handler to process MAX_HEADER_BYTES
+const MAX_HEADER_BYTES = 1024 * 1024
+
 func (r *Router) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
 	r.registry.StartPruningCycle()
 
@@ -153,7 +156,7 @@ func (r *Router) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
 		Handler:        r.handler,
 		ConnState:      r.HandleConnState,
 		IdleTimeout:    r.config.FrontendIdleTimeout,
-		MaxHeaderBytes: r.config.MaxHeaderBytes,
+		MaxHeaderBytes: MAX_HEADER_BYTES,
 	}
 
 	err := r.serveHTTP(server, r.errChan)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -808,7 +808,6 @@ var _ = Describe("Router", func() {
 		var client http.Client
 
 		BeforeEach(func() {
-			config.MaxHeaderBytes = 1
 			client = http.Client{}
 		})
 
@@ -827,7 +826,7 @@ var _ = Describe("Router", func() {
 		})
 
 		It("the request fails if the headers are over the limit", func() {
-			longRequestPath := strings.Repeat("ninebytes", 500) // golang adds 4096 bytes of padding to MaxHeaderBytes, so we need something at least that big + 1 bytes
+			longRequestPath := strings.Repeat("ninebytes", 117_000) // golang adds 4096 bytes of padding to MaxHeaderBytes, so we need something at least that big + 1mb
 			uri := fmt.Sprintf("http://maxheadersize.%s:%d/%s", test_util.LocalhostDNS, config.Port, longRequestPath)
 			req, _ := http.NewRequest("GET", uri, nil)
 			resp, err := client.Do(req)
@@ -841,7 +840,8 @@ var _ = Describe("Router", func() {
 		})
 
 		It("the request succeeds if the headers are under the limit", func() {
-			uri := fmt.Sprintf("http://maxheadersize.%s:%d/smallheader", test_util.LocalhostDNS, config.Port)
+			longRequestPath := strings.Repeat("ninebytes", 116_000) // golang adds 4096 bytes of padding to MaxHeaderBytes, so we need something at least that big + 1mb
+			uri := fmt.Sprintf("http://maxheadersize.%s:%d/%s", test_util.LocalhostDNS, config.Port, longRequestPath)
 			req, _ := http.NewRequest("GET", uri, nil)
 			resp, err := client.Do(req)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
