### PR TITLE
Check trace ID length before parsing the UUID

### DIFF
--- a/handlers/requestinfo.go
+++ b/handlers/requestinfo.go
@@ -104,22 +104,20 @@ func (r *RequestInfo) ProvideTraceInfo() (TraceInfo, error) {
 }
 
 func (r *RequestInfo) SetTraceInfo(traceID, spanID string) error {
-	guid := traceID[0:8] + "-" + traceID[8:12] + "-" + traceID[12:16] + "-" + traceID[16:20] + "-" + traceID[20:]
-	_, err := gouuid.ParseHex(guid)
-	if err == nil {
-		r.TraceInfo = TraceInfo{
-			TraceID: traceID,
-			SpanID:  spanID,
-			UUID:    guid,
+	if len(traceID) >= 20 {
+		guid := traceID[0:8] + "-" + traceID[8:12] + "-" + traceID[12:16] + "-" + traceID[16:20] + "-" + traceID[20:]
+		_, err := gouuid.ParseHex(guid)
+		if err == nil {
+			r.TraceInfo = TraceInfo{
+				TraceID: traceID,
+				SpanID:  spanID,
+				UUID:    guid,
+			}
+			return nil
 		}
-		return nil
 	}
 
-	guid, err = uuid.GenerateUUID()
-	if err != nil {
-		return err
-	}
-	traceID, spanID, err = generateTraceAndSpanIDFromGUID(guid)
+	guid, err := uuid.GenerateUUID()
 	if err != nil {
 		return err
 	}

--- a/handlers/requestinfo_test.go
+++ b/handlers/requestinfo_test.go
@@ -179,14 +179,22 @@ var _ = Describe("RequestInfo", func() {
 			})
 		})
 
-		Context("when traceID that can not be converted to UUID and spanID are provided", func() {
-			It("generates new UUID, trace and span ID", func() {
+		Context("when traceID that can not be converted to UUID provided", func() {
+			It("generates new UUID, reuses provided trace and span ID", func() {
 				requestInfo.SetTraceInfo("111111111111d1111111111111111111", "2222222222222222")
-				Expect(requestInfo.TraceInfo.TraceID).NotTo(Equal("111111111111d1111111111111111111"))
-				Expect(requestInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
-				Expect(requestInfo.TraceInfo.SpanID).NotTo(Equal("2222222222222222"))
-				Expect(requestInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				Expect(requestInfo.TraceInfo.TraceID).To(Equal("111111111111d1111111111111111111"))
+				Expect(requestInfo.TraceInfo.SpanID).To(Equal("2222222222222222"))
 				Expect(requestInfo.TraceInfo.UUID).ToNot(Equal("11111111-1111-d111-1111-111111111111"))
+				Expect(requestInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
+			})
+		})
+
+		Context("when traceID is not UUID length", func() {
+			It("generates new UUID, reuses provided trace and span ID", func() {
+				err := requestInfo.SetTraceInfo("12345", "2222222222222222")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(requestInfo.TraceInfo.TraceID).To(Equal("12345"))
+				Expect(requestInfo.TraceInfo.SpanID).To(Equal("2222222222222222"))
 				Expect(requestInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 			})
 		})

--- a/handlers/zipkin_test.go
+++ b/handlers/zipkin_test.go
@@ -200,10 +200,8 @@ var _ = Describe("Zipkin", func() {
 
 			It("sets request context", func() {
 				handler.ServeHTTP(resp, req, nextHandler)
-				Expect(reqInfo.TraceInfo.TraceID).NotTo(Equal(invalidUUIDb3TraceID))
-				Expect(reqInfo.TraceInfo.SpanID).NotTo(Equal(b3SpanID))
-				Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
-				Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
+				Expect(reqInfo.TraceInfo.TraceID).To(Equal(invalidUUIDb3TraceID))
+				Expect(reqInfo.TraceInfo.SpanID).To(Equal(b3SpanID))
 				Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 			})
 		})
@@ -318,9 +316,7 @@ var _ = Describe("Zipkin", func() {
 
 			It("sets request context", func() {
 				handler.ServeHTTP(resp, req, nextHandler)
-				Expect(reqInfo.TraceInfo.TraceID).NotTo(Equal(invalidUUIDb3TraceID))
-				Expect(reqInfo.TraceInfo.SpanID).NotTo(Equal(b3SpanID))
-				Expect(reqInfo.TraceInfo.TraceID).To(MatchRegexp(b3IDRegex))
+				Expect(reqInfo.TraceInfo.TraceID).To(Equal(invalidUUIDb3TraceID))
 				Expect(reqInfo.TraceInfo.SpanID).To(MatchRegexp(b3SpanRegex))
 				Expect(reqInfo.TraceInfo.UUID).To(MatchRegexp(UUIDRegex))
 			})


### PR DESCRIPTION
Reported here https://github.com/cloudfoundry/routing-release/issues/346

Parser for b3 trace ID header assumes the length is at least 20 characters, but b3 accepts length of 16 characters as well. Instead of throwing an error, accept b3 trace id as it was provided and it only gets validated by `b3.ParseSingleHeader`.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have gorouter unit tests

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
