### PR TITLE
Add trace identifier to gorouter logs when handling request

### DIFF
--- a/handlers/access_log.go
+++ b/handlers/access_log.go
@@ -55,7 +55,7 @@ func (a *accessLog) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http
 
 	reqInfo, err := ContextRequestInfo(r)
 	if err != nil {
-		a.logger.Fatal("request-info-err", zap.Error(err))
+		a.logger.Panic("request-info-err", zap.Error(err))
 		return
 	}
 

--- a/handlers/access_log_test.go
+++ b/handlers/access_log_test.go
@@ -150,9 +150,9 @@ var _ = Describe("AccessLog", func() {
 			handler.Use(handlers.NewAccessLog(accessLogger, extraHeadersToLog, false, fakeLogger))
 			handler.Use(nextHandler)
 		})
-		It("calls Fatal on the logger", func() {
+		It("calls Panic on the logger", func() {
 			handler.ServeHTTP(resp, req)
-			Expect(fakeLogger.FatalCallCount()).To(Equal(1))
+			Expect(fakeLogger.PanicCallCount()).To(Equal(1))
 		})
 	})
 

--- a/handlers/clientcert.go
+++ b/handlers/clientcert.go
@@ -42,6 +42,7 @@ func NewClientCert(
 }
 
 func (c *clientCert) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	logger := LoggerWithTraceInfo(c.logger, r)
 	skip := c.skipSanitization(r)
 	if !skip {
 		switch c.forwardingMode {
@@ -65,14 +66,14 @@ func (c *clientCert) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 				rw,
 				http.StatusGatewayTimeout,
 				fmt.Sprintf("Failed to validate Route Service Signature: %s", err.Error()),
-				c.logger,
+				logger,
 			)
 		} else {
 			c.errorWriter.WriteError(
 				rw,
 				http.StatusBadGateway,
 				fmt.Sprintf("Failed to validate Route Service Signature: %s", err.Error()),
-				c.logger,
+				logger,
 			)
 		}
 		return

--- a/handlers/handlers_suite_test.go
+++ b/handlers/handlers_suite_test.go
@@ -1,6 +1,9 @@
 package handlers_test
 
 import (
+	"net/http"
+
+	"code.cloudfoundry.org/gorouter/handlers"
 	"code.cloudfoundry.org/gorouter/test_util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -11,4 +14,24 @@ import (
 func TestHandlers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	test_util.RunSpecWithHoneyCombReporter(t, "Handlers Suite")
+}
+
+type PrevHandler struct{}
+
+func (h *PrevHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	next(w, req)
+}
+
+type PrevHandlerWithTrace struct{}
+
+func (h *PrevHandlerWithTrace) ServeHTTP(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	reqInfo, err := handlers.ContextRequestInfo(req)
+	if err == nil {
+		reqInfo.TraceInfo = handlers.TraceInfo{
+			TraceID: "1111",
+			SpanID:  "2222",
+		}
+	}
+
+	next(w, req)
 }

--- a/handlers/httpstartstop_test.go
+++ b/handlers/httpstartstop_test.go
@@ -270,23 +270,3 @@ var _ = Describe("HTTPStartStop Handler", func() {
 		})
 	})
 })
-
-type PrevHandler struct{}
-
-func (h *PrevHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	next(w, req)
-}
-
-type PrevHandlerWithTrace struct{}
-
-func (h *PrevHandlerWithTrace) ServeHTTP(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
-	reqInfo, err := handlers.ContextRequestInfo(req)
-	if err == nil {
-		reqInfo.TraceInfo = handlers.TraceInfo{
-			TraceID: "1111",
-			SpanID:  "2222",
-		}
-	}
-
-	next(w, req)
-}

--- a/handlers/lookup_test.go
+++ b/handlers/lookup_test.go
@@ -491,8 +491,8 @@ var _ = Describe("Lookup", func() {
 				pool.Put(testEndpoint1)
 				reg.LookupReturns(pool)
 			})
-			It("calls Fatal on the logger", func() {
-				Expect(logger.FatalCallCount()).To(Equal(1))
+			It("calls Panic on the logger", func() {
+				Expect(logger.PanicCallCount()).To(Equal(1))
 				Expect(nextCalled).To(BeFalse())
 			})
 		})

--- a/handlers/paniccheck.go
+++ b/handlers/paniccheck.go
@@ -40,7 +40,8 @@ func (p *panicCheck) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 				if !ok {
 					err = fmt.Errorf("%v", rec)
 				}
-				p.logger.Error("panic-check", zap.String("host", r.Host), zap.Nest("error", zap.Error(err), zap.Stack()))
+				logger := LoggerWithTraceInfo(p.logger, r)
+				logger.Error("panic-check", zap.String("host", r.Host), zap.Nest("error", zap.Error(err), zap.Stack()))
 
 				rw.Header().Set(router_http.CfRouterError, "unknown_failure")
 				rw.WriteHeader(http.StatusBadGateway)

--- a/handlers/protocolcheck.go
+++ b/handlers/protocolcheck.go
@@ -30,6 +30,7 @@ func NewProtocolCheck(logger logger.Logger, errorWriter errorwriter.ErrorWriter,
 }
 
 func (p *protocolCheck) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	logger := LoggerWithTraceInfo(p.logger, r)
 	if !p.isProtocolSupported(r) {
 		// must be hijacked, otherwise no response is sent back
 		conn, buf, err := p.hijack(rw)
@@ -38,7 +39,7 @@ func (p *protocolCheck) ServeHTTP(rw http.ResponseWriter, r *http.Request, next 
 				rw,
 				http.StatusBadRequest,
 				"Unsupported protocol",
-				p.logger,
+				logger,
 			)
 			return
 		}

