### PR TITLE
Optional mTLS client certificate metadata verification

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -213,9 +213,9 @@ type HTTPRewriteResponses struct {
 // ValidSubjects.
 type VerifyClientCertificateMetadataRule struct {
 	// The issuer DN , for which the subject validation should apply
-	CASubject CertSubject `yaml:"ca_subject"`
+	CASubject CertSubject `yaml:"issuer_in_chain"`
 	// The subject DNs	 that are allowed to be used for mTLS connections to Gorouter
-	ValidSubjects []CertSubject `yaml:"valid_subjects"`
+	ValidSubjects []CertSubject `yaml:"valid_cert_subjects"`
 }
 
 // CertSubject defines the same fields as pkix.Name and allows YAML declaration of said fields. This is used to

--- a/config/config.go
+++ b/config/config.go
@@ -203,7 +203,7 @@ type HTTPRewriteResponses struct {
 	RemoveHeaders          []HeaderNameValue `yaml:"remove_headers,omitempty"`
 }
 
-// VerifyClientCertificateMetadata defines verification rules for client certificates, which allow additional checks
+// VerifyClientCertificateMetadataRules defines verification rules for client certificates, which allow additional checks
 // for the certificates' subject.
 //
 // A rule is applied based on the CA certificate's subject. The CA certificate is defined as part of `client_ca_certs`
@@ -247,7 +247,7 @@ func (c CertSubject) ToName() pkix.Name {
 	}
 }
 
-// VerifyClientCertMetadata checks for th certificate chain received from the tls.Config.VerifyPeerCertificate
+// VerifyClientCertMetadata checks for the certificate chain received from the tls.Config.VerifyPeerCertificate
 // function callback, whether any configured VerifyClientCertificateMetadataRule applies.
 //
 // If a rule does apply, it is evaluated.
