### PR TITLE
Fix memory leak when connections are prematurely closed on the client…

### DIFF
--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -221,6 +221,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 	if err != nil && originalRequest.Context().Err() == context.Canceled && err != context.Canceled {
 		rt.logger.Error("gateway-error-and-original-request-context-cancelled", zap.Error(err))
 		err = originalRequest.Context().Err()
+		originalRequest.Body.Close()
 	}
 
 	finalErr := err


### PR DESCRIPTION
…-side.

If a client closes a connection while gorouter is waiting on a response from the app, we are leaking request objects. When the request objects are up to 1mb each, it becomes easy to grow gorouter's memory footprint, requiring a restart.

This ensures that in the event of the 499 cases, we close the original request body, allowing the full request to be garbage collected.

<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