--- a/handlers/proxy_healthcheck.go
+++ b/handlers/proxy_healthcheck.go
@@ -1,27 +1,25 @@
 package handlers
 
 import (
-	"code.cloudfoundry.org/gorouter/common/health"
-	"code.cloudfoundry.org/gorouter/logger"
-	"github.com/urfave/negroni"
 	"net/http"
+
+	"code.cloudfoundry.org/gorouter/common/health"
+	"github.com/urfave/negroni"
 )
 
 type proxyHealthcheck struct {
 	userAgent string
 	health    *health.Health
-	logger    logger.Logger
 }
 
 // NewHealthcheck creates a handler that responds to healthcheck requests.
 // If userAgent is set to a non-empty string, it will use that user agent to
 // differentiate between healthcheck requests and non-healthcheck requests.
 // Otherwise, it will treat all requests as healthcheck requests.
-func NewProxyHealthcheck(userAgent string, health *health.Health, logger logger.Logger) negroni.Handler {
+func NewProxyHealthcheck(userAgent string, health *health.Health) negroni.Handler {
 	return &proxyHealthcheck{
 		userAgent: userAgent,
 		health:    health,
-		logger:    logger,
 	}
 }
 

--- a/handlers/proxy_healthcheck_test.go
+++ b/handlers/proxy_healthcheck_test.go
@@ -1,13 +1,13 @@
 package handlers_test
 
 import (
-	"code.cloudfoundry.org/gorouter/common/health"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 
+	"code.cloudfoundry.org/gorouter/common/health"
+
 	"code.cloudfoundry.org/gorouter/handlers"
-	"code.cloudfoundry.org/gorouter/logger"
 	"code.cloudfoundry.org/gorouter/test_util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,7 +17,6 @@ import (
 var _ = Describe("Proxy Healthcheck", func() {
 	var (
 		handler      negroni.Handler
-		logger       logger.Logger
 		resp         *httptest.ResponseRecorder
 		req          *http.Request
 		healthStatus *health.Health
@@ -25,13 +24,12 @@ var _ = Describe("Proxy Healthcheck", func() {
 		nextCalled   bool
 	)
 	BeforeEach(func() {
-		logger = test_util.NewTestZapLogger("healthcheck")
 		req = test_util.NewRequest("GET", "example.com", "/", nil)
 		resp = httptest.NewRecorder()
 		healthStatus = &health.Health{}
 		healthStatus.SetHealth(health.Healthy)
 
-		handler = handlers.NewProxyHealthcheck("HTTP-Monitor/1.1", healthStatus, logger)
+		handler = handlers.NewProxyHealthcheck("HTTP-Monitor/1.1", healthStatus)
 		nextHandler = http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 			nextCalled = true
 		})

--- a/handlers/proxywriter.go
+++ b/handlers/proxywriter.go
@@ -26,7 +26,7 @@ func NewProxyWriter(logger logger.Logger) negroni.Handler {
 func (p *proxyWriterHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	reqInfo, err := ContextRequestInfo(r)
 	if err != nil {
-		p.logger.Fatal("request-info-err", zap.Error(err))
+		p.logger.Panic("request-info-err", zap.Error(err))
 		return
 	}
 	proxyWriter := utils.NewProxyResponseWriter(rw)

--- a/handlers/proxywriter_test.go
+++ b/handlers/proxywriter_test.go
@@ -90,9 +90,9 @@ var _ = Describe("ProxyWriter", func() {
 			badHandler.Use(handlers.NewProxyWriter(fakeLogger))
 			badHandler.UseHandlerFunc(nextHandler)
 		})
-		It("calls Fatal on the logger", func() {
+		It("calls Panic on the logger", func() {
 			badHandler.ServeHTTP(resp, req)
-			Expect(fakeLogger.FatalCallCount()).To(Equal(1))
+			Expect(fakeLogger.PanicCallCount()).To(Equal(1))
 			Expect(nextCalled).To(BeFalse())
 		})
 	})

--- a/handlers/query_param.go
+++ b/handlers/query_param.go
@@ -21,9 +21,10 @@ func NewQueryParam(logger logger.Logger) negroni.Handler {
 }
 
 func (q *queryParam) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	logger := LoggerWithTraceInfo(q.logger, r)
 	semicolonInParams := strings.Contains(r.RequestURI, ";")
 	if semicolonInParams {
-		q.logger.Warn("deprecated-semicolon-params", zap.String("vcap_request_id", r.Header.Get(VcapRequestIdHeader)))
+		logger.Warn("deprecated-semicolon-params", zap.String("vcap_request_id", r.Header.Get(VcapRequestIdHeader)))
 	}
 
 	next(rw, r)

--- a/handlers/reporter.go
+++ b/handlers/reporter.go
@@ -28,13 +28,14 @@ func NewReporter(reporter metrics.ProxyReporter, logger logger.Logger) negroni.H
 
 // ServeHTTP handles reporting the response after the request has been completed
 func (rh *reporterHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	logger := LoggerWithTraceInfo(rh.logger, r)
 	next(rw, r)
 
 	requestInfo, err := ContextRequestInfo(r)
-	// logger.Fatal does not cause gorouter to exit 1 but rather throw panic with
+	// logger.Panic does not cause gorouter to exit 1 but rather throw panic with
 	// stacktrace in error log
 	if err != nil {
-		rh.logger.Fatal("request-info-err", zap.Error(err))
+		logger.Panic("request-info-err", zap.Error(err))
 		return
 	}
 

--- a/handlers/request_id.go
+++ b/handlers/request_id.go
@@ -31,14 +31,17 @@ func (s *setVcapRequestIdHeader) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 		s.logger.Error("failed-to-get-request-info", zap.Error(err))
 		return
 	}
+
+	logger := LoggerWithTraceInfo(s.logger, r)
+
 	traceInfo, err := requestInfo.ProvideTraceInfo()
 	if err != nil {
-		s.logger.Error("failed-to-get-trace-info", zap.Error(err))
+		logger.Error("failed-to-get-trace-info", zap.Error(err))
 		return
 	}
 
 	r.Header.Set(VcapRequestIdHeader, traceInfo.UUID)
-	s.logger.Debug("vcap-request-id-header-set", zap.String("VcapRequestIdHeader", traceInfo.UUID))
+	logger.Debug("vcap-request-id-header-set", zap.String("VcapRequestIdHeader", traceInfo.UUID))
 
 	next(rw, r)
 }

--- a/handlers/request_id_test.go
+++ b/handlers/request_id_test.go
@@ -83,6 +83,11 @@ var _ = Describe("Set Vcap Request Id header", func() {
 		It("sets the ID header from request context", func() {
 			Expect(vcapIdHeader).To(Equal("11111111-1111-1111-1111-111111111111"))
 		})
+
+		It("logs the header with trace info", func() {
+			Expect(logger).To(gbytes.Say("vcap-request-id-header-set"))
+			Expect(logger).To(gbytes.Say(`"data":{"trace-id":"11111111111111111111111111111111","span-id":"2222222222222222","VcapRequestIdHeader":"` + vcapIdHeader + `"}`))
+		})
 	})
 
 	Context("when X-Vcap-Request-Id is set", func() {

--- a/handlers/requestinfo.go
+++ b/handlers/requestinfo.go
@@ -10,6 +10,7 @@ import (
 	"code.cloudfoundry.org/gorouter/proxy/utils"
 	"code.cloudfoundry.org/gorouter/route"
 
+	"github.com/openzipkin/zipkin-go/idgenerator"
 	"github.com/urfave/negroni"
 )
 
@@ -60,7 +61,20 @@ type RequestInfo struct {
 	ShouldRouteToInternalRouteService bool
 	FailedAttempts                    int
 
+	TraceID string
+	SpanID  string
+
 	BackendReqHeaders http.Header
+}
+
+func (r *RequestInfo) ProvideTraceInfo() (string, string) {
+	if r.TraceID != "" && r.SpanID != "" {
+		return r.TraceID, r.SpanID
+	}
+	trace := idgenerator.NewRandom128().TraceID()
+	r.TraceID = trace.String()
+	r.SpanID = idgenerator.NewRandom128().SpanID(trace).String()
+	return r.TraceID, r.SpanID
 }
 
 // ContextRequestInfo gets the RequestInfo from the request Context

--- a/handlers/w3c.go
+++ b/handlers/w3c.go
@@ -87,9 +87,8 @@ func (m *W3C) ServeUpdatedTraceparent(
 		return
 	}
 
-	if requestInfo.TraceID == "" {
-		requestInfo.TraceID = fmt.Sprintf("%x", traceparent.TraceID)
-		requestInfo.SpanID = fmt.Sprintf("%x", traceparent.ParentID)
+	if requestInfo.TraceInfo.TraceID == "" {
+		requestInfo.SetTraceInfo(fmt.Sprintf("%x", traceparent.TraceID), fmt.Sprintf("%x", traceparent.ParentID))
 	}
 
 	tracestate := ParseW3CTracestate(r.Header.Get(W3CTracestateHeader))

--- a/handlers/w3c_test.go
+++ b/handlers/w3c_test.go
@@ -1,10 +1,12 @@
 package handlers_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strings"
 
 	"code.cloudfoundry.org/gorouter/handlers"
 	"code.cloudfoundry.org/gorouter/test_util"
@@ -16,7 +18,7 @@ import (
 
 var _ = Describe("W3C", func() {
 	extractParentID := func(traceparent string) string {
-		r := regexp.MustCompile("^00-[a-f0-9]{32}-([a-f0-9]{16})-01$")
+		r := regexp.MustCompile("^00-[[:xdigit:]]{32}-([[:xdigit:]]{16})-01$")
 
 		matches := r.FindStringSubmatch(traceparent)
 
@@ -34,16 +36,23 @@ var _ = Describe("W3C", func() {
 		logger     logger.Logger
 		resp       http.ResponseWriter
 		req        *http.Request
+		reqInfo    *handlers.RequestInfo
 		nextCalled bool
 	)
 
-	nextHandler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+	nextHandler := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		var err error
+		reqInfo, err = handlers.ContextRequestInfo(r)
+		Expect(err).NotTo(HaveOccurred())
 		nextCalled = true
 	})
 
 	BeforeEach(func() {
 		logger = test_util.NewTestZapLogger("w3c")
-		req = test_util.NewRequest("GET", "example.com", "/", nil)
+		ri := new(handlers.RequestInfo)
+		req = test_util.NewRequest("GET", "example.com", "/", nil).
+			WithContext(context.WithValue(context.Background(), handlers.RequestInfoCtxKey, ri))
+
 		resp = httptest.NewRecorder()
 		nextCalled = false
 	})
@@ -58,22 +67,48 @@ var _ = Describe("W3C", func() {
 			})
 
 			Context("when there are no pre-existing headers", func() {
-				It("sets W3C headers and calls the next handler", func() {
-					handler.ServeHTTP(resp, req, nextHandler)
+				Context("when request context has trace and span id", func() {
+					BeforeEach(func() {
+						ri := new(handlers.RequestInfo)
+						ri.TraceID = strings.Repeat("1", 32)
+						ri.SpanID = strings.Repeat("2", 16)
+						req = test_util.NewRequest("GET", "example.com", "/", nil).
+							WithContext(context.WithValue(context.Background(), handlers.RequestInfoCtxKey, ri))
+					})
 
-					traceparentHeader := req.Header.Get(handlers.W3CTraceparentHeader)
+					It("uses trace ID from request context", func() {
+						handler.ServeHTTP(resp, req, nextHandler)
 
-					Expect(traceparentHeader).To(MatchRegexp(
-						"^00-[a-f0-9]{32}-[a-f0-9]{16}-01$"), "Must match the W3C spec",
-					)
+						traceparentHeader := req.Header.Get(handlers.W3CTraceparentHeader)
 
-					parentID := extractParentID(traceparentHeader)
+						Expect(traceparentHeader).To(Equal("00-11111111111111111111111111111111-2222222222222222-01"))
 
-					Expect(req.Header.Get(handlers.W3CTracestateHeader)).To(
-						Equal(fmt.Sprintf("gorouter=%s", parentID)),
-					)
+						Expect(reqInfo.TraceID).To(Equal(strings.Repeat("1", 32)))
+						Expect(reqInfo.SpanID).To(Equal(strings.Repeat("2", 16)))
+					})
+				})
 
-					Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+				Context("when request context doesn't have trace and span id", func() {
+					It("sets W3C headers from request context and calls the next handler", func() {
+						handler.ServeHTTP(resp, req, nextHandler)
+
+						traceparentHeader := req.Header.Get(handlers.W3CTraceparentHeader)
+
+						Expect(traceparentHeader).To(MatchRegexp(
+							"^00-[[:xdigit:]]{32}-[[:xdigit:]]{16}-01$"), "Must match the W3C spec",
+						)
+
+						parentID := extractParentID(traceparentHeader)
+
+						Expect(req.Header.Get(handlers.W3CTracestateHeader)).To(
+							Equal(fmt.Sprintf("gorouter=%s", parentID)),
+						)
+
+						Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+
+						Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
+						Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+					})
 				})
 			})
 
@@ -110,6 +145,30 @@ var _ = Describe("W3C", func() {
 
 					Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
 				})
+
+				Context("when request context has trace and span id", func() {
+					BeforeEach(func() {
+						ri := new(handlers.RequestInfo)
+						ri.TraceID = strings.Repeat("3", 32)
+						ri.SpanID = strings.Repeat("4", 16)
+						req = test_util.NewRequest("GET", "example.com", "/", nil).
+							WithContext(context.WithValue(context.Background(), handlers.RequestInfoCtxKey, ri))
+					})
+
+					It("doesn't update request context", func() {
+						handler.ServeHTTP(resp, req, nextHandler)
+						Expect(reqInfo.TraceID).To(Equal(strings.Repeat("3", 32)))
+						Expect(reqInfo.SpanID).To(Equal(strings.Repeat("4", 16)))
+					})
+				})
+
+				Context("when request context doesn't have trace and span id", func() {
+					It("updates request context with trace ID and generated parent ID", func() {
+						handler.ServeHTTP(resp, req, nextHandler)
+						Expect(reqInfo.TraceID).To(Equal(strings.Repeat("1", 32)))
+						Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+					})
+				})
 			})
 
 			Context("when there are pre-existing headers including gorouter", func() {
@@ -143,6 +202,12 @@ var _ = Describe("W3C", func() {
 					)
 
 					Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+				})
+
+				It("sets request context", func() {
+					handler.ServeHTTP(resp, req, nextHandler)
+					Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
+					Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
 				})
 			})
 		})
@@ -204,6 +269,12 @@ var _ = Describe("W3C", func() {
 
 					Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
 				})
+
+				It("sets request context", func() {
+					handler.ServeHTTP(resp, req, nextHandler)
+					Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
+					Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				})
 			})
 
 			Context("when there are pre-existing headers including gorouter which has a different tenant ID", func() {
@@ -237,6 +308,12 @@ var _ = Describe("W3C", func() {
 					)
 
 					Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+				})
+
+				It("sets request context", func() {
+					handler.ServeHTTP(resp, req, nextHandler)
+					Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
+					Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
 				})
 			})
 
@@ -272,6 +349,12 @@ var _ = Describe("W3C", func() {
 
 					Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
 				})
+
+				It("sets request context", func() {
+					handler.ServeHTTP(resp, req, nextHandler)
+					Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
+					Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				})
 			})
 		})
 
@@ -289,6 +372,12 @@ var _ = Describe("W3C", func() {
 			Expect(req.Header.Get(handlers.W3CTracestateHeader)).To(BeEmpty())
 
 			Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+		})
+
+		It("sets request context", func() {
+			handler.ServeHTTP(resp, req, nextHandler)
+			Expect(reqInfo.TraceID).To(BeEmpty())
+			Expect(reqInfo.SpanID).To(BeEmpty())
 		})
 	})
 })