@@ -288,7 +288,7 @@ func checkIfRuleAppliesToChain(chain []*x509.Certificate, logger logger.Logger, 
 //
 // Returns an error when:
 // * the certificate does not match any of the ValidSubjects in rule.
-// * the chain does not contain a client certificate (i.e. IsCA == false).
+// * the chain does not contain any client certificates (i.e. IsCA == false).
 func checkClientCertificateMetadataRule(chain []*x509.Certificate, logger logger.Logger, rule VerifyClientCertificateMetadataRule) error {
 	for _, cert := range chain {
 		if !cert.IsCA {
@@ -360,16 +360,16 @@ type Config struct {
 	IsolationSegments        []string `yaml:"isolation_segments,omitempty"`
 	RoutingTableShardingMode string   `yaml:"routing_table_sharding_mode,omitempty"`
 
-	CipherString                      string                                `yaml:"cipher_suites,omitempty"`
-	CipherSuites                      []uint16                              `yaml:"-"`
-	MinTLSVersionString               string                                `yaml:"min_tls_version,omitempty"`
-	MaxTLSVersionString               string                                `yaml:"max_tls_version,omitempty"`
-	MinTLSVersion                     uint16                                `yaml:"-"`
-	MaxTLSVersion                     uint16                                `yaml:"-"`
-	ClientCertificateValidationString string                                `yaml:"client_cert_validation,omitempty"`
-	ClientCertificateValidation       tls.ClientAuthType                    `yaml:"-"`
-	OnlyTrustClientCACerts            bool                                  `yaml:"only_trust_client_ca_certs"`
-	TLSHandshakeTimeout               time.Duration                         `yaml:"tls_handshake_timeout"`
+	CipherString                                    string                                `yaml:"cipher_suites,omitempty"`
+	CipherSuites                                    []uint16                              `yaml:"-"`
+	MinTLSVersionString                             string                                `yaml:"min_tls_version,omitempty"`
+	MaxTLSVersionString                             string                                `yaml:"max_tls_version,omitempty"`
+	MinTLSVersion                                   uint16                                `yaml:"-"`
+	MaxTLSVersion                                   uint16                                `yaml:"-"`
+	ClientCertificateValidationString               string                                `yaml:"client_cert_validation,omitempty"`
+	ClientCertificateValidation                     tls.ClientAuthType                    `yaml:"-"`
+	OnlyTrustClientCACerts                          bool                                  `yaml:"only_trust_client_ca_certs"`
+	TLSHandshakeTimeout                             time.Duration                         `yaml:"tls_handshake_timeout"`
 	VerifyClientCertificateMetadata   []VerifyClientCertificateMetadataRule `yaml:"verify_client_certificate_metadata,omitempty"`
 
 	LoadBalancerHealthyThreshold    time.Duration `yaml:"load_balancer_healthy_threshold,omitempty"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1408,10 +1408,11 @@ route_services_secret_decrypt_only: 1PfbARmvIn6cgyKorA1rqR2d34rBOo+z3qJGz17pi8Y=
 
 					configSnippet.CACerts = []string{string(rootRSAPEM), string(rootECDSAPEM)}
 				})
-				Context("when verify_client_certificate_metadata is provided and one of the CA subjects is not in the ClientCAPool", func() {
+				Context("when verify_client_certificate_metadata is enabled, and one of the provided CA subjects is not in the ClientCAPool", func() {
 					BeforeEach(func() {
 						configSnippet.ClientCACerts = string(clientRSAPEM)
-						configSnippet.VerifyClientCertificateMetadata = []VerifyClientCertificateMetadataRule{
+						configSnippet.VerifyClientCertificatesBasedOnProvidedMetadata = true
+						configSnippet.VerifyClientCertificateMetadataRules = []VerifyClientCertificateMetadataRule{
 							{
 								CASubject:     CertSubject{CommonName: "abc.com"},
 								ValidSubjects: []CertSubject{CertSubject{Organization: []string{"abc, Inc."}}},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1418,7 +1418,7 @@ route_services_secret_decrypt_only: 1PfbARmvIn6cgyKorA1rqR2d34rBOo+z3qJGz17pi8Y=
 							},
 						}
 					})
-					It("fails to validate", func() {
+					It("returns a meaningful error", func() {
 						configBytes := createYMLSnippet(configSnippet)
 						err := config.Initialize(configBytes)
 						Expect(err).ToNot(HaveOccurred())

--- a/router/router.go
+++ b/router/router.go
@@ -240,7 +240,7 @@ func (r *Router) serveHTTPS(server *http.Server, errChan chan error) error {
 		ClientAuth:   r.config.ClientCertificateValidation,
 	}
 
-	if r.config.VerifyClientCertificateMetadata != nil {
+	if r.config.VerifyClientCertificatesBasedOnProvidedMetadata && r.config.VerifyClientCertificateMetadataRules != nil {
 		tlsConfig.VerifyPeerCertificate = r.verifyMtlsMetadata
 	}
 
@@ -279,12 +279,12 @@ func (r *Router) serveHTTPS(server *http.Server, errChan chan error) error {
 	return nil
 }
 
-// verifyMtlsMetadata checks the Config.VerifyClientCertificateMetadata rules, if any are defined.
+// verifyMtlsMetadata checks the Config.VerifyClientCertificateMetadataRules rules, if any are defined.
 //
 // Returns an error if one of the applicable verification rules fails.
 func (r *Router) verifyMtlsMetadata(_ [][]byte, chains [][]*x509.Certificate) error {
 	if chains != nil {
-		return config.VerifyClientCertMetadata(r.config.VerifyClientCertificateMetadata, chains, r.logger)
+		return config.VerifyClientCertMetadata(r.config.VerifyClientCertificateMetadataRules, chains, r.logger)
 	}
 	return nil
 }

--- a/router/router.go
+++ b/router/router.go
@@ -286,7 +286,6 @@ func (r *Router) verifyMtlsMetadata(_ [][]byte, chains [][]*x509.Certificate) er
 	if chains != nil {
 		return config.VerifyClientCertMetadata(r.config.VerifyClientCertificateMetadata, chains, r.logger)
 	}
-	fmt.Printf("Chains length %d", len(chains))
 	return nil
 }
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1866,7 +1866,8 @@ var _ = Describe("Router", func() {
 						Context("when verify_client_certificate_metadata is provided ", func() {
 							Context("when the client cert subject is one of the valid subjects for the specified CA subject", func() {
 								BeforeEach(func() {
-									config.VerifyClientCertificateMetadata = []cfg.VerifyClientCertificateMetadataRule{
+									config.VerifyClientCertificatesBasedOnProvidedMetadata = true
+									config.VerifyClientCertificateMetadataRules = []cfg.VerifyClientCertificateMetadataRule{
 										{
 											CASubject:     cfg.CertSubject{CommonName: "xyz.com", Organization: []string{"xyz, Inc."}},
 											ValidSubjects: []cfg.CertSubject{cfg.CertSubject{Organization: []string{"xyz, Inc."}, CommonName: "xyz.com"}},
@@ -1879,7 +1880,8 @@ var _ = Describe("Router", func() {
 							})
 							Context("when the client cert subject is not in the valid subjects for the specified CA subject", func() {
 								BeforeEach(func() {
-									config.VerifyClientCertificateMetadata = []cfg.VerifyClientCertificateMetadataRule{
+									config.VerifyClientCertificatesBasedOnProvidedMetadata = true
+									config.VerifyClientCertificateMetadataRules = []cfg.VerifyClientCertificateMetadataRule{
 										{
 											CASubject:     cfg.CertSubject{CommonName: "xyz.com", Organization: []string{"xyz, Inc."}},
 											ValidSubjects: []cfg.CertSubject{cfg.CertSubject{Organization: []string{"invalid."}}},
@@ -1904,9 +1906,40 @@ var _ = Describe("Router", func() {
 									Expect(resp).To(BeNil())
 								})
 							})
+							Context("when the client cert subject is not an exact match for the valid subjects for the specified CA subject", func() {
+								BeforeEach(func() {
+									config.VerifyClientCertificatesBasedOnProvidedMetadata = true
+									config.VerifyClientCertificateMetadataRules = []cfg.VerifyClientCertificateMetadataRule{
+										{
+											CASubject: cfg.CertSubject{CommonName: "xyz.com", Organization: []string{"xyz, Inc."}},
+											ValidSubjects: []cfg.CertSubject{
+												{CommonName: "xyz.com"},
+											},
+										},
+									}
+								})
+								It("unsuccessfully serves SSL traffic", func() {
+									app := test.NewGreetApp([]route.Uri{"test." + test_util.LocalhostDNS}, config.Port, mbusClient, nil)
+									app.RegisterAndListen()
+									Eventually(func() bool {
+										return appRegistered(registry, app)
+									}).Should(BeTrue())
+
+									uri := fmt.Sprintf("https://test.%s:%d/", test_util.LocalhostDNS, config.SSLPort)
+									req, _ := http.NewRequest("GET", uri, nil)
+									tlsClientConfig.Certificates = []tls.Certificate{*clientCert}
+
+									resp, err := client.Do(req)
+									println("Error", err.Error())
+									Expect(err).To(HaveOccurred())
+									Expect(err).To(MatchError(ContainSubstring("remote error: tls: bad certificate")))
+									Expect(resp).To(BeNil())
+								})
+							})
 							Context("when the CA subject doesn't match to any of the CA subjects in the rules", func() {
 								BeforeEach(func() {
-									config.VerifyClientCertificateMetadata = []cfg.VerifyClientCertificateMetadataRule{
+									config.VerifyClientCertificatesBasedOnProvidedMetadata = true
+									config.VerifyClientCertificateMetadataRules = []cfg.VerifyClientCertificateMetadataRule{
 										{
 											CASubject:     cfg.CertSubject{CommonName: "abc.com"},
 											ValidSubjects: []cfg.CertSubject{cfg.CertSubject{Organization: []string{"abc, Inc."}}},

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1874,7 +1874,6 @@ var _ = Describe("Router", func() {
 									}
 								})
 								It("successfully serves SSL traffic", func() {
-
 									expectSuccessfulConnection()
 								})
 							})
@@ -1915,7 +1914,6 @@ var _ = Describe("Router", func() {
 									}
 								})
 								It("successfully serves SSL traffic", func() {
-
 									expectSuccessfulConnection()
 								})
 							})


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

We want to add optional mTLS client certificate metadata verification in addition to the issuer CA validity checks.

Given a particular signing CA (identified by its subject) we want to limit the allowed client certificate subjects that are allowed to send requests.

While the underlying issue is better solved with changes to the PKI and trust relationship between CAs, the PKI or its use by other sub-entities is not always under the control of the operator.

* An explanation of the use cases your change solves

The use case is an upstream proxy managed by a different entity that uses a widely spread private CA for issuing its certificates.

We want to avoid that every user of that CA is able to issue requests to Gorouter, while still explicitly allowing the upstream proxy and its CA certificates, which are short-lived and need rotation.

In the specific use case, we have a CA that controls, which certificates are issued for specific sub-entities, which are clearly identified in the certificate's subject DN. 

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

e.g. configuration in routing-release:
```yaml
router:
  verify_client_certificate_metadata:
    - issuer_in_chain:
        common_name: Some Root CA
        country:
          - DE
      valid_cert_subjects:
        - common_name: Awesome Service 1
          organizational_unit:
            - sub-entity4
          organization:
            - Acme, Inc.
          country:
            - US
        - common_name: Awesome Service 2
          organizational_unit:
            - sub-entity7
          organization:
            - Acme, Inc.
          country:
            - US
```

1. Send a request using a client certificate that is signed by a CA that is configured in `client_ca_certs:` 
   but not in the explicit allowed subjects, configured in `verify_client_certificate_metadata:`:
   ```shell
   curl --cacert other-department-5.pem https://app.cf.example.com
   ```
2. Send a request using a client certificate that is signed by a CA that is configured in `client_ca_certs:`
   and in the allowed subjects, configured in `verify_client_certificate_metadata:`:
   ```shell
   curl --cacert awesome-service-2.pem https://app.cf.example.com
   ```

* Expected result after the change

1. The request fails with a TLS handshake error. Gorouter logs the certificate subject and the fact that this certificate was not allowed.
2. succeeds, as desired.

* Current result before the change

1. The request passes through without TLS handshake errors, allows access to a different party that should not have access.
2. succeeds, as desired.


* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
