### PR TITLE
Emit access logs for 431 responses to Loggegator

### DIFF
--- a/accesslog/dropsonde_logsender.go
+++ b/accesslog/dropsonde_logsender.go
@@ -1,6 +1,7 @@
 package accesslog
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -22,6 +23,12 @@ type DropsondeLogSender struct {
 
 func (l *DropsondeLogSender) SendAppLog(appID, message string, tags map[string]string) {
 	if l.sourceInstance == "" || appID == "" {
+		l.logger.Debug("dropping-loggregator-access-log",
+			zap.Error(fmt.Errorf("either no appId or source instance present")),
+			zap.String("appID", appID),
+			zap.String("sourceInstance", l.sourceInstance),
+		)
+
 		return
 	}
 

--- a/handlers/max_request_size_test.go
+++ b/handlers/max_request_size_test.go
@@ -2,10 +2,12 @@ package handlers_test
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 
+	"code.cloudfoundry.org/gorouter/config"
 	"code.cloudfoundry.org/gorouter/handlers"
 	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
 	"code.cloudfoundry.org/gorouter/route"
@@ -27,16 +29,12 @@ var _ = Describe("MaxRequestSize", func() {
 		responseBody []byte
 		requestBody  *bytes.Buffer
 
-		maxSize    int
+		cfg        *config.Config
 		fakeLogger *logger_fakes.FakeLogger
+		rh         *handlers.MaxRequestSize
 
 		nextCalled bool
-		reqChan    chan *http.Request
 	)
-	testEndpoint := route.NewEndpoint(&route.EndpointOpts{
-		Host: "host",
-		Port: 1234,
-	})
 
 	nextHandler := negroni.HandlerFunc(func(rw http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
 		_, err := ioutil.ReadAll(req.Body)
@@ -45,16 +43,10 @@ var _ = Describe("MaxRequestSize", func() {
 		rw.WriteHeader(http.StatusTeapot)
 		rw.Write([]byte("I'm a little teapot, short and stout."))
 
-		reqInfo, err := handlers.ContextRequestInfo(req)
-		if err == nil {
-			reqInfo.RouteEndpoint = testEndpoint
-		}
-
 		if next != nil {
 			next(rw, req)
 		}
 
-		reqChan <- req
 		nextCalled = true
 	})
 
@@ -69,32 +61,41 @@ var _ = Describe("MaxRequestSize", func() {
 	}
 
 	BeforeEach(func() {
+		cfg = &config.Config{
+			MaxHeaderBytes:           40,
+			LoadBalance:              config.LOAD_BALANCE_RR,
+			StickySessionCookieNames: config.StringSet{"blarg": struct{}{}},
+		}
 		requestBody = bytes.NewBufferString("What are you?")
 		rawPath = "/"
 		header = http.Header{}
 		resp = httptest.NewRecorder()
-
-		maxSize = 40
-		fakeLogger = new(logger_fakes.FakeLogger)
 	})
 
 	JustBeforeEach(func() {
+		fakeLogger = new(logger_fakes.FakeLogger)
 		handler = negroni.New()
-		handler.Use(handlers.NewMaxRequestSize(maxSize, fakeLogger))
+		rh = handlers.NewMaxRequestSize(cfg, fakeLogger)
+		handler.Use(rh)
 		handler.Use(nextHandler)
-
-		reqChan = make(chan *http.Request, 1)
 
 		nextCalled = false
 
 		var err error
 		req, err = http.NewRequest("GET", "http://example.com"+rawPath, requestBody)
-		req.Header = header
 		Expect(err).NotTo(HaveOccurred())
-	})
 
-	AfterEach(func() {
-		close(reqChan)
+		req.Header = header
+		reqInfo := &handlers.RequestInfo{
+			RoutePool: route.NewPool(&route.PoolOpts{}),
+		}
+		reqInfo.RoutePool.Put(route.NewEndpoint(&route.EndpointOpts{
+			AppId:             "fake-app",
+			Host:              "fake-host",
+			Port:              1234,
+			PrivateInstanceId: "fake-instance",
+		}))
+		req = req.WithContext(context.WithValue(req.Context(), handlers.RequestInfoCtxKey, reqInfo))
 	})
 
 	Context("when request size is under the limit", func() {
@@ -108,6 +109,13 @@ var _ = Describe("MaxRequestSize", func() {
 		It("calls the next handler", func() {
 			handleRequest()
 			Expect(nextCalled).To(BeTrue())
+		})
+		It("doesn't set the reqInfo's RouteEndpoint", func() {
+			handleRequest()
+			reqInfo, err := handlers.ContextRequestInfo(req)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(reqInfo.RouteEndpoint).To(BeNil())
 		})
 	})
 	Context("when request URI is over the limit", func() {
@@ -171,31 +179,54 @@ var _ = Describe("MaxRequestSize", func() {
 			handleRequest()
 			Expect(nextCalled).To(BeFalse())
 		})
+		It("sets the reqInfo's RouteEndpoint, so access logs work", func() {
+			handleRequest()
+
+			reqInfo, err := handlers.ContextRequestInfo(req)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(reqInfo.RouteEndpoint).ToNot(BeNil())
+			Expect(reqInfo.RouteEndpoint.ApplicationId).To(Equal("fake-app"))
+		})
 	})
 
 	Describe("NewMaxRequestSize()", func() {
-		It("returns a new requestSizeHandler using the provided size", func() {
-			rh := handlers.NewMaxRequestSize(1234, fakeLogger)
-			Expect(rh.MaxSize).To(Equal(1234))
+		Context("when using a custom MaxHeaderBytes", func() {
+			BeforeEach(func() {
+				cfg.MaxHeaderBytes = 1234
+			})
+			It("returns a new requestSizeHandler using the provided size", func() {
+				Expect(rh.MaxSize).To(Equal(1234))
+			})
 		})
 
-		It("defaults to 1mb if the provided size is negative", func() {
-			rh := handlers.NewMaxRequestSize(-1, fakeLogger)
-			Expect(rh.MaxSize).To(Equal(1024 * 1024))
+		Context("when using a negative MaxHeaderBytes", func() {
+			BeforeEach(func() {
+				cfg.MaxHeaderBytes = -1
+			})
+			It("defaults to 1mb", func() {
+				Expect(rh.MaxSize).To(Equal(1024 * 1024))
+			})
+		})
+		Context("when using a zero-value MaxHeaderBytes", func() {
+			BeforeEach(func() {
+				cfg.MaxHeaderBytes = 0
+			})
+			It("defaults to 1mb", func() {
+				Expect(rh.MaxSize).To(Equal(1024 * 1024))
+			})
 		})
 
-		It("defaults to 1mb if the provided size is 0", func() {
-			rh := handlers.NewMaxRequestSize(0, fakeLogger)
-			Expect(rh.MaxSize).To(Equal(1024 * 1024))
-		})
-
-		It("defaults  to 1mb if the provided size is greater than 1mb and logs a warning", func() {
-			rh := handlers.NewMaxRequestSize(2*1024*1024, fakeLogger)
-			Expect(rh.MaxSize).To(Equal(1024 * 1024))
-		})
-		It("logs a warning if the provided size is greater than 1mb and logs a warning", func() {
-			handlers.NewMaxRequestSize(2*1024*1024, fakeLogger)
-			Expect(fakeLogger.WarnCallCount()).To(Equal(1))
+		Context("when using a >1mb MaxHeaderBytes", func() {
+			BeforeEach(func() {
+				cfg.MaxHeaderBytes = handlers.ONE_MB * 2
+			})
+			It("defaults  to 1mb if the provided size", func() {
+				Expect(rh.MaxSize).To(Equal(1024 * 1024))
+			})
+			It("logs a warning", func() {
+				Expect(fakeLogger.WarnCallCount()).To(Equal(1))
+			})
 		})
 	})
 })

--- a/handlers/requestinfo.go
+++ b/handlers/requestinfo.go
@@ -15,7 +15,7 @@ import (
 
 type key string
 
-const requestInfoCtxKey key = "RequestInfo"
+const RequestInfoCtxKey key = "RequestInfo"
 
 // RequestInfo stores all metadata about the request and is used to pass
 // informaton between handlers
@@ -47,7 +47,7 @@ func NewRequestInfo() negroni.Handler {
 
 func (r *RequestInfoHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
 	reqInfo := new(RequestInfo)
-	req = req.WithContext(context.WithValue(req.Context(), requestInfoCtxKey, reqInfo))
+	req = req.WithContext(context.WithValue(req.Context(), RequestInfoCtxKey, reqInfo))
 	reqInfo.StartedAt = time.Now()
 	next(w, req)
 }
@@ -65,7 +65,7 @@ func GetEndpoint(ctx context.Context) (*route.Endpoint, error) {
 }
 
 func getRequestInfo(ctx context.Context) (*RequestInfo, error) {
-	ri := ctx.Value(requestInfoCtxKey)
+	ri := ctx.Value(RequestInfoCtxKey)
 	if ri == nil {
 		return nil, errors.New("RequestInfo not set on context")
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -179,7 +179,6 @@ func NewProxy(
 		}
 	}
 	n.Use(handlers.NewAccessLog(accessLogger, headersToLog, logger))
-	n.Use(handlers.NewMaxRequestSize(cfg.MaxHeaderBytes, logger))
 	n.Use(handlers.NewQueryParam(logger))
 	n.Use(handlers.NewReporter(reporter, logger))
 	n.Use(handlers.NewHTTPRewriteHandler(cfg.HTTPRewrite, headersToAlwaysRemove))
@@ -188,6 +187,7 @@ func NewProxy(
 	n.Use(w3cHandler)
 	n.Use(handlers.NewProtocolCheck(logger, errorWriter, cfg.EnableHTTP2))
 	n.Use(handlers.NewLookup(registry, reporter, logger, errorWriter, cfg.EmptyPoolResponseCode503))
+	n.Use(handlers.NewMaxRequestSize(cfg.MaxHeaderBytes, logger, p.defaultLoadBalance, getStickySession, p.stickySessionCookieNames))
 	n.Use(handlers.NewClientCert(
 		SkipSanitize(routeServiceHandler.(*handlers.RouteService)),
 		ForceDeleteXFCCHeader(routeServiceHandler.(*handlers.RouteService), cfg.ForwardedClientCert),

--- a/proxy/session_affinity_test.go
+++ b/proxy/session_affinity_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"code.cloudfoundry.org/gorouter/proxy"
+	"code.cloudfoundry.org/gorouter/handlers"
 	"code.cloudfoundry.org/gorouter/test_util"
 
 	. "github.com/onsi/ginkgo"
@@ -64,7 +64,7 @@ var _ = Describe("Session Affinity", func() {
 				Eventually(done).Should(Receive())
 
 				resp, _ := conn.ReadResponse()
-				cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+				cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
 				Expect(cookie).ToNot(BeNil())
 				Expect(cookie.Path).To(Equal("/path1"))
 				Expect(cookie.Value).To(Equal("instance-id-1"))
@@ -75,7 +75,7 @@ var _ = Describe("Session Affinity", func() {
 				Eventually(done).Should(Receive())
 
 				resp, _ = conn.ReadResponse()
-				cookie = getCookie(proxy.VcapCookieId, resp.Cookies())
+				cookie = getCookie(handlers.VcapCookieId, resp.Cookies())
 				Expect(cookie).ToNot(BeNil())
 				Expect(cookie.Path).To(Equal("/path1"))
 				Expect(cookie.Value).To(Equal("instance-id-1"))
@@ -96,7 +96,7 @@ var _ = Describe("Session Affinity", func() {
 				Eventually(done).Should(Receive())
 
 				resp, _ := conn.ReadResponse()
-				cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+				cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
 				Expect(cookie).ToNot(BeNil())
 				Expect(cookie.Path).To(Equal("/path1"))
 				Expect(cookie.Value).To(Equal("instance-id-1"))
@@ -107,7 +107,7 @@ var _ = Describe("Session Affinity", func() {
 				Eventually(done).Should(Receive())
 
 				resp, _ = conn.ReadResponse()
-				cookie = getCookie(proxy.VcapCookieId, resp.Cookies())
+				cookie = getCookie(handlers.VcapCookieId, resp.Cookies())
 				Expect(cookie).ToNot(BeNil())
 				Expect(cookie.Path).To(Equal("/path2/context/path"))
 				Expect(cookie.Value).To(Equal("instance-id-2"))
@@ -128,7 +128,7 @@ var _ = Describe("Session Affinity", func() {
 				Eventually(done).Should(Receive())
 
 				resp, _ := conn.ReadResponse()
-				cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+				cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
 				Expect(cookie).ToNot(BeNil())
 				Expect(cookie.Path).To(Equal("/path1"))
 				Expect(cookie.Value).To(Equal("instance-id-1"))
@@ -139,7 +139,7 @@ var _ = Describe("Session Affinity", func() {
 				Eventually(done).Should(Receive())
 
 				resp, _ = conn.ReadResponse()
-				cookie = getCookie(proxy.VcapCookieId, resp.Cookies())
+				cookie = getCookie(handlers.VcapCookieId, resp.Cookies())
 				Expect(cookie).ToNot(BeNil())
 				Expect(cookie.Path).To(Equal("/"))
 				Expect(cookie.Value).To(Equal("instance-id-2"))
@@ -161,7 +161,7 @@ var _ = Describe("Session Affinity", func() {
 				Eventually(done).Should(Receive())
 
 				resp, _ := x.ReadResponse()
-				Expect(getCookie(proxy.VcapCookieId, resp.Cookies())).To(BeNil())
+				Expect(getCookie(handlers.VcapCookieId, resp.Cookies())).To(BeNil())
 			})
 		})
 
@@ -181,7 +181,7 @@ var _ = Describe("Session Affinity", func() {
 				jsessionId := getCookie(StickyCookieKey, resp.Cookies())
 				Expect(jsessionId).ToNot(BeNil())
 
-				cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+				cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
 				Expect(cookie).ToNot(BeNil())
 				Expect(cookie.Value).To(Equal("my-id"))
 				Expect(cookie.Secure).To(BeFalse())
@@ -211,7 +211,7 @@ var _ = Describe("Session Affinity", func() {
 					jsessionId := getCookie(StickyCookieKey, resp.Cookies())
 					Expect(jsessionId).ToNot(BeNil())
 
-					cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+					cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
 					Expect(cookie).ToNot(BeNil())
 					Expect(cookie.Expires).To(Equal(expiry))
 				})
@@ -237,7 +237,7 @@ var _ = Describe("Session Affinity", func() {
 					jsessionId := getCookie(StickyCookieKey, resp.Cookies())
 					Expect(jsessionId).ToNot(BeNil())
 
-					cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+					cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
 					Expect(cookie).ToNot(BeNil())
 					Expect(cookie.Value).To(Equal("my-id"))
 					Expect(cookie.Secure).To(BeTrue())
@@ -264,7 +264,7 @@ var _ = Describe("Session Affinity", func() {
 					jsessionId := getCookie(StickyCookieKey, resp.Cookies())
 					Expect(jsessionId).ToNot(BeNil())
 
-					cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+					cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
 					Expect(cookie).ToNot(BeNil())
 					Expect(cookie.Value).To(Equal("my-id"))
 					Expect(cookie.Secure).To(BeTrue())
@@ -293,7 +293,7 @@ var _ = Describe("Session Affinity", func() {
 					jsessionId := getCookie(StickyCookieKey, resp.Cookies())
 					Expect(jsessionId).ToNot(BeNil())
 
-					cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+					cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
 					Expect(cookie).ToNot(BeNil())
 					Expect(cookie.Value).To(Equal("my-id"))
 					Expect(cookie.SameSite).To(Equal(http.SameSiteStrictMode))
@@ -309,7 +309,7 @@ var _ = Describe("Session Affinity", func() {
 
 		BeforeEach(func() {
 			cookie := &http.Cookie{
-				Name:  proxy.VcapCookieId,
+				Name:  handlers.VcapCookieId,
 				Value: "my-id",
 				Path:  "/",
 
@@ -340,7 +340,7 @@ var _ = Describe("Session Affinity", func() {
 
 				resp, _ := x.ReadResponse()
 				Expect(getCookie(StickyCookieKey, resp.Cookies())).To(BeNil())
-				Expect(getCookie(proxy.VcapCookieId, resp.Cookies())).To(BeNil())
+				Expect(getCookie(handlers.VcapCookieId, resp.Cookies())).To(BeNil())
 			})
 
 			Context("when the preferred server is gone", func() {
@@ -355,7 +355,7 @@ var _ = Describe("Session Affinity", func() {
 					Eventually(done).Should(Receive())
 
 					resp, _ := x.ReadResponse()
-					cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+					cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
 					Expect(cookie).ToNot(BeNil())
 					Expect(cookie.Value).To(Equal("other-id"))
 					Expect(cookie.Secure).To(BeFalse())
@@ -380,7 +380,7 @@ var _ = Describe("Session Affinity", func() {
 				jsessionId := getCookie(StickyCookieKey, resp.Cookies())
 				Expect(jsessionId).ToNot(BeNil())
 
-				cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+				cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
 				Expect(cookie).ToNot(BeNil())
 				Expect(cookie.Value).To(Equal("some-id"))
 				Expect(cookie.Secure).To(BeFalse())
@@ -408,7 +408,7 @@ var _ = Describe("Session Affinity", func() {
 					Expect(jsessionId).ToNot(BeNil())
 					Expect(jsessionId.MaxAge).To(Equal(-1))
 
-					cookie := getCookie(proxy.VcapCookieId, resp.Cookies())
+					cookie := getCookie(handlers.VcapCookieId, resp.Cookies())
 					Expect(cookie).ToNot(BeNil())
 					Expect(cookie.Value).To(Equal("my-id"))
 					Expect(cookie.Secure).To(BeFalse())

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -311,7 +311,7 @@ var _ = Describe("Router", func() {
 
 		var vcapCookie *http.Cookie
 		for _, cookie := range resp.Cookies() {
-			if cookie.Name == proxy.VcapCookieId {
+			if cookie.Name == handlers.VcapCookieId {
 				vcapCookie = cookie
 			}
 		}
@@ -341,7 +341,7 @@ var _ = Describe("Router", func() {
 
 		var vcapCookie *http.Cookie
 		for _, cookie := range resp.Cookies() {
-			if cookie.Name == proxy.VcapCookieId {
+			if cookie.Name == handlers.VcapCookieId {
 				vcapCookie = cookie
 			}
 		}


### PR DESCRIPTION
**Background**
Even though access logs for 431 responses were correctly being logged to `access.log`, these logs were not being emitted to Loggregator. The code for emitting these logs [requires an AppID or a SourceInstanceID](https://github.com/cloudfoundry/gorouter/blob/379860daa83a162ffe0b6039eafb7c8bfa1eaccf/accesslog/dropsonde_logsender.go#L24-L26). However, because the handler that enforces request header size returns a 431 before an app/backend is even selected, these fields were both missing, and the log was not being emitted.

**The Change**
This change adds logic to the MaxRequestSize handler so that it chooses a backend in order to populate the AppID field and successfully emits the access log to Loggregator. This backend is only chosen in cases where it will cut the request short and return a 431.

*Other smaller/incidental changes*
- Logs a message to gorouter log files when a Loggregator log message is not sent due to AppID or SourceInstanceID being empty
- Adding a new helper function `EndpointIteratorForRequest` for reuse in multiple files/packages
- Moving some code from the `proxy` package to the `handlers` package so that the new helper function can leverage the code without a circular import
- Some reorganization of tests in `max_request_size_test.go`
- Additional functionality for the `fakeMetron` in integration tests for easier testing

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