--- a/handlers/w3c_test.go
+++ b/handlers/w3c_test.go
@@ -70,8 +70,9 @@ var _ = Describe("W3C", func() {
 				Context("when request context has trace and span id", func() {
 					BeforeEach(func() {
 						ri := new(handlers.RequestInfo)
-						ri.TraceID = strings.Repeat("1", 32)
-						ri.SpanID = strings.Repeat("2", 16)
+						ri.TraceInfo.TraceID = strings.Repeat("1", 32)
+						ri.TraceInfo.SpanID = strings.Repeat("2", 16)
+						ri.TraceInfo.UUID = "11111111-1111-1111-1111-111111111111"
 						req = test_util.NewRequest("GET", "example.com", "/", nil).
 							WithContext(context.WithValue(context.Background(), handlers.RequestInfoCtxKey, ri))
 					})
@@ -83,8 +84,9 @@ var _ = Describe("W3C", func() {
 
 						Expect(traceparentHeader).To(Equal("00-11111111111111111111111111111111-2222222222222222-01"))
 
-						Expect(reqInfo.TraceID).To(Equal(strings.Repeat("1", 32)))
-						Expect(reqInfo.SpanID).To(Equal(strings.Repeat("2", 16)))
+						Expect(reqInfo.TraceInfo.TraceID).To(Equal(strings.Repeat("1", 32)))
+						Expect(reqInfo.TraceInfo.SpanID).To(Equal(strings.Repeat("2", 16)))
+						Expect(reqInfo.TraceInfo.UUID).To(Equal("11111111-1111-1111-1111-111111111111"))
 					})
 				})
 
@@ -106,8 +108,9 @@ var _ = Describe("W3C", func() {
 
 						Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
 
-						Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
-						Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+						Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
+						Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+						Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 					})
 				})
 			})
