### PR TITLE
feat(round-tripper): retry requests more often

### DIFF
--- a/integration/retry_test.go
+++ b/integration/retry_test.go
@@ -1,0 +1,84 @@
+package integration
+
+import (
+	"bytes"
+	"code.cloudfoundry.org/gorouter/route"
+	"code.cloudfoundry.org/gorouter/test/common"
+	"code.cloudfoundry.org/gorouter/test_util"
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net/http"
+)
+
+var _ = Describe("Retries", func() {
+	var (
+		testState *testState
+	)
+
+	BeforeEach(func() {
+		testState = NewTestState()
+		testState.cfg.Backends.MaxAttempts = 15
+		testState.StartGorouterOrFail()
+	})
+
+	AfterEach(func() {
+		if testState != nil {
+			testState.StopAndCleanup()
+		}
+	})
+
+	Context("when gorouter talks to a broken app behind envoy", func() {
+		var appURL string
+		var badApp *common.TcpApp
+
+		BeforeEach(func() {
+			appURL = "bad-app." + test_util.LocalhostDNS
+
+			badApp = common.NewTcpApp([]route.Uri{route.Uri(appURL)}, testState.cfg.Port, testState.mbusClient, nil, "")
+			badApp.Register()
+		})
+
+		AfterEach(func() {
+			badApp.Stop()
+		})
+
+		It("retries POST requests when no data was written", func() {
+			payload := "this could be a meaningful body"
+
+			var handlers []func(conn *test_util.HttpConn)
+
+			closeOnAccept := func(conn *test_util.HttpConn) {
+				conn.Close()
+			}
+
+			respondOK := func(conn *test_util.HttpConn) {
+				_, err := http.ReadRequest(conn.Reader)
+				Expect(err).NotTo(HaveOccurred())
+
+				resp := test_util.NewResponse(http.StatusOK)
+				conn.WriteResponse(resp)
+				conn.Close()
+			}
+
+			for i := 0; i < 14; i++ {
+				handlers = append(handlers, closeOnAccept)
+			}
+
+			handlers = append(handlers, respondOK)
+			badApp.SetHandlers(handlers)
+			badApp.Listen()
+
+			req := testState.newPostRequest(
+				fmt.Sprintf("http://%s", appURL),
+				bytes.NewReader([]byte(payload)),
+			)
+			resp, err := testState.client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(200))
+			if resp.Body != nil {
+				resp.Body.Close()
+			}
+		})
+	})
+})

