### PR TITLE
Update integration test for newer go-metric-registry versions

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -729,7 +729,7 @@ var _ = Describe("Router Integration", func() {
 			response, err := ioutil.ReadAll(r.Body)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(string(response)).To(ContainSubstring("process_resident_memory_bytes"))
+			Expect(string(response)).To(ContainSubstring("promhttp_metric_handler_errors_total"))
 		})
 	})
 


### PR DESCRIPTION
Change response expectations for newer versions of go-metric-registry

Context: https://vmware.slack.com/archives/C02P4E4R8FJ/p1683301765432339