@@ -149,24 +152,27 @@ var _ = Describe("W3C", func() {
 				Context("when request context has trace and span id", func() {
 					BeforeEach(func() {
 						ri := new(handlers.RequestInfo)
-						ri.TraceID = strings.Repeat("3", 32)
-						ri.SpanID = strings.Repeat("4", 16)
+						ri.TraceInfo.TraceID = strings.Repeat("3", 32)
+						ri.TraceInfo.SpanID = strings.Repeat("4", 16)
+						ri.TraceInfo.UUID = "33333333-3333-3333-3333-333333333333"
 						req = test_util.NewRequest("GET", "example.com", "/", nil).
 							WithContext(context.WithValue(context.Background(), handlers.RequestInfoCtxKey, ri))
 					})
 
 					It("doesn't update request context", func() {
 						handler.ServeHTTP(resp, req, nextHandler)
-						Expect(reqInfo.TraceID).To(Equal(strings.Repeat("3", 32)))
-						Expect(reqInfo.SpanID).To(Equal(strings.Repeat("4", 16)))
+						Expect(reqInfo.TraceInfo.TraceID).To(Equal(strings.Repeat("3", 32)))
+						Expect(reqInfo.TraceInfo.SpanID).To(Equal(strings.Repeat("4", 16)))
+						Expect(reqInfo.TraceInfo.UUID).To(Equal("33333333-3333-3333-3333-333333333333"))
 					})
 				})
 
 				Context("when request context doesn't have trace and span id", func() {
 					It("updates request context with trace ID and generated parent ID", func() {
 						handler.ServeHTTP(resp, req, nextHandler)
-						Expect(reqInfo.TraceID).To(Equal(strings.Repeat("1", 32)))
-						Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+						Expect(reqInfo.TraceInfo.TraceID).To(Equal(strings.Repeat("1", 32)))
+						Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+						Expect(reqInfo.TraceInfo.UUID).To(Equal("11111111-1111-1111-1111-111111111111"))
 					})
 				})
 			})
