### PR TITLE
Update example.yml

### DIFF
--- a/example_config/example.yml
+++ b/example_config/example.yml
@@ -4,10 +4,11 @@ status:
   pass:
 
 nats:
-  - host: "localhost"
-    port: 4222
-    user:
-    pass:
+  hosts:
+    - hostname: localhost
+      port: 4222
+  user:
+  pass:
 
 logging:
   file:


### PR DESCRIPTION
The example config does no longer match the expected structure for `nats`.

This change was introduced here https://github.com/cloudfoundry/gorouter/commit/c69a1e19bd1c14ec8c35b5d074dff7214a5caa6a but not reflected in the example config.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [ ] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
