### PR TITLE
put final status code in access logs, not 1XX

### DIFF
--- a/proxy/utils/responsewriter.go
+++ b/proxy/utils/responsewriter.go
@@ -89,7 +89,7 @@ func (p *proxyResponseWriter) WriteHeader(s int) {
 
 	p.w.WriteHeader(s)
 
-	if p.status == 0 {
+	if p.status == 0 || (p.status >= 100 && p.status <= 199) {
 		p.status = s
 	}
 }

--- a/proxy/utils/responsewriter_test.go
+++ b/proxy/utils/responsewriter_test.go
@@ -154,6 +154,14 @@ var _ = Describe("ProxyWriter", func() {
 		Expect(proxy.Status()).To(Equal(http.StatusTeapot))
 	})
 
+	It("WriteHeader rewrites the status if the original status was 1XX", func() {
+		Expect(proxy.Status()).To(Equal(0))
+		proxy.WriteHeader(http.StatusContinue)
+		Expect(proxy.Status()).To(Equal(http.StatusContinue))
+		proxy.WriteHeader(http.StatusOK)
+		Expect(proxy.Status()).To(Equal(http.StatusOK))
+	})
+
 	It("delegates the call to Write", func() {
 		l, err := proxy.Write([]byte("foo"))
 		Expect(l).To(BeNumerically("==", 3))


### PR DESCRIPTION
A 1xx Informational status code means that the server has received the request and is continuing the process. A 1xx status code is purely temporary and is given while the request processing continues.

After a response with a 1XX status code, there should always be a reponse after it. We shouldn't hide the status of the "real" response.

This change makes gorouter backwards compatible with how the access logs and 1XX responses worked before we bumped to go 1.20.