@@ -206,8 +212,9 @@ var _ = Describe("W3C", func() {
 
 				It("sets request context", func() {
 					handler.ServeHTTP(resp, req, nextHandler)
-					Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
-					Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+					Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
+					Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+					Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 				})
 			})
 		})
@@ -272,8 +279,9 @@ var _ = Describe("W3C", func() {
 
 				It("sets request context", func() {
 					handler.ServeHTTP(resp, req, nextHandler)
-					Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
-					Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+					Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
+					Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+					Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 				})
 			})
 
@@ -312,8 +320,9 @@ var _ = Describe("W3C", func() {
 
 				It("sets request context", func() {
 					handler.ServeHTTP(resp, req, nextHandler)
-					Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
-					Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+					Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
+					Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+					Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 				})
 			})
 
@@ -352,8 +361,9 @@ var _ = Describe("W3C", func() {
 
 				It("sets request context", func() {
 					handler.ServeHTTP(resp, req, nextHandler)
-					Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
-					Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+					Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
+					Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+					Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 				})
 			})
 		})
@@ -376,8 +386,9 @@ var _ = Describe("W3C", func() {
 
 		It("sets request context", func() {
 			handler.ServeHTTP(resp, req, nextHandler)
-			Expect(reqInfo.TraceID).To(BeEmpty())
-			Expect(reqInfo.SpanID).To(BeEmpty())
+			Expect(reqInfo.TraceInfo.TraceID).To(BeEmpty())
+			Expect(reqInfo.TraceInfo.SpanID).To(BeEmpty())
+			Expect(reqInfo.TraceInfo.UUID).To(BeEmpty())
 		})
 	})
 })

