### PR TITLE
Set ExpectContinueTimeout to 1 sec, like default transport does

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -111,23 +111,25 @@ func NewProxy(
 
 	roundTripperFactory := &round_tripper.FactoryImpl{
 		BackendTemplate: &http.Transport{
-			DialContext:         dialer.DialContext,
-			DisableKeepAlives:   cfg.DisableKeepAlives,
-			MaxIdleConns:        cfg.MaxIdleConns,
-			IdleConnTimeout:     90 * time.Second, // setting the value to golang default transport
-			MaxIdleConnsPerHost: cfg.MaxIdleConnsPerHost,
-			DisableCompression:  true,
-			TLSClientConfig:     backendTLSConfig,
-			TLSHandshakeTimeout: cfg.TLSHandshakeTimeout,
+			DialContext:           dialer.DialContext,
+			DisableKeepAlives:     cfg.DisableKeepAlives,
+			MaxIdleConns:          cfg.MaxIdleConns,
+			IdleConnTimeout:       90 * time.Second, // setting the value to golang default transport
+			MaxIdleConnsPerHost:   cfg.MaxIdleConnsPerHost,
+			DisableCompression:    true,
+			TLSClientConfig:       backendTLSConfig,
+			TLSHandshakeTimeout:   cfg.TLSHandshakeTimeout,
+			ExpectContinueTimeout: 1 * time.Second,
 		},
 		RouteServiceTemplate: &http.Transport{
-			DialContext:         dialer.DialContext,
-			DisableKeepAlives:   cfg.DisableKeepAlives,
-			MaxIdleConns:        cfg.MaxIdleConns,
-			IdleConnTimeout:     90 * time.Second, // setting the value to golang default transport
-			MaxIdleConnsPerHost: cfg.MaxIdleConnsPerHost,
-			DisableCompression:  true,
-			TLSClientConfig:     routeServiceTLSConfig,
+			DialContext:           dialer.DialContext,
+			DisableKeepAlives:     cfg.DisableKeepAlives,
+			MaxIdleConns:          cfg.MaxIdleConns,
+			IdleConnTimeout:       90 * time.Second, // setting the value to golang default transport
+			MaxIdleConnsPerHost:   cfg.MaxIdleConnsPerHost,
+			DisableCompression:    true,
+			TLSClientConfig:       routeServiceTLSConfig,
+			ExpectContinueTimeout: 1 * time.Second,
 		},
 		IsInstrumented: cfg.SendHttpStartStopClientEvent,
 	}

--- a/proxy/round_tripper/dropsonde_round_tripper.go
+++ b/proxy/round_tripper/dropsonde_round_tripper.go
@@ -45,15 +45,16 @@ func (t *FactoryImpl) New(expectedServerName string, isRouteService bool, isHttp
 	customTLSConfig := utils.TLSConfigWithServerName(expectedServerName, template.TLSClientConfig, isRouteService)
 
 	newTransport := &http.Transport{
-		DialContext:         template.DialContext,
-		DisableKeepAlives:   template.DisableKeepAlives,
-		MaxIdleConns:        template.MaxIdleConns,
-		IdleConnTimeout:     template.IdleConnTimeout,
-		MaxIdleConnsPerHost: template.MaxIdleConnsPerHost,
-		DisableCompression:  template.DisableCompression,
-		TLSClientConfig:     customTLSConfig,
-		TLSHandshakeTimeout: template.TLSHandshakeTimeout,
-		ForceAttemptHTTP2:   isHttp2,
+		DialContext:           template.DialContext,
+		DisableKeepAlives:     template.DisableKeepAlives,
+		MaxIdleConns:          template.MaxIdleConns,
+		IdleConnTimeout:       template.IdleConnTimeout,
+		MaxIdleConnsPerHost:   template.MaxIdleConnsPerHost,
+		DisableCompression:    template.DisableCompression,
+		TLSClientConfig:       customTLSConfig,
+		TLSHandshakeTimeout:   template.TLSHandshakeTimeout,
+		ForceAttemptHTTP2:     isHttp2,
+		ExpectContinueTimeout: template.ExpectContinueTimeout,
 	}
 	if t.IsInstrumented {
 		return NewDropsondeRoundTripper(newTransport)


### PR DESCRIPTION
There has been a change of behavior between go 1.19 and go 1.20, which now requires us to set this. 