### PR TITLE
feat(gorouter): retry requests on 529 status code.

### DIFF
--- a/proxy/fails/basic_classifiers.go
+++ b/proxy/fails/basic_classifiers.go
@@ -13,6 +13,8 @@ var IdempotentRequestEOFError = errors.New("EOF (via idempotent request)")
 
 var IncompleteRequestError = errors.New("incomplete request")
 
+var BackendOverloadedError = errors.New("backend overloaded")
+
 var AttemptedTLSWithNonTLSBackend = ClassifierFunc(func(err error) bool {
 	return errors.As(err, &tls.RecordHeaderError{})
 })
@@ -85,4 +87,8 @@ var IdempotentRequestEOF = ClassifierFunc(func(err error) bool {
 
 var IncompleteRequest = ClassifierFunc(func(err error) bool {
 	return errors.Is(err, IncompleteRequestError)
+})
+
+var BackendOverloaded = ClassifierFunc(func(err error) bool {
+	return errors.Is(err, BackendOverloadedError)
 })

--- a/proxy/fails/basic_classifiers.go
+++ b/proxy/fails/basic_classifiers.go
@@ -15,6 +15,8 @@ var IncompleteRequestError = errors.New("incomplete request")
 
 var BackendOverloadedError = errors.New("backend overloaded")
 
+var BackendOverloadedNotRetriableError = errors.New("backend overloaded (retry failed, request too large)")
+
 var AttemptedTLSWithNonTLSBackend = ClassifierFunc(func(err error) bool {
 	return errors.As(err, &tls.RecordHeaderError{})
 })

--- a/proxy/fails/classifier_group.go
+++ b/proxy/fails/classifier_group.go
@@ -21,6 +21,7 @@ var RetriableClassifiers = ClassifierGroup{
 	ExpiredOrNotYetValidCertFailure,
 	IdempotentRequestEOF,
 	IncompleteRequest,
+	BackendOverloaded,
 }
 
 var FailableClassifiers = ClassifierGroup{

--- a/proxy/round_tripper/error_handler.go
+++ b/proxy/round_tripper/error_handler.go
@@ -37,6 +37,7 @@ var DefaultErrorSpecs = []ErrorSpec{
 	{fails.RemoteFailedCertCheck, SSLCertRequiredMessage, 496, nil},
 	{fails.ContextCancelled, ContextCancelledMessage, 499, nil},
 	{fails.RemoteHandshakeFailure, SSLHandshakeMessage, 525, handleSSLHandshake},
+	{fails.BackendOverloaded, ServiceIsOverloaded, 529, nil},
 }
 
 type ErrorHandler struct {

--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -30,6 +30,7 @@ const (
 	HostnameErrorMessage      = "503 Service Unavailable"
 	InvalidCertificateMessage = "526 Invalid SSL Certificate"
 	SSLHandshakeMessage       = "525 SSL Handshake Failed"
+	ServiceIsOverloaded       = "529 The Service is Overloaded"
 	SSLCertRequiredMessage    = "496 SSL Certificate Required"
 	ContextCancelledMessage   = "499 Request Cancelled"
 	HTTP2Protocol             = "http2"
@@ -369,6 +370,11 @@ func (rt *roundTripper) timedRoundTrip(tr http.RoundTripper, request *http.Reque
 	if err != nil {
 		cancel()
 		return nil, err
+	}
+	if resp.StatusCode == 529 {
+		// special case: the backend says it's overloaded
+		cancel()
+		return nil, fails.BackendOverloadedError
 	}
 
 	return resp, err

--- a/proxy/round_tripper/rewind.go
+++ b/proxy/round_tripper/rewind.go
@@ -1,0 +1,41 @@
+package round_tripper
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+)
+
+const rewindableContentLengthLimit = 1 << 20 // 1M
+
+// A rewindableBody is used to re-read a http.Request's body on retries
+type rewindableBody []byte
+
+// tryPreBufferBody tries to pre-buffer an incoming request's body into a byte array.
+// The array can be used to reset the request's body later.
+func tryPreBufferBody(req *http.Request) (*rewindableBody, error) {
+	if req.Body == nil {
+		return nil, nil
+	}
+
+	if req.ContentLength == 0 || req.ContentLength > rewindableContentLengthLimit {
+		return nil, nil
+	}
+
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	body := rewindableBody(data)
+
+	return &body, nil
+}
+
+// rewindRequest resets a request's body so that it can be read again.
+func (body *rewindableBody) rewindRequest(req *http.Request) {
+	if req.Body != nil {
+		_ = req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(*body))
+	}
+}


### PR DESCRIPTION
* A short explanation of the proposed change:

Some users want to fine-grain the flow of requests to their apps.
Concrete example: An app can take one request, but is then busy for a while so it wants the client to go to another instance.
Usually, you would send a `429 Too many requests` and let the client do a retry.
However, in this case the client can't retry on a different instance, because Gorouter selects the instance.

This change makes it transparent for the client in that a backend may opt to send a `529 Service is overloaded` as a hint for gorouter to try another instance. The client does not need special coding, unless *all* of the backends are overloaded (in which case the 529 will be forwarded to the client). By default, gorouter will transparently retry on 529s as if any other retry-able error had occurred.

* An explanation of the use cases your change solves
See above. App users want to be able to tell gorouter deliberately to retry another instance.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
tbd

* Expected result after the change
Gorouter retries on 529s

* Current result before the change
Gorouter ignores 592s

* Links to any other associated PRs
n/a

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
