### PR TITLE
Fix misspellings in yaml-mapping introduced in #367

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -222,8 +222,8 @@ type VerifyClientCertificateMetadataRule struct {
 // express distinguished names for certificate subjects in a comparable manner.
 type CertSubject struct {
 	Country            []string `yaml:"country"`
-	Organization       []string `yaml:"organisation"`
-	OrganizationalUnit []string `yaml:"organisation_unit"`
+	Organization       []string `yaml:"organization"`
+	OrganizationalUnit []string `yaml:"organizational_unit"`
 	CommonName         string   `yaml:"common_name"`
 	SerialNumber       string   `yaml:"serial_number"`
 	Locality           []string `yaml:"locality"`
@@ -296,8 +296,8 @@ func checkClientCertificateMetadataRule(chain []*x509.Certificate, logger logger
 		}
 		subject := cert.Subject
 		for _, validSubject := range rule.ValidSubjects {
-			vaildCertSubject := validSubject.ToName()
-			if vaildCertSubject.ToRDNSequence().String() == subject.ToRDNSequence().String() {
+			validCertSubject := validSubject.ToName()
+			if validCertSubject.ToRDNSequence().String() == subject.ToRDNSequence().String() {
 				logger.Debug("chain", zap.String("issuer", cert.Issuer.String()), zap.Bool("CA", cert.IsCA), zap.String("subject", cert.Subject.String()))
 				return nil
 			}


### PR DESCRIPTION
* A short explanation of the proposed change:

https://github.com/cloudfoundry/gorouter/pull/367 introduced Optional mTLS client certificate metadata verification.
There were some typos in the yaml/configuration mapping. This PR unifies the yaml mapping to follow the naming in `pkix`.
Also fixes a typo in a variable name in `config.go`.

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
