### PR TITLE
fix: do not retry if context has been cancelled

### DIFF
--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -441,6 +441,11 @@ func isIdempotent(request *http.Request) bool {
 }
 
 func (rt *roundTripper) isRetriable(request *http.Request, err error, trace *requestTracer) (bool, error) {
+	// if the context has been cancelled we do not perform further retries
+	if request.Context().Err() != nil {
+		return false, fmt.Errorf("%w (%w)", request.Context().Err(), err)
+	}
+
 	// io.EOF errors are considered safe to retry for certain requests
 	// Replace the error here to track this state when classifying later.
 	if err == io.EOF && isIdempotent(request) {


### PR DESCRIPTION
The additional retry logic introduced by #337 caused any error to become retry-able if the request did not make it to the back end. This included errors that came from context cancellation. This commit makes requests non-retry-able as soon as the context has been cancelled.

See related Slack discussion: https://cloudfoundry.slack.com/archives/C01ABMVNE9E/p1683313910835329

* [X] I have viewed signed and have submitted the Contributor License Agreement
* [X] I have made this pull request to the `main` branch
* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).
* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite
* [ ] (Optional) I have run CF Acceptance Tests on bosh lite