--- a/proxy/fails/basic_classifiers_test.go
+++ b/proxy/fails/basic_classifiers_test.go
@@ -234,7 +234,8 @@ var _ = Describe("ErrorClassifiers - enemy tests", func() {
 	Describe("ExpiredOrNotYetValidCertFailure", func() {
 		Context("when the cert is expired or not yet valid", func() {
 			var (
-				expiredClientCert *x509.Certificate
+				expiredClientCert   *x509.Certificate
+				expiredClientCACert *x509.CertPool
 			)
 
 			BeforeEach(func() {
@@ -243,10 +244,12 @@ var _ = Describe("ErrorClassifiers - enemy tests", func() {
 				var err error
 				expiredClientCert, err = x509.ParseCertificate(block.Bytes)
 				Expect(err).NotTo(HaveOccurred())
+				expiredClientCACert = x509.NewCertPool()
+				expiredClientCACert.AddCert(expiredClientCertPool.CACert)
 			})
 
 			It("matches", func() {
-				_, err := expiredClientCert.Verify(x509.VerifyOptions{})
+				_, err := expiredClientCert.Verify(x509.VerifyOptions{Roots: expiredClientCACert})
 				Expect(fails.ExpiredOrNotYetValidCertFailure(err)).To(BeTrue())
 			})
 		})

--- a/proxy/fails/classifier_group.go
+++ b/proxy/fails/classifier_group.go
@@ -20,6 +20,7 @@ var RetriableClassifiers = ClassifierGroup{
 	UntrustedCert,
 	ExpiredOrNotYetValidCertFailure,
 	IdempotentRequestEOF,
+	IncompleteRequest,
 }
 
 var FailableClassifiers = ClassifierGroup{

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -11,6 +11,10 @@ import (
 
 	"code.cloudfoundry.org/gorouter/common/health"
 
+	"github.com/cloudfoundry/dropsonde"
+	"github.com/uber-go/zap"
+	"github.com/urfave/negroni"
+
 	"code.cloudfoundry.org/gorouter/accesslog"
 	router_http "code.cloudfoundry.org/gorouter/common/http"
 	"code.cloudfoundry.org/gorouter/config"
@@ -25,9 +29,6 @@ import (
 	"code.cloudfoundry.org/gorouter/registry"
 	"code.cloudfoundry.org/gorouter/route"
 	"code.cloudfoundry.org/gorouter/routeservice"
-	"github.com/cloudfoundry/dropsonde"
-	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
 )
 
 var (
@@ -110,7 +111,7 @@ func NewProxy(
 
 	roundTripperFactory := &round_tripper.FactoryImpl{
 		BackendTemplate: &http.Transport{
-			Dial:                dialer.Dial,
+			DialContext:         dialer.DialContext,
 			DisableKeepAlives:   cfg.DisableKeepAlives,
 			MaxIdleConns:        cfg.MaxIdleConns,
 			IdleConnTimeout:     90 * time.Second, // setting the value to golang default transport
@@ -120,7 +121,7 @@ func NewProxy(
 			TLSHandshakeTimeout: cfg.TLSHandshakeTimeout,
 		},
 		RouteServiceTemplate: &http.Transport{
-			Dial:                dialer.Dial,
+			DialContext:         dialer.DialContext,
 			DisableKeepAlives:   cfg.DisableKeepAlives,
 			MaxIdleConns:        cfg.MaxIdleConns,
 			IdleConnTimeout:     90 * time.Second, // setting the value to golang default transport

--- a/proxy/round_tripper/dropsonde_round_tripper.go
+++ b/proxy/round_tripper/dropsonde_round_tripper.go
@@ -3,8 +3,9 @@ package round_tripper
 import (
 	"net/http"
 
-	"code.cloudfoundry.org/gorouter/proxy/utils"
 	"github.com/cloudfoundry/dropsonde"
+
+	"code.cloudfoundry.org/gorouter/proxy/utils"
 )
 
 func NewDropsondeRoundTripper(p ProxyRoundTripper) ProxyRoundTripper {
@@ -44,7 +45,7 @@ func (t *FactoryImpl) New(expectedServerName string, isRouteService bool, isHttp
 	customTLSConfig := utils.TLSConfigWithServerName(expectedServerName, template.TLSClientConfig, isRouteService)
 
 	newTransport := &http.Transport{
-		Dial:                template.Dial,
+		DialContext:         template.DialContext,
 		DisableKeepAlives:   template.DisableKeepAlives,
 		MaxIdleConns:        template.MaxIdleConns,
 		IdleConnTimeout:     template.IdleConnTimeout,

--- a/proxy/round_tripper/error_handler_test.go
+++ b/proxy/round_tripper/error_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"net"
 	"net/http/httptest"
 
@@ -136,9 +137,41 @@ var _ = Describe("HandleError", func() {
 			})
 		})
 
+		Context("HostnameMismatch wrapped in IncompleteRequestError", func() {
+			BeforeEach(func() {
+				wrappedErr := x509.HostnameError{Host: "the wrong one"}
+				err = fmt.Errorf("%w (%w)", fails.IncompleteRequestError, wrappedErr)
+				errorHandler.HandleError(responseWriter, err)
+			})
+
+			It("has a 503 Status Code", func() {
+				Expect(responseWriter.Status()).To(Equal(503))
+			})
+
+			It("emits a backend_invalid_id metric", func() {
+				Expect(metricReporter.CaptureBackendInvalidIDCallCount()).To(Equal(1))
+			})
+		})
+
 		Context("Untrusted Cert", func() {
 			BeforeEach(func() {
 				err = x509.UnknownAuthorityError{}
+				errorHandler.HandleError(responseWriter, err)
+			})
+
+			It("has a 526 Status Code", func() {
+				Expect(responseWriter.Status()).To(Equal(526))
+			})
+
+			It("emits a backend_invalid_tls_cert metric", func() {
+				Expect(metricReporter.CaptureBackendInvalidTLSCertCallCount()).To(Equal(1))
+			})
+		})
+
+		Context("Untrusted Cert wrapped in IncompleteRequestError", func() {
+			BeforeEach(func() {
+				wrappedErr := x509.UnknownAuthorityError{}
+				err = fmt.Errorf("%w (%w)", fails.IncompleteRequestError, wrappedErr)
 				errorHandler.HandleError(responseWriter, err)
 			})
 
@@ -166,9 +199,41 @@ var _ = Describe("HandleError", func() {
 			})
 		})
 
+		Context("Attempted TLS with non-TLS backend error wrapped in IncompleteRequestError", func() {
+			BeforeEach(func() {
+				wrappedErr := tls.RecordHeaderError{Msg: "bad handshake"}
+				err = fmt.Errorf("%w (%w)", fails.IncompleteRequestError, wrappedErr)
+				errorHandler.HandleError(responseWriter, err)
+			})
+
+			It("has a 525 Status Code", func() {
+				Expect(responseWriter.Status()).To(Equal(525))
+			})
+
+			It("emits a backend_tls_handshake_failed metric", func() {
+				Expect(metricReporter.CaptureBackendTLSHandshakeFailedCallCount()).To(Equal(1))
+			})
+		})
+
 		Context("Remote handshake failure", func() {
 			BeforeEach(func() {
 				err = &net.OpError{Op: "remote error", Err: errors.New("tls: handshake failure")}
+				errorHandler.HandleError(responseWriter, err)
+			})
+
+			It("has a 525 Status Code", func() {
+				Expect(responseWriter.Status()).To(Equal(525))
+			})
+
+			It("emits a backend_tls_handshake_failed metric", func() {
+				Expect(metricReporter.CaptureBackendTLSHandshakeFailedCallCount()).To(Equal(1))
+			})
+		})
+
+		Context("Remote handshake failure wrapped in IncompleteRequestError", func() {
+			BeforeEach(func() {
+				wrappedErr := &net.OpError{Op: "remote error", Err: errors.New("tls: handshake failure")}
+				err = fmt.Errorf("%w (%w)", fails.IncompleteRequestError, wrappedErr)
 				errorHandler.HandleError(responseWriter, err)
 			})
 

--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -143,7 +143,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 	} else {
 		maxAttempts = rt.maxRouteServiceAttempts
 	}
-	for attempt := 0; attempt < maxAttempts || maxAttempts == 0; attempt++ {
+	for attempt := 1; attempt <= maxAttempts || maxAttempts == 0; attempt++ {
 		logger := rt.logger
 		trace.reset()
 
@@ -156,7 +156,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 			logger = logger.With(zap.Nest("route-endpoint", endpoint.ToLogData()...))
 			reqInfo.RouteEndpoint = endpoint
 
-			logger.Debug("backend", zap.Int("attempt", attempt+1))
+			logger.Debug("backend", zap.Int("attempt", attempt))
 			if endpoint.IsTLS() {
 				request.URL.Scheme = "https"
 			} else {
@@ -176,7 +176,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 				retriable := !trace.gotConn || (rt.aggressiveRetries && !trace.wroteHeaders) || isIdempotent(request)
 				logger.Error("backend-endpoint-failed",
 					zap.Error(err),
-					zap.Int("attempt", attempt+1),
+					zap.Int("attempt", attempt),
 					zap.String("vcap_request_id", request.Header.Get(handlers.VcapRequestIdHeader)),
 					zap.Bool("retriable", retriable),
 					zap.Int("num-endpoints", numberOfEndpoints),
@@ -195,7 +195,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 			logger.Debug(
 				"route-service",
 				zap.Object("route-service-url", reqInfo.RouteServiceURL),
-				zap.Int("attempt", attempt+1),
+				zap.Int("attempt", attempt),
 			)
 
 			endpoint = &route.Endpoint{

--- a/proxy/round_tripper/trace.go
+++ b/proxy/round_tripper/trace.go
@@ -92,6 +92,12 @@ func traceRequest(req *http.Request) (*http.Request, *requestTracer) {
 		GotConn: func(info httptrace.GotConnInfo) {
 			t.gotConn.Store(true)
 			t.connInfo.Store(&info)
+			if !info.Reused {
+				// FIXME: workaround for https://github.com/golang/go/issues/59310
+				// This gives net/http: Transport.persistConn.readLoop the time possibly mark the connection
+				// as broken before roundtrip starts.
+				time.Sleep(500 * time.Microsecond)
+			}
 		},
 		DNSStart: func(_ httptrace.DNSStartInfo) {
 			t.tDNSStart.Store(time.Now().UnixNano())

--- a/proxy/round_tripper/trace.go
+++ b/proxy/round_tripper/trace.go
@@ -1,0 +1,119 @@
+package round_tripper
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptrace"
+	"sync/atomic"
+	"time"
+)
+
+// requestTracer holds trace data of a single request.
+type requestTracer struct {
+	gotConn      atomic.Bool
+	connInfo     atomic.Pointer[httptrace.GotConnInfo]
+	wroteHeaders atomic.Bool
+	tDNSStart    atomic.Int64
+	tDNSDone     atomic.Int64
+	tDialStart   atomic.Int64
+	tDialDone    atomic.Int64
+	tTLSStart    atomic.Int64
+	tTLSDone     atomic.Int64
+}
+
+// Reset the trace data. Helpful when performing the same request again.
+func (t *requestTracer) Reset() {
+	t.gotConn.Store(false)
+	t.connInfo.Store(nil)
+	t.wroteHeaders.Store(false)
+	t.tDNSStart.Store(0)
+	t.tDNSDone.Store(0)
+	t.tDialStart.Store(0)
+	t.tDialDone.Store(0)
+	t.tTLSStart.Store(0)
+	t.tTLSDone.Store(0)
+}
+
+// GotConn returns true if a connection (TCP + TLS) to the backend was established on the traced request.
+func (t *requestTracer) GotConn() bool {
+	return t.gotConn.Load()
+}
+
+// WroteHeaders returns true if HTTP headers were written on the traced request.
+func (t *requestTracer) WroteHeaders() bool {
+	return t.wroteHeaders.Load()
+}
+
+// ConnReused returns true if the traced request used an idle connection.
+// it returns false if no idle connection was used or if the information was unavailable.
+func (t *requestTracer) ConnReused() bool {
+	info := t.connInfo.Load()
+	if info != nil {
+		return info.Reused
+	}
+	return false
+}
+
+// timeDelta returns the duration from t1 to t2.
+// t1 and t2 are expected to be derived from time.UnixNano()
+// it returns -1 if the duration isn't positive.
+func timeDelta(t1, t2 int64) float64 {
+	d := float64(t2-t1) / float64(time.Second)
+	if d < 0 {
+		d = -1
+	}
+	return d
+}
+
+// DnsTime returns the time taken for the DNS lookup of the traced request.
+// in error cases the time will be set to -1.
+func (t *requestTracer) DnsTime() float64 {
+	return timeDelta(t.tDNSStart.Load(), t.tDNSDone.Load())
+}
+
+// DialTime returns the time taken for the TCP handshake of the traced request.
+// in error cases the time will be set to -1.
+func (t *requestTracer) DialTime() float64 {
+	return timeDelta(t.tDialStart.Load(), t.tDialDone.Load())
+}
+
+// TlsTime returns the time taken for the TLS handshake of the traced request.
+// in error cases the time will be set to -1.
+func (t *requestTracer) TlsTime() float64 {
+	return timeDelta(t.tTLSStart.Load(), t.tTLSDone.Load())
+}
+
+// traceRequest attaches a httptrace.ClientTrace to the given request. The
+// returned requestTracer indicates whether certain stages of the requests
+// lifecycle have been reached.
+func traceRequest(req *http.Request) (*http.Request, *requestTracer) {
+	t := &requestTracer{}
+	r2 := req.WithContext(httptrace.WithClientTrace(req.Context(), &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			t.gotConn.Store(true)
+			t.connInfo.Store(&info)
+		},
+		DNSStart: func(_ httptrace.DNSStartInfo) {
+			t.tDNSStart.Store(time.Now().UnixNano())
+		},
+		DNSDone: func(_ httptrace.DNSDoneInfo) {
+			t.tDNSDone.Store(time.Now().UnixNano())
+		},
+		ConnectStart: func(_, _ string) {
+			t.tDialStart.Store(time.Now().UnixNano())
+		},
+		ConnectDone: func(_, _ string, _ error) {
+			t.tDialDone.Store(time.Now().UnixNano())
+		},
+		TLSHandshakeStart: func() {
+			t.tTLSStart.Store(time.Now().UnixNano())
+		},
+		TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
+			t.tTLSDone.Store(time.Now().UnixNano())
+		},
+		WroteHeaders: func() {
+			t.wroteHeaders.Store(true)
+		},
+	}))
+	return r2, t
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -393,6 +393,7 @@ func zapData(uri route.Uri, endpoint *route.Endpoint) []zap.Field {
 	}
 	return []zap.Field{
 		zap.Stringer("uri", uri),
+		zap.String("route_service_url", endpoint.RouteServiceUrl),
 		zap.String("backend", endpoint.CanonicalAddr()),
 		zap.String("application_id", endpoint.ApplicationId),
 		zap.String("instance_id", endpoint.PrivateInstanceId),

--- a/test/common/tcp_app.go
+++ b/test/common/tcp_app.go
@@ -1,0 +1,180 @@
+package common
+
+import (
+	"code.cloudfoundry.org/gorouter/common/uuid"
+	"code.cloudfoundry.org/gorouter/route"
+	"code.cloudfoundry.org/gorouter/test_util"
+	"encoding/json"
+	"fmt"
+	nats "github.com/nats-io/nats.go"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net"
+	"sync"
+)
+
+type TcpApp struct {
+	mutex sync.Mutex
+
+	port         uint16      // app listening port
+	rPort        uint16      // router listening port
+	urls         []route.Uri // host registered host name
+	mbusClient   *nats.Conn
+	tags         map[string]string
+	listener     net.Listener
+	handlers     []func(conn *test_util.HttpConn)
+	stopped      bool
+	routeService string
+	GUID         string
+}
+
+func NewTcpApp(urls []route.Uri, rPort uint16, mbusClient *nats.Conn, tags map[string]string, routeService string) *TcpApp {
+	app := new(TcpApp)
+
+	port := test_util.NextAvailPort()
+
+	app.port = port
+	app.rPort = rPort
+	app.urls = urls
+	app.mbusClient = mbusClient
+	app.tags = tags
+	app.routeService = routeService
+	app.GUID, _ = uuid.GenerateUUID()
+
+	return app
+}
+
+func (a *TcpApp) SetHandlers(handlers []func(conn *test_util.HttpConn)) {
+	a.handlers = handlers
+}
+
+func (a *TcpApp) Urls() []route.Uri {
+	return a.urls
+}
+
+func (a *TcpApp) SetRouteService(routeService string) {
+	a.routeService = routeService
+}
+
+func (a *TcpApp) Endpoint() string {
+	return fmt.Sprintf("http://%s:%d/", a.urls[0], a.rPort)
+}
+
+func (a *TcpApp) Listen() error {
+	var err error
+	a.listener, err = net.Listen("tcp", fmt.Sprintf(":%d", a.port))
+
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		defer GinkgoRecover()
+		for i := 0; i < len(a.handlers); i++ {
+			if a.isStopped() {
+				a.listener.Close()
+				break
+			}
+			conn, err := a.listener.Accept()
+			Expect(err).NotTo(HaveOccurred())
+
+			a.handlers[i](test_util.NewHttpConn(conn))
+		}
+
+	}()
+	return nil
+}
+
+func (a *TcpApp) RegisterAndListen() {
+	a.Register()
+	a.Listen()
+}
+
+func (a *TcpApp) Port() uint16 {
+	return a.port
+}
+
+func (a *TcpApp) AppGUID() string {
+	return a.GUID
+}
+
+func (a *TcpApp) TlsRegister(serverCertDomainSAN string) {
+	a.TlsRegisterWithIndex(serverCertDomainSAN, 0)
+}
+func (a *TcpApp) TlsRegisterWithIndex(serverCertDomainSAN string, index int) {
+	id, _ := uuid.GenerateUUID()
+	rm := registerMessage{
+		Host:                    "127.0.0.1",
+		TlsPort:                 a.port,
+		Port:                    a.port,
+		Uris:                    a.urls,
+		Tags:                    a.tags,
+		Dea:                     "dea",
+		App:                     a.GUID,
+		PrivateInstanceIndex:    fmt.Sprintf("%d", index),
+		StaleThresholdInSeconds: 1,
+
+		RouteServiceUrl:     a.routeService,
+		ServerCertDomainSAN: serverCertDomainSAN,
+		PrivateInstanceId:   id,
+	}
+
+	b, _ := json.Marshal(rm)
+	a.mbusClient.Publish("router.register", b)
+}
+func (a *TcpApp) Register() {
+	id, _ := uuid.GenerateUUID()
+	rm := registerMessage{
+		Host:                    "127.0.0.1",
+		Port:                    a.port,
+		Uris:                    a.urls,
+		Tags:                    a.tags,
+		Dea:                     "dea",
+		App:                     a.GUID,
+		PrivateInstanceIndex:    "0",
+		StaleThresholdInSeconds: 1,
+
+		RouteServiceUrl:   a.routeService,
+		PrivateInstanceId: id,
+	}
+
+	b, _ := json.Marshal(rm)
+	a.mbusClient.Publish("router.register", b)
+}
+
+func (a *TcpApp) Unregister() {
+	rm := registerMessage{
+		Host: "127.0.0.1",
+		Port: a.port,
+		Uris: a.urls,
+		Tags: nil,
+		Dea:  "dea",
+		App:  "0",
+	}
+
+	b, _ := json.Marshal(rm)
+	a.mbusClient.Publish("router.unregister", b)
+
+	a.Stop()
+}
+
+func (a *TcpApp) start() {
+	a.mutex.Lock()
+	a.stopped = false
+	a.mutex.Unlock()
+}
+
+func (a *TcpApp) Stop() {
+	a.mutex.Lock()
+	a.stopped = true
+	if a.listener != nil {
+		a.listener.Close()
+	}
+	a.mutex.Unlock()
+}
+
+func (a *TcpApp) isStopped() bool {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	return a.stopped
+}

--- a/test_util/helpers.go
+++ b/test_util/helpers.go
@@ -291,6 +291,9 @@ func generateConfig(statusPort, proxyPort uint16, natsPorts ...uint16) *config.C
 		EnableZipkin: true,
 	}
 
+	c.Backends.MaxAttempts = 3
+	c.RouteServiceConfig.MaxAttempts = 3
+
 	return c
 }
 
@@ -399,7 +402,7 @@ func CreateSignedCertWithRootCA(cert CertNames) CertChain {
 	rootCert, err := x509.ParseCertificate(rootCADER)
 	Expect(err).NotTo(HaveOccurred())
 
-	ownKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	ownKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	Expect(err).NotTo(HaveOccurred())
 
 	certDER, err := x509.CreateCertificate(rand.Reader, &certTemplate, rootCert, &ownKey.PublicKey, rootPrivateKey)


### PR DESCRIPTION
The round tripper didn't make any effort to understand at which stage a
request failed and consequently only retried requests that failed while
establishing the connection or are idempotent by definition. This
commit introduces a check whether the headers were fully transmitted to
the target endpoint. If the headers were not transmitted, the target
server should discard the request in any case allowing us to retry it.

#### Check-List:
* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `main` branch
* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).
* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite
* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
