### PR TITLE
fix(proxy): Count slow responses as response_time, not gorouter_time

### DIFF
--- a/accesslog/schema/access_log_record.go
+++ b/accesslog/schema/access_log_record.go
@@ -110,6 +110,7 @@ type AccessLogRecord struct {
 	RouterError            string
 	LogAttemptsDetails     bool
 	FailedAttempts         int
+	RoundTripSuccessful    bool
 	record                 []byte
 
 	// See the handlers.RequestInfo struct for details on these timings.
@@ -139,7 +140,7 @@ func (r *AccessLogRecord) gorouterTime() float64 {
 	at := r.appTime()
 
 	if rt >= 0 && at >= 0 {
-		return r.roundtripTime() - r.appTime()
+		return rt - at
 	} else {
 		return -1
 	}
@@ -182,7 +183,7 @@ func (r *AccessLogRecord) failedAttemptsTime() float64 {
 // successful. If there was a successful attempt the returned time indicates
 // how long it took.
 func (r *AccessLogRecord) successfulAttemptTime() float64 {
-	if r.AppRequestFinishedAt.Equal(r.LastFailedAttemptFinishedAt) {
+	if !r.RoundTripSuccessful {
 		return -1
 	}
 

--- a/accesslog/schema/access_log_record_test.go
+++ b/accesslog/schema/access_log_record_test.go
@@ -52,6 +52,7 @@ var _ = Describe("AccessLogRecord", func() {
 			},
 			BodyBytesSent:        23,
 			StatusCode:           200,
+			RoundTripSuccessful:  true,
 			RouteEndpoint:        endpoint,
 			ReceivedAt:           time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
 			FinishedAt:           time.Date(2000, time.January, 1, 0, 1, 0, 0, time.UTC),
@@ -490,7 +491,7 @@ var _ = Describe("AccessLogRecord", func() {
 		It("adds a '-' if there was no successful attempt", func() {
 			record.LogAttemptsDetails = true
 			record.FailedAttempts = 1
-			record.LastFailedAttemptFinishedAt = record.AppRequestFinishedAt
+			record.RoundTripSuccessful = false
 
 			var b bytes.Buffer
 			_, err := record.WriteTo(&b)

--- a/handlers/access_log.go
+++ b/handlers/access_log.go
@@ -68,6 +68,7 @@ func (a *accessLog) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http
 	alr.StatusCode = proxyWriter.Status()
 	alr.RouterError = proxyWriter.Header().Get(router_http.CfRouterError)
 	alr.FailedAttempts = reqInfo.FailedAttempts
+	alr.RoundTripSuccessful = reqInfo.RoundTripSuccessful
 
 	alr.ReceivedAt = reqInfo.ReceivedAt
 	alr.AppRequestStartedAt = reqInfo.AppRequestStartedAt

--- a/handlers/requestinfo.go
+++ b/handlers/requestinfo.go
@@ -42,8 +42,7 @@ type RequestInfo struct {
 	AppRequestStartedAt time.Time
 	// LastFailedAttemptFinishedAt is the end of the last failed request,
 	// if any. If there was at least one failed attempt this will be set, if
-	// there was no successful attempt this value will equal
-	// AppRequestFinishedAt.
+	// there was no successful attempt the RequestFailed flag will be set.
 	LastFailedAttemptFinishedAt time.Time
 
 	// These times document at which timestamps the individual phases of the
@@ -72,6 +71,9 @@ type RequestInfo struct {
 	RouteServiceURL                   *url.URL
 	ShouldRouteToInternalRouteService bool
 	FailedAttempts                    int
+
+	// RoundTripSuccessful will be set once a request has successfully reached a backend instance.
+	RoundTripSuccessful bool
 
 	TraceInfo TraceInfo
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -258,7 +258,9 @@ func (p *proxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.Requ
 		return
 	}
 
+	reqInfo.AppRequestStartedAt = time.Now()
 	next(responseWriter, request)
+	reqInfo.AppRequestFinishedAt = time.Now()
 }
 
 func (p *proxy) setupProxyRequest(target *http.Request) {

--- a/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/proxy/round_tripper/proxy_round_tripper_test.go
@@ -235,7 +235,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 					Expect(retriableClassifier.ClassifyCallCount()).To(Equal(2))
 
 					Expect(reqInfo.RouteEndpoint).To(Equal(endpoint))
-					Expect(reqInfo.AppRequestFinishedAt).To(BeTemporally("~", time.Now(), 50*time.Millisecond))
+					Expect(reqInfo.RoundTripSuccessful).To(BeTrue())
 					Expect(res.StatusCode).To(Equal(http.StatusTeapot))
 				})
 
@@ -344,7 +344,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 						Expect(retriableClassifier.ClassifyCallCount()).To(Equal(4))
 
 						Expect(reqInfo.RouteEndpoint).To(Equal(endpoint))
-						Expect(reqInfo.AppRequestFinishedAt).To(BeTemporally("~", time.Now(), 50*time.Millisecond))
+						Expect(reqInfo.RoundTripSuccessful).To(BeFalse())
 					})
 				})
 
@@ -360,7 +360,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 						Expect(retriableClassifier.ClassifyCallCount()).To(Equal(4))
 
 						Expect(reqInfo.RouteEndpoint).To(Equal(endpoint))
-						Expect(reqInfo.AppRequestFinishedAt).To(BeTemporally("~", time.Now(), 50*time.Millisecond))
+						Expect(reqInfo.RoundTripSuccessful).To(BeTrue())
 						Expect(res.StatusCode).To(Equal(http.StatusTeapot))
 					})
 				})
@@ -382,7 +382,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 					Expect(transport.RoundTripCallCount()).To(Equal(1))
 
 					Expect(reqInfo.RouteEndpoint).To(Equal(endpoint))
-					Expect(reqInfo.AppRequestFinishedAt).To(BeTemporally("~", time.Now(), 50*time.Millisecond))
+					Expect(reqInfo.RoundTripSuccessful).To(BeFalse())
 				})
 
 				It("captures each routing request to the backend", func() {
@@ -534,7 +534,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 					Expect(err).To(Equal(handler.NoEndpointsAvailable))
 
 					Expect(reqInfo.RouteEndpoint).To(BeNil())
-					Expect(reqInfo.AppRequestFinishedAt).To(BeTemporally("~", time.Now(), 50*time.Millisecond))
+					Expect(reqInfo.RoundTripSuccessful).To(BeFalse())
 				})
 
 				It("calls the error handler", func() {


### PR DESCRIPTION
* A short explanation of the proposed change:

Count backend response time towards response_time and backend_time, not gorouter_time.

Time calculation needs to happen for the entire response, including response body, not just the beginning of the response.
Therefore, the time must be taken after ReverseProxy has copied the response body and not after RoundTripper has returned, which is too early.

* An explanation of the use cases your change solves

Fixes https://github.com/cloudfoundry/routing-release/issues/348
<details><summary>Implementation Detail</summary>
<p>
I have changed the semantic of determining if all attempts have failed. It used to be if `AppRequestFinishedAt` and `LastFailedAttemptFinishedAt` timestamps are equal. This can no longer be used because we no longer set the `AppRequestFinishedAt` timestamp in `ProxyRoundTripper` but in `Proxy` after `ReverseProxy` has finished.

I found it awkward to convey the information that a request has ultimately failed by making two timestamps the same. Instead, I opted for a clear `RequestFailed` flag that is now part `RequestInfo` and will be set in `ProxyRoundTripper` and `Lookup` where we decide early on if a request can no longer make it to a backend (because the route does not exist, pool is empty, overloaded, etc.)
</p>
</details> 

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

- See "steps to reproduce" in [routing-release issue 348](https://github.com/cloudfoundry/routing-release/issues/348)
- When the fix is applies, both slow apps A and B should report about 10s `backend_time` and `response_time` but very little (sub-second) `gorouter_time` in the access log. 

* Expected result after the change

- `backend_time` now includes the time to read the complete backend response, including the body
- `gorouter_time` is no longer conflated with `backend_time` 
-  `backend_time` reports `-` (no value) if the backend could not be reached at all

* Current result before the change

- `backend_time` does not include the time to read a possible body. it only contains the round trip time
- `gorouter_time` is conflated with `backend_time`. it contains the time needed to read the response body
- `backend_time` reports `0.0000` if the backend could not be reached at all



* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