--- a/handlers/w3c_traceparent.go
+++ b/handlers/w3c_traceparent.go
@@ -28,14 +28,17 @@ type W3CTraceparent struct {
 // It uses trace ID and span ID provided in the request context
 // Or generates new IDs
 func NewW3CTraceparent(requestInfo *RequestInfo) (W3CTraceparent, error) {
-	traceID, parentID := requestInfo.ProvideTraceInfo()
-
-	traceIDB, err := hex.DecodeString(traceID)
+	traceInfo, err := requestInfo.ProvideTraceInfo()
 	if err != nil {
 		return W3CTraceparent{}, err
 	}
 
-	parentIDB, err := hex.DecodeString(parentID)
+	traceIDB, err := hex.DecodeString(traceInfo.TraceID)
+	if err != nil {
+		return W3CTraceparent{}, err
+	}
+
+	parentIDB, err := hex.DecodeString(traceInfo.SpanID)
 	if err != nil {
 		return W3CTraceparent{}, err
 	}

--- a/handlers/x_forwarded_proto.go
+++ b/handlers/x_forwarded_proto.go
@@ -2,15 +2,12 @@ package handlers
 
 import (
 	"net/http"
-
-	"code.cloudfoundry.org/gorouter/logger"
 )
 
 type XForwardedProto struct {
 	SkipSanitization         func(req *http.Request) bool
 	ForceForwardedProtoHttps bool
 	SanitizeForwardedProto   bool
-	Logger                   logger.Logger
 }
 
 func (h *XForwardedProto) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {

--- a/handlers/x_forwarded_proto_test.go
+++ b/handlers/x_forwarded_proto_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 
 	"code.cloudfoundry.org/gorouter/handlers"
-	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,11 +16,9 @@ var _ = Describe("X-Forwarded-Proto", func() {
 		req        *http.Request
 		res        *httptest.ResponseRecorder
 		nextCalled bool
-		logger     *logger_fakes.FakeLogger
 	)
 
 	BeforeEach(func() {
-		logger = new(logger_fakes.FakeLogger)
 		req, _ = http.NewRequest("GET", "/foo", nil)
 		nextCalled = false
 	})
@@ -44,7 +41,6 @@ var _ = Describe("X-Forwarded-Proto", func() {
 				SkipSanitization:         func(req *http.Request) bool { return true },
 				ForceForwardedProtoHttps: false,
 				SanitizeForwardedProto:   false,
-				Logger:                   logger,
 			}
 		})
 
@@ -71,7 +67,6 @@ var _ = Describe("X-Forwarded-Proto", func() {
 				SkipSanitization:         func(req *http.Request) bool { return false },
 				ForceForwardedProtoHttps: true,
 				SanitizeForwardedProto:   false,
-				Logger:                   logger,
 			}
 		})
 
@@ -94,7 +89,6 @@ var _ = Describe("X-Forwarded-Proto", func() {
 				SkipSanitization:         func(req *http.Request) bool { return false },
 				ForceForwardedProtoHttps: false,
 				SanitizeForwardedProto:   true,
-				Logger:                   logger,
 			}
 		})
 
@@ -124,7 +118,6 @@ var _ = Describe("X-Forwarded-Proto", func() {
 				SkipSanitization:         func(req *http.Request) bool { return false },
 				ForceForwardedProtoHttps: false,
 				SanitizeForwardedProto:   false,
-				Logger:                   logger,
 			}
 		})
 

--- a/handlers/zipkin.go
+++ b/handlers/zipkin.go
@@ -77,8 +77,8 @@ func (z *Zipkin) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 		r.Header.Set(b3.Context, b3.BuildSingleHeader(*sc))
 
 		logger.Debug("b3-trace-id-span-id-header-exists",
-			zap.String("traceID", existingTraceID),
-			zap.String("spanID", existingSpanID),
+			zap.String("trace-id", existingTraceID),
+			zap.String("span-id", existingSpanID),
 		)
 
 		err = requestInfo.SetTraceInfo(sc.TraceID.String(), sc.ID.String())

