### PR TITLE
Check for more details certificate errors introduced in go 1.21

### DIFF
--- a/proxy/fails/basic_classifiers.go
+++ b/proxy/fails/basic_classifiers.go
@@ -40,7 +40,13 @@ var ConnectionResetOnRead = ClassifierFunc(func(err error) bool {
 var RemoteFailedCertCheck = ClassifierFunc(func(err error) bool {
 	var opErr *net.OpError
 	if errors.As(err, &opErr) {
-		return opErr.Op == "remote error" && opErr.Err.Error() == "tls: bad certificate"
+		if opErr.Op == "remote error" {
+			if opErr.Err.Error() == "tls: bad certificate" ||
+				opErr.Err.Error() == "tls: unknown certificate authority" ||
+				opErr.Err.Error() == "tls: certificate required" {
+				return true
+			}
+		}
 	}
 	return false
 })


### PR DESCRIPTION
Go 1.21 now returns some more detailed certificate errors when the client certificate is invalid.

See more https://go.dev/doc/go1.21

```
The TLS alert codes sent from the server for client authentication failures have been improved. Previously, these failures always resulted in a "bad certificate" alert. Now, certain failures will result in more appropriate alert codes, as defined by RFC 5246 and RFC 8446:

For TLS 1.3 connections, if the server is configured to require client authentication using [RequireAnyClientCert](https://go.dev/pkg/crypto/tls/#RequireAnyClientCert) or [RequireAndVerifyClientCert](https://go.dev/pkg/crypto/tls/#RequireAndVerifyClientCert), and the client does not provide any certificate, the server will now return the "certificate required" alert.
If the client provides a certificate that is not signed by the set of trusted certificate authorities configured on the server, the server will return the "unknown certificate authority" alert.
If the client provides a certificate that is either expired or not yet valid, the server will return the "expired certificate" alert.
In all other scenarios related to client authentication failures, the server still returns "bad certificate".
```

Now checking for `unknown certificate authority` and `certificate required` errors as well. Expired certificate error is already being validated by [ExpiredOrNotYetValidCertFailure](https://github.com/cloudfoundry/gorouter/blob/main/proxy/fails/basic_classifiers.go#L52) error. And everything has tests already, this change should fix them.