### PR TITLE
refactor(proxy): Replace duplicated properties with config references.

### DIFF
--- a/proxy/modifyresponse.go
+++ b/proxy/modifyresponse.go
@@ -31,8 +31,8 @@ func (p *proxy) modifyResponse(res *http.Response) error {
 		return errors.New("reqInfo.RoutePool is empty on a successful response")
 	}
 
-	if p.traceKey != "" && req.Header.Get(router_http.VcapTraceHeader) == p.traceKey {
-		res.Header.Set(router_http.VcapRouterHeader, p.ip)
+	if p.config.TraceKey != "" && req.Header.Get(router_http.VcapTraceHeader) == p.config.TraceKey {
+		res.Header.Set(router_http.VcapRouterHeader, p.config.Ip)
 		res.Header.Set(router_http.VcapBackendHeader, endpoint.CanonicalAddr())
 		res.Header.Set(router_http.CfRouteEndpointHeader, endpoint.CanonicalAddr())
 	}

--- a/proxy/modifyresponse_unit_test.go
+++ b/proxy/modifyresponse_unit_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"code.cloudfoundry.org/gorouter/config"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -20,7 +21,7 @@ var _ = Describe("modifyResponse", func() {
 		reqInfo *handlers.RequestInfo
 	)
 	BeforeEach(func() {
-		p = &proxy{}
+		p = &proxy{config: &config.Config{}}
 		rw := httptest.NewRecorder()
 		rw.WriteHeader(http.StatusOK)
 		resp = rw.Result()
@@ -111,7 +112,7 @@ var _ = Describe("modifyResponse", func() {
 		Context("when trace key is provided", func() {
 			Context("when X-Vcap-Trace does not match", func() {
 				BeforeEach(func() {
-					p.traceKey = "other-key"
+					p.config.TraceKey = "other-key"
 				})
 				It("does not add any headers", func() {
 					err := p.modifyResponse(resp)
@@ -123,8 +124,8 @@ var _ = Describe("modifyResponse", func() {
 			})
 			Context("when X-Vcap-Trace does match", func() {
 				BeforeEach(func() {
-					p.traceKey = "trace-key"
-					p.ip = "1.1.1.1"
+					p.config.TraceKey = "trace-key"
+					p.config.Ip = "1.1.1.1"
 				})
 				It("adds the Vcap Trace headers", func() {
 					err := p.modifyResponse(resp)


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:
Proxy and Roundtripper have lots of field that are basically just duplicated config properties. Adding a new config property and making use of it in either of them adds a lot of boiler plate code just to duplicate and copy the config property into a matching proxy / roundtripper property with no added value. If at all, confusion is added as to where the source value came from.

I've touched Proxy and RoundTripper in this change but there are probably more of those lurking in the code.

* An explanation of the use cases your change solves
By adding a reference to the gorouter config and directly using it to read config values where they are needed, the intermediate duplicate & copy step is avoided which should lead to less clutter and more clarity overall.

No functional changes were made, this is a pure refactor change.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)
run test suites. nothing should break.

* Expected result after the change
n/a

* Current result before the change
n/a
* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have run all the unit tests using `scripts/run-unit-tests-in-docker` from [routing-release](https://github.com/cloudfoundry/routing-release).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests on bosh lite

* [ ] (Optional) I have run CF Acceptance Tests on bosh lite
