### PR TITLE
fix: prevent side-effects of additional retry-able errors

### DIFF
--- a/proxy/fails/classifier_group.go
+++ b/proxy/fails/classifier_group.go
@@ -24,11 +24,27 @@ var RetriableClassifiers = ClassifierGroup{
 }
 
 var FailableClassifiers = ClassifierGroup{
-	RetriableClassifiers,
+	Dial,
+	AttemptedTLSWithNonTLSBackend,
+	HostnameMismatch,
+	RemoteFailedCertCheck,
+	RemoteHandshakeFailure,
+	RemoteHandshakeTimeout,
+	UntrustedCert,
+	ExpiredOrNotYetValidCertFailure,
 	ConnectionResetOnRead,
 }
 
-var PrunableClassifiers = RetriableClassifiers
+var PrunableClassifiers = ClassifierGroup{
+	Dial,
+	AttemptedTLSWithNonTLSBackend,
+	HostnameMismatch,
+	RemoteFailedCertCheck,
+	RemoteHandshakeFailure,
+	RemoteHandshakeTimeout,
+	UntrustedCert,
+	ExpiredOrNotYetValidCertFailure,
+}
 
 // Classify returns true on errors that are retryable
 func (cg ClassifierGroup) Classify(err error) bool {

--- a/proxy/fails/classifier_group_test.go
+++ b/proxy/fails/classifier_group_test.go
@@ -56,7 +56,7 @@ var _ = Describe("ClassifierGroup", func() {
 	})
 
 	Describe("prunable", func() {
-		It("matches hostname mismatch", func() {
+		It("matches prunable errors", func() {
 			pc := fails.PrunableClassifiers
 
 			Expect(pc.Classify(&net.OpError{Op: "dial"})).To(BeTrue())
@@ -69,8 +69,6 @@ var _ = Describe("ClassifierGroup", func() {
 			Expect(pc.Classify(x509.UnknownAuthorityError{})).To(BeTrue())
 			Expect(pc.Classify(x509.CertificateInvalidError{Reason: x509.Expired})).To(BeTrue())
 			Expect(pc.Classify(errors.New("i'm a potato"))).To(BeFalse())
-			Expect(pc.Classify(fails.IdempotentRequestEOFError)).To(BeTrue())
-			Expect(pc.Classify(fails.IncompleteRequestError)).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
* A short explanation of the proposed change:

This commit removes `IdempotentRequestEOF` and `IncompleteRequest` from the fail-able and prune-able classifier group. This prevents errors that should not affect the endpoint from being marked as failed or being pruned. To do so all classifiers groups are split into distinct groups and any cross references between them are removed.

The main motivation for this change is to avoid confusion and bugs due to artificial dependencies between the groups.

* An explanation of the use cases your change solves

Developer efficiency?

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

None, change is internal.

* Expected result after the change

N/A.

* Current result before the change

N/A.

* Links to any other associated PRs

N/A.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
