### PR TITLE
Continue to forward relevant headers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -227,6 +227,7 @@ type Config struct {
 	ForwardedClientCert      string   `yaml:"forwarded_client_cert,omitempty"`
 	ForceForwardedProtoHttps bool     `yaml:"force_forwarded_proto_https,omitempty"`
 	SanitizeForwardedProto   bool     `yaml:"sanitize_forwarded_proto,omitempty"`
+	HopByHopHeadersToFilter  []string `yaml:"hop_by_hop_headers_to_filter"`
 	IsolationSegments        []string `yaml:"isolation_segments,omitempty"`
 	RoutingTableShardingMode string   `yaml:"routing_table_sharding_mode,omitempty"`
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1545,6 +1545,18 @@ enable_http2: false
 			})
 		})
 
+		Context("hop_by_hop_headers_to_filter", func() {
+			It("setting hop_by_hop_headers_to_filter succeeds", func() {
+				var b = []byte(fmt.Sprintf(`
+hop_by_hop_headers_to_filter: [ "X-ME", "X-Foo" ]
+`))
+				err := config.Initialize(b)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(config.Process()).To(Succeed())
+				Expect(config.HopByHopHeadersToFilter).To(Equal([]string{"X-ME", "X-Foo"}))
+			})
+		})
+
 		Context("When given a routing_table_sharding_mode that is supported ", func() {
 			Context("sharding mode `all`", func() {
 				It("succeeds", func() {

--- a/integration/header_test.go
+++ b/integration/header_test.go
@@ -65,6 +65,7 @@ var _ = Describe("Headers", func() {
 
 	Context("Keeps relevant headers", func() {
 		BeforeEach(func() {
+			testState.cfg.HopByHopHeadersToFilter = []string{"X-Forwarded-Proto"}
 			testApp = NewUnstartedTestApp(http.HandlerFunc(
 				func(w http.ResponseWriter, r *http.Request) {
 					defer GinkgoRecover()

--- a/proxy/handler/request_handler.go
+++ b/proxy/handler/request_handler.go
@@ -169,6 +169,9 @@ func (h *RequestHandler) HandleWebSocketRequest(iter route.EndpointIterator) {
 }
 
 func (h *RequestHandler) SanitizeRequestConnection() {
+	if len(h.hopByHopHeadersToFilter) == 0 {
+		return
+	}
 	connections := h.request.Header.Values("Connection")
 	for index, connection := range connections {
 		if connection != "" {

--- a/proxy/handler/request_handler_test.go
+++ b/proxy/handler/request_handler_test.go
@@ -50,6 +50,7 @@ var _ = Describe("RequestHandler", func() {
 				req, pr,
 				&metric.FakeProxyReporter{}, logger, ew,
 				time.Second*2, time.Second*2, 3, &tls.Config{},
+				nil,
 				handler.DisableXFFLogging(true),
 			)
 		})
@@ -98,6 +99,7 @@ var _ = Describe("RequestHandler", func() {
 				req, pr,
 				&metric.FakeProxyReporter{}, logger, ew,
 				time.Second*2, time.Second*2, 3, &tls.Config{},
+				nil,
 				handler.DisableSourceIPLogging(true),
 			)
 		})
@@ -134,6 +136,19 @@ var _ = Describe("RequestHandler", func() {
 	})
 
 	Context("when connection header has forbidden values", func() {
+		var hopByHopHeadersToFilter []string
+		BeforeEach(func() {
+			hopByHopHeadersToFilter = []string{
+				"X-Forwarded-For",
+				"X-Forwarded-Proto",
+				"B3",
+				"X-B3",
+				"X-B3-SpanID",
+				"X-B3-TraceID",
+				"X-Request-Start",
+				"X-Forwarded-Client-Cert",
+			}
+		})
 		Context("For a single Connection header", func() {
 			BeforeEach(func() {
 				req = &http.Request{
@@ -164,6 +179,7 @@ var _ = Describe("RequestHandler", func() {
 					req, pr,
 					&metric.FakeProxyReporter{}, logger, ew,
 					time.Second*2, time.Second*2, 3, &tls.Config{},
+					hopByHopHeadersToFilter,
 					handler.DisableSourceIPLogging(true),
 				)
 			})
@@ -206,6 +222,7 @@ var _ = Describe("RequestHandler", func() {
 					req, pr,
 					&metric.FakeProxyReporter{}, logger, ew,
 					time.Second*2, time.Second*2, 3, &tls.Config{},
+					hopByHopHeadersToFilter,
 					handler.DisableSourceIPLogging(true),
 				)
 			})

--- a/proxy/handler/request_handler_test.go
+++ b/proxy/handler/request_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/gorouter/errorwriter"
@@ -128,6 +129,94 @@ var _ = Describe("RequestHandler", func() {
 			It("does not include the RemoteAddr header in log output", func() {
 				rh.HandleWebSocketRequest(&iter.FakeEndpointIterator{})
 				Eventually(logger.Buffer()).Should(gbytes.Say(`"RemoteAddr":"-"`))
+			})
+		})
+	})
+
+	Context("when connection header has forbidden values", func() {
+		Context("For a single Connection header", func() {
+			BeforeEach(func() {
+				req = &http.Request{
+					RemoteAddr: "downtown-nino-brown",
+					Host:       "gersh",
+					URL: &url.URL{
+						Path: "/foo",
+					},
+					Header: http.Header{},
+				}
+				values := []string{
+					"Content-Type",
+					"User-Agent",
+					"X-Forwarded-Proto",
+					"Accept",
+					"X-B3-Spanid",
+					"X-B3-Traceid",
+					"B3",
+					"X-Request-Start",
+					"Cookie",
+					"X-Cf-Applicationid",
+					"X-Cf-Instanceid",
+					"X-Cf-Instanceindex",
+					"X-Vcap-Request-Id",
+				}
+				req.Header.Add("Connection", strings.Join(values, ", "))
+				rh = handler.NewRequestHandler(
+					req, pr,
+					&metric.FakeProxyReporter{}, logger, ew,
+					time.Second*2, time.Second*2, 3, &tls.Config{},
+					handler.DisableSourceIPLogging(true),
+				)
+			})
+			Describe("SanitizeRequestConnection", func() {
+				It("Filters hop-by-hop headers", func() {
+					rh.SanitizeRequestConnection()
+					Expect(req.Header.Get("Connection")).To(Equal("Content-Type, User-Agent, Accept, Cookie, X-Cf-Applicationid, X-Cf-Instanceid, X-Cf-Instanceindex, X-Vcap-Request-Id"))
+				})
+			})
+		})
+		Context("For multiple Connection headers", func() {
+			BeforeEach(func() {
+				req = &http.Request{
+					RemoteAddr: "downtown-nino-brown",
+					Host:       "gersh",
+					URL: &url.URL{
+						Path: "/foo",
+					},
+					Header: http.Header{},
+				}
+				req.Header.Add("Connection", strings.Join([]string{
+					"Content-Type",
+					"X-B3-Spanid",
+					"X-B3-Traceid",
+					"X-Request-Start",
+					"Cookie",
+					"X-Cf-Instanceid",
+					"X-Vcap-Request-Id",
+				}, ", "))
+				req.Header.Add("Connection", strings.Join([]string{
+					"Content-Type",
+					"User-Agent",
+					"X-Forwarded-Proto",
+					"Accept",
+					"X-B3-Spanid",
+					"X-Cf-Applicationid",
+					"X-Cf-Instanceindex",
+				}, ", "))
+				rh = handler.NewRequestHandler(
+					req, pr,
+					&metric.FakeProxyReporter{}, logger, ew,
+					time.Second*2, time.Second*2, 3, &tls.Config{},
+					handler.DisableSourceIPLogging(true),
+				)
+			})
+			Describe("SanitizeRequestConnection", func() {
+				It("Filters hop-by-hop headers", func() {
+					rh.SanitizeRequestConnection()
+					headers := req.Header.Values("Connection")
+					Expect(len(headers)).To(Equal(2))
+					Expect(headers[0]).To(Equal("Content-Type, Cookie, X-Cf-Instanceid, X-Vcap-Request-Id"))
+					Expect(headers[1]).To(Equal("Content-Type, User-Agent, Accept, X-Cf-Applicationid, X-Cf-Instanceindex"))
+				})
 			})
 		})
 	})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -60,6 +60,7 @@ type proxy struct {
 	disableXFFLogging        bool
 	disableSourceIPLogging   bool
 	stickySessionCookieNames config.StringSet
+	hopByHopHeadersToFilter  []string
 }
 
 func NewProxy(
@@ -102,6 +103,7 @@ func NewProxy(
 		disableXFFLogging:        cfg.Logging.DisableLogForwardedFor,
 		disableSourceIPLogging:   cfg.Logging.DisableLogSourceIP,
 		stickySessionCookieNames: cfg.StickySessionCookieNames,
+		hopByHopHeadersToFilter:  cfg.HopByHopHeadersToFilter,
 	}
 
 	dialer := &net.Dialer{
@@ -253,6 +255,7 @@ func (p *proxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.Requ
 		p.websocketDialTimeout,
 		p.maxAttempts,
 		p.backendTLSConfig,
+		p.hopByHopHeadersToFilter,
 		handler.DisableXFFLogging(p.disableXFFLogging),
 		handler.DisableSourceIPLogging(p.disableSourceIPLogging),
 	)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -277,6 +277,7 @@ func (p *proxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.Requ
 		},
 	}
 
+	handler.SanitizeRequestConnection()
 	if handlers.IsWebSocketUpgrade(request) {
 		handler.HandleWebSocketRequest(endpointIterator)
 		return


### PR DESCRIPTION
by removing hop-by-hop headers that could interfere with gorouter.

Context:
    - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection
    - https://nathandavison.com/blog/abusing-http-hop-by-hop-request-headers

The following list of keywords are removed from Connection header, so that gorouter can continue to utilize those headers when they are set and will continue to forward them down to the relavant handlers.

nits: Use io.ReadAll instead of ioutil since that's been the default as of Go1.16