--- a/handlers/zipkin.go
+++ b/handlers/zipkin.go
@@ -28,29 +28,32 @@ func NewZipkin(enabled bool, logger logger.Logger) *Zipkin {
 
 func (z *Zipkin) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	defer next(rw, r)
+
+	logger := LoggerWithTraceInfo(z.logger, r)
+
 	if !z.zipkinEnabled {
 		return
 	}
 
 	requestInfo, err := ContextRequestInfo(r)
 	if err != nil {
-		z.logger.Error("failed-to-get-request-info", zap.Error(err))
+		logger.Error("failed-to-get-request-info", zap.Error(err))
 		return
 	}
 
 	existingContext := r.Header.Get(b3.Context)
 	if existingContext != "" {
-		z.logger.Debug("b3-header-exists",
+		logger.Debug("b3-header-exists",
 			zap.String("b3", existingContext),
 		)
 
 		sc, err := b3.ParseSingleHeader(existingContext)
 		if err != nil {
-			z.logger.Error("failed-to-parse-single-header", zap.Error(err))
+			logger.Error("failed-to-parse-single-header", zap.Error(err))
 		} else {
 			err = requestInfo.SetTraceInfo(sc.TraceID.String(), sc.ID.String())
 			if err != nil {
-				z.logger.Error("failed-to-set-trace-info", zap.Error(err))
+				logger.Error("failed-to-set-trace-info", zap.Error(err))
 			} else {
 				return
 			}
@@ -68,19 +71,19 @@ func (z *Zipkin) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 			r.Header.Get(b3.Flags),
 		)
 		if err != nil {
-			z.logger.Info("failed-to-parse-b3-trace-id", zap.Error(err))
+			logger.Info("failed-to-parse-b3-trace-id", zap.Error(err))
 			return
 		}
 		r.Header.Set(b3.Context, b3.BuildSingleHeader(*sc))
 
-		z.logger.Debug("b3-trace-id-span-id-header-exists",
+		logger.Debug("b3-trace-id-span-id-header-exists",
 			zap.String("traceID", existingTraceID),
 			zap.String("spanID", existingSpanID),
 		)
 
 		err = requestInfo.SetTraceInfo(sc.TraceID.String(), sc.ID.String())
 		if err != nil {
-			z.logger.Error("failed-to-set-trace-info", zap.Error(err))
+			logger.Error("failed-to-set-trace-info", zap.Error(err))
 		} else {
 			return
 		}
@@ -88,7 +91,7 @@ func (z *Zipkin) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 
 	traceInfo, err := requestInfo.ProvideTraceInfo()
 	if err != nil {
-		z.logger.Error("failed-to-get-trace-info", zap.Error(err))
+		logger.Error("failed-to-get-trace-info", zap.Error(err))
 		return
 	}
 

--- a/handlers/zipkin_test.go
+++ b/handlers/zipkin_test.go
@@ -16,14 +16,18 @@ import (
 
 // 64-bit random hexadecimal string
 const (
-	b3IDRegex       = `^[[:xdigit:]]{32}$`
-	b3Regex         = `^[[:xdigit:]]{32}-[[:xdigit:]]{16}(-[01d](-[[:xdigit:]]{16})?)?$`
-	b3TraceID       = "7f46165474d11ee5836777d85df2cdab"
-	b3SpanID        = "54ebcb82b14862d9"
-	b3SpanRegex     = `[[:xdigit:]]{16}$`
-	b3ParentSpanID  = "e56b75d6af463476"
-	invalidB3Single = "1g56165474d11ee5836777d85df2cdab-32ebcb82b14862d9-1-ab6b75d6af463476"
-	validB3Single   = "6d8780b7d3eed3f5108c880d778f29eb-108c880d778f29eb"
+	b3IDRegex            = `^[[:xdigit:]]{32}$`
+	b3Regex              = `^[[:xdigit:]]{32}-[[:xdigit:]]{16}(-[01d](-[[:xdigit:]]{16})?)?$`
+	b3TraceID            = "7f46165474d11ee5836777d85df2cdab"
+	UUID                 = "7f461654-74d1-1ee5-8367-77d85df2cdab"
+	b3SpanID             = "54ebcb82b14862d9"
+	b3SpanRegex          = `[[:xdigit:]]{16}$`
+	b3ParentSpanID       = "e56b75d6af463476"
+	invalidB3Single      = "1g56165474d11ee5836777d85df2cdab-32ebcb82b14862d9-1-ab6b75d6af463476"
+	validB3Single        = "6d8780b7d3ee13f5108c880d778f29eb-108c880d778f29eb"
+	invalidUUIDB3Single  = "6d8780b7d3eed3f5108c880d778f29eb-108c880d778f29eb"
+	invalidUUIDb3TraceID = "6d8780b7d3eed3f5108c880d778f29eb"
+	invalidUUIDb3SpanID  = "108c880d778f29eb"
 )
 
 var _ = Describe("Zipkin", func() {
@@ -72,8 +76,9 @@ var _ = Describe("Zipkin", func() {
 
 		It("sets request context", func() {
 			handler.ServeHTTP(resp, req, nextHandler)
-			Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
-			Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+			Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
+			Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+			Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 		})
 
 		Context("with B3TraceIdHeader, B3SpanIdHeader and B3ParentSpanIdHeader already set", func() {
@@ -106,8 +111,9 @@ var _ = Describe("Zipkin", func() {
 
 			It("sets request context", func() {
 				handler.ServeHTTP(resp, req, nextHandler)
-				Expect(reqInfo.TraceID).To(Equal(b3TraceID))
-				Expect(reqInfo.SpanID).To(Equal(b3SpanID))
+				Expect(reqInfo.TraceInfo.TraceID).To(Equal(b3TraceID))
+				Expect(reqInfo.TraceInfo.SpanID).To(Equal(b3SpanID))
+				Expect(reqInfo.TraceInfo.UUID).To(Equal(UUID))
 			})
 		})
 
@@ -171,8 +177,34 @@ var _ = Describe("Zipkin", func() {
 
 			It("sets request context", func() {
 				handler.ServeHTTP(resp, req, nextHandler)
-				Expect(reqInfo.TraceID).To(Equal(b3TraceID))
-				Expect(reqInfo.SpanID).To(Equal(b3SpanID))
+				Expect(reqInfo.TraceInfo.TraceID).To(Equal(b3TraceID))
+				Expect(reqInfo.TraceInfo.SpanID).To(Equal(b3SpanID))
+				Expect(reqInfo.TraceInfo.UUID).To(Equal(UUID))
+			})
+		})
+
+		Context("with B3TraceIdHeader that is invalid UUID and valid B3SpanIdHeader already set", func() {
+			BeforeEach(func() {
+				req.Header.Set(b3.TraceID, invalidUUIDb3TraceID)
+				req.Header.Set(b3.SpanID, b3SpanID)
+			})
+
+			It("doesn't overwrite the B3 headers", func() {
+				handler.ServeHTTP(resp, req, nextHandler)
+				Expect(req.Header.Get(b3.TraceID)).To(Equal(invalidUUIDb3TraceID))
+				Expect(req.Header.Get(b3.SpanID)).To(Equal(b3SpanID))
+				Expect(req.Header.Get(b3.Context)).To(Equal(invalidUUIDb3TraceID + "-" + b3SpanID))
+
+				Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+			})
+
+			It("sets request context", func() {
+				handler.ServeHTTP(resp, req, nextHandler)
+				Expect(reqInfo.TraceInfo.TraceID).NotTo(Equal(invalidUUIDb3TraceID))
+				Expect(reqInfo.TraceInfo.SpanID).NotTo(Equal(b3SpanID))
+				Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
+				Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 			})
 		})
 
@@ -193,8 +225,9 @@ var _ = Describe("Zipkin", func() {
 
 			It("sets request context", func() {
 				handler.ServeHTTP(resp, req, nextHandler)
-				Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
-				Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
+				Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 			})
 		})
 
@@ -215,8 +248,9 @@ var _ = Describe("Zipkin", func() {
 
 			It("sets request context", func() {
 				handler.ServeHTTP(resp, req, nextHandler)
-				Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
-				Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
+				Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 			})
 		})
 
@@ -237,8 +271,9 @@ var _ = Describe("Zipkin", func() {
 
 			It("sets request context", func() {
 				handler.ServeHTTP(resp, req, nextHandler)
-				Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
-				Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
+				Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 			})
 		})
 
@@ -260,8 +295,34 @@ var _ = Describe("Zipkin", func() {
 
 			It("sets request context", func() {
 				handler.ServeHTTP(resp, req, nextHandler)
-				Expect(reqInfo.TraceID).To(MatchRegexp(b3IDRegex))
-				Expect(reqInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
+				Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
+			})
+		})
+
+		Context("with B3Header which is an invalid UUID", func() {
+			BeforeEach(func() {
+				req.Header.Set(b3.Context, invalidUUIDB3Single)
+			})
+
+			It("overwrites the B3Header", func() {
+				handler.ServeHTTP(resp, req, nextHandler)
+				Expect(req.Header.Get(b3.Context)).To(Equal(invalidUUIDB3Single))
+				Expect(req.Header.Get(b3.TraceID)).To(BeEmpty())
+				Expect(req.Header.Get(b3.SpanID)).To(BeEmpty())
+				Expect(req.Header.Get(b3.ParentSpanID)).To(BeEmpty())
+
+				Expect(nextCalled).To(BeTrue(), "Expected the next handler to be called.")
+			})
+
+			It("sets request context", func() {
+				handler.ServeHTTP(resp, req, nextHandler)
+				Expect(reqInfo.TraceInfo.TraceID).NotTo(Equal(invalidUUIDb3TraceID))
+				Expect(reqInfo.TraceInfo.SpanID).NotTo(Equal(b3SpanID))
+				Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
+				Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 			})
 		})
 	})
@@ -283,8 +344,9 @@ var _ = Describe("Zipkin", func() {
 
 		It("doesn't set trace and span IDs in request context", func() {
 			handler.ServeHTTP(resp, req, nextHandler)
-			Expect(reqInfo.TraceID).To(BeEmpty())
-			Expect(reqInfo.SpanID).To(BeEmpty())
+			Expect(reqInfo.TraceInfo.TraceID).To(BeEmpty())
+			Expect(reqInfo.TraceInfo.SpanID).To(BeEmpty())
+			Expect(reqInfo.TraceInfo.UUID).To(BeEmpty())
 		})
 	})
 })

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -168,6 +168,8 @@ func NewProxy(
 	n.Use(handlers.NewPanicCheck(p.health, logger))
 	n.Use(handlers.NewRequestInfo())
 	n.Use(handlers.NewProxyWriter(logger))
+	n.Use(zipkinHandler)
+	n.Use(w3cHandler)
 	n.Use(handlers.NewVcapRequestIdHeader(logger))
 	if cfg.SendHttpStartStopServerEvent {
 		n.Use(handlers.NewHTTPStartStop(dropsonde.DefaultEmitter, logger))
@@ -182,8 +184,6 @@ func NewProxy(
 	n.Use(handlers.NewReporter(reporter, logger))
 	n.Use(handlers.NewHTTPRewriteHandler(cfg.HTTPRewrite, headersToAlwaysRemove))
 	n.Use(handlers.NewProxyHealthcheck(cfg.HealthCheckUserAgent, p.health, logger))
-	n.Use(zipkinHandler)
-	n.Use(w3cHandler)
 	n.Use(handlers.NewProtocolCheck(logger, errorWriter, cfg.EnableHTTP2))
 	n.Use(handlers.NewLookup(registry, reporter, logger, errorWriter, cfg.EmptyPoolResponseCode503))
 	n.Use(handlers.NewMaxRequestSize(cfg, logger))


### PR DESCRIPTION
**A short explanation of the proposed change:**

Every request handler in the Gorouter now adds unique trace and span ID to the logs. 

Trace and span IDs are consolidated from B3, W3C and VCAP_REQUEST_ID headers.

Details on how consolidation of headers works:

- If B3 headers are set by user and zipkin is enabled in Gorouter, if they can be parsed as valid UUID, they will be used for trace and span ID as well as for VCAP_REQUEST_ID and W3C ID.
- If B3 headers are not set and zipkin is enabled, Gorouter will generate trace and span ID. They will be used for B3, VCAP_REQUEST_ID and W3C ID.
- If zipkin is disabled, and W3C headers are set by user and W3C is enabled in the Gorouter, W3C headers will be used as trace and span ID as well as for VCAP_REQUEST_ID.
- If W3C headers are not set by user and W3C is enabled in the Gorouter, W3C headers will be generated in the Gorouter and set as trace and span ID as well as for VCAP_REQUEST_ID.
- VCAP_REQUEST_ID cannot be set by user. It will be generated and used as trace and span ID if zipkin and W3C are disabled in the gorouter.

**An explanation of the use cases your change solves**

It would be easier to trace a specific request across multiple logs - gorouter.log, gorouter.err.log, access.log. In the future, the same trace ID will be used for the logs that follows a transaction in the system across multiple components (Cloud Controller, BBS, Rep, Garden) like cf push. This trace ID can be used to search all related logs to the transaction in log accumulating systems like splunk.

**Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)**

```
$ curl api.cf-app.com
```

On the gorouter VM, tail all logs in `/var/vcap/sys/log/gorouter`. See logs contain:

```
"data":{"trace-id":"25f23d6af46d460e71357ddc0759a198","span-id":"71357ddc0759a198"}
```
**Expected result after the change**

All gorouter logs related to request handling have trace and span ID.

**Current result before the change**

Only access.log contain request ID.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
