### PR TITLE
test(proxy): Make gorouter_time less strict on slow responses

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1482,7 +1482,7 @@ var _ = Describe("Proxy", func() {
 				Expect(string(b)).To(ContainSubstring("response_time:"))
 				Expect(string(b)).To(ContainSubstring("gorouter_time:"))
 				Expect(string(b)).To(MatchRegexp("response_time:0.1"))
-				Expect(string(b)).To(MatchRegexp("gorouter_time:0.00"))
+				Expect(string(b)).To(MatchRegexp("gorouter_time:0.0"))
 			})
 
 			Context("in websocket requests", func() {
@@ -1530,7 +1530,7 @@ var _ = Describe("Proxy", func() {
 					Expect(logStr).To(ContainSubstring(`"GET / HTTP/1.1" 101`))
 					Expect(logStr).To(ContainSubstring(`x_forwarded_for:"127.0.0.1" x_forwarded_proto:"http" vcap_request_id:`))
 					Expect(logStr).To(MatchRegexp(`response_time:0.1`))
-					Expect(logStr).To(MatchRegexp(`gorouter_time:0.00`))
+					Expect(logStr).To(MatchRegexp(`gorouter_time:0.0`))
 				})
 			})
 
@@ -1594,7 +1594,7 @@ var _ = Describe("Proxy", func() {
 						g.Expect(logStr).To(MatchRegexp("backend_time:0.1"))         // 0.1 seconds delay from slow backend app
 						g.Expect(logStr).To(MatchRegexp("failed_attempts_time:0.2")) // plus 0.2 seconds from dial attempts
 						g.Expect(logStr).To(MatchRegexp("response_time:0.3"))        // makes 0.3 seconds total response time
-						g.Expect(logStr).To(MatchRegexp("gorouter_time:0.00"))
+						g.Expect(logStr).To(MatchRegexp("gorouter_time:0.0"))
 						g.Expect(logStr).To(MatchRegexp("failed_attempts:2"))
 						g.Expect(logStr).To(MatchRegexp(`app_index:"3"`))
 
@@ -1698,7 +1698,7 @@ var _ = Describe("Proxy", func() {
 							g.Expect(logStr).To(MatchRegexp("backend_time:0.1"))         // 0.1 seconds delay from slow backend app
 							g.Expect(logStr).To(MatchRegexp("failed_attempts_time:0.2")) // plus 0.2 seconds from dial attempts
 							g.Expect(logStr).To(MatchRegexp("response_time:0.3"))        // makes 0.3 seconds total response time
-							g.Expect(logStr).To(MatchRegexp("gorouter_time:0.00"))
+							g.Expect(logStr).To(MatchRegexp("gorouter_time:0.0"))
 							g.Expect(logStr).To(MatchRegexp("failed_attempts:2"))
 							g.Expect(logStr).To(MatchRegexp(`app_index:"3"`))
 						}, "20s").Should(Succeed())
@@ -1732,7 +1732,7 @@ var _ = Describe("Proxy", func() {
 						Expect(logStr).To(MatchRegexp("failed_attempts:3"))
 						Expect(logStr).To(MatchRegexp("failed_attempts_time:0.3"))
 						Expect(logStr).To(MatchRegexp("response_time:0.3"))
-						Expect(logStr).To(MatchRegexp("gorouter_time:0.00"))
+						Expect(logStr).To(MatchRegexp("gorouter_time:0.0"))
 						Expect(logStr).To(MatchRegexp(`backend_time:"-"`))
 						Expect(logStr).To(MatchRegexp(`dns_time:"-"`))
 						Expect(logStr).To(MatchRegexp(`dial_time:"-"`))

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1481,8 +1481,8 @@ var _ = Describe("Proxy", func() {
 				Expect(strings.HasPrefix(string(b), "slow-response-app - [")).To(BeTrue())
 				Expect(string(b)).To(ContainSubstring("response_time:"))
 				Expect(string(b)).To(ContainSubstring("gorouter_time:"))
-				Expect(string(b)).To(MatchRegexp("response_time:0.1"))
-				Expect(string(b)).To(MatchRegexp("gorouter_time:0.0"))
+				Expect(string(b)).To(ContainSubstring("response_time:0.1"))
+				Expect(string(b)).To(ContainSubstring("gorouter_time:0.0"))
 			})
 
 			Context("in websocket requests", func() {
@@ -1529,8 +1529,8 @@ var _ = Describe("Proxy", func() {
 					Expect(strings.HasPrefix(logStr, "slow-ws-test - [")).To(BeTrue())
 					Expect(logStr).To(ContainSubstring(`"GET / HTTP/1.1" 101`))
 					Expect(logStr).To(ContainSubstring(`x_forwarded_for:"127.0.0.1" x_forwarded_proto:"http" vcap_request_id:`))
-					Expect(logStr).To(MatchRegexp(`response_time:0.1`))
-					Expect(logStr).To(MatchRegexp(`gorouter_time:0.0`))
+					Expect(logStr).To(ContainSubstring(`response_time:0.1`))
+					Expect(logStr).To(ContainSubstring(`gorouter_time:0.0`))
 				})
 			})
 
@@ -1591,12 +1591,12 @@ var _ = Describe("Proxy", func() {
 						g.Expect(strings.HasPrefix(logStr, "partially-broken-app - [")).To(BeTrue())
 						g.Expect(logStr).To(ContainSubstring("response_time:"))
 						g.Expect(logStr).To(ContainSubstring("gorouter_time:"))
-						g.Expect(logStr).To(MatchRegexp("backend_time:0.1"))         // 0.1 seconds delay from slow backend app
-						g.Expect(logStr).To(MatchRegexp("failed_attempts_time:0.2")) // plus 0.2 seconds from dial attempts
-						g.Expect(logStr).To(MatchRegexp("response_time:0.3"))        // makes 0.3 seconds total response time
-						g.Expect(logStr).To(MatchRegexp("gorouter_time:0.0"))
-						g.Expect(logStr).To(MatchRegexp("failed_attempts:2"))
-						g.Expect(logStr).To(MatchRegexp(`app_index:"3"`))
+						g.Expect(logStr).To(ContainSubstring("backend_time:0.1"))         // 0.1 seconds delay from slow backend app
+						g.Expect(logStr).To(ContainSubstring("failed_attempts_time:0.2")) // plus 0.2 seconds from dial attempts
+						g.Expect(logStr).To(ContainSubstring("response_time:0.3"))        // makes 0.3 seconds total response time
+						g.Expect(logStr).To(ContainSubstring("gorouter_time:0.0"))
+						g.Expect(logStr).To(ContainSubstring("failed_attempts:2"))
+						g.Expect(logStr).To(ContainSubstring(`app_index:"3"`))
 
 					}, "20s").Should(Succeed()) // we don't know which endpoint will be chosen first, so we have to try until sequence 1,2,3 has been hit
 				})
@@ -1633,14 +1633,14 @@ var _ = Describe("Proxy", func() {
 					Expect(strings.HasPrefix(logStr, "fully-broken-app - [")).To(BeTrue())
 					Expect(logStr).To(ContainSubstring("response_time:"))
 					Expect(logStr).To(ContainSubstring("gorouter_time:"))
-					Expect(logStr).To(MatchRegexp("failed_attempts:3"))
-					Expect(logStr).To(MatchRegexp("failed_attempts_time:0.3"))
-					Expect(logStr).To(MatchRegexp("response_time:0.3"))
-					Expect(logStr).To(MatchRegexp("gorouter_time:0"))
-					Expect(logStr).To(MatchRegexp(`backend_time:"-"`))
-					Expect(logStr).To(MatchRegexp(`dns_time:"-"`))
-					Expect(logStr).To(MatchRegexp(`dial_time:"-"`))
-					Expect(logStr).To(MatchRegexp(`tls_time:"-"`))
+					Expect(logStr).To(ContainSubstring("failed_attempts:3"))
+					Expect(logStr).To(ContainSubstring("failed_attempts_time:0.3"))
+					Expect(logStr).To(ContainSubstring("response_time:0.3"))
+					Expect(logStr).To(ContainSubstring("gorouter_time:0"))
+					Expect(logStr).To(ContainSubstring(`backend_time:"-"`))
+					Expect(logStr).To(ContainSubstring(`dns_time:"-"`))
+					Expect(logStr).To(ContainSubstring(`dial_time:"-"`))
+					Expect(logStr).To(ContainSubstring(`tls_time:"-"`))
 				})
 				Context("in websocket requests", func() {
 					BeforeEach(func() {
@@ -1695,12 +1695,12 @@ var _ = Describe("Proxy", func() {
 							g.Expect(strings.HasPrefix(logStr, "partially-broken-ws-app - [")).To(BeTrue())
 							g.Expect(logStr).To(ContainSubstring(`"GET / HTTP/1.1" 101`))
 							g.Expect(logStr).To(ContainSubstring(`x_forwarded_for:"127.0.0.1" x_forwarded_proto:"http" vcap_request_id:`))
-							g.Expect(logStr).To(MatchRegexp("backend_time:0.1"))         // 0.1 seconds delay from slow backend app
-							g.Expect(logStr).To(MatchRegexp("failed_attempts_time:0.2")) // plus 0.2 seconds from dial attempts
-							g.Expect(logStr).To(MatchRegexp("response_time:0.3"))        // makes 0.3 seconds total response time
-							g.Expect(logStr).To(MatchRegexp("gorouter_time:0.0"))
-							g.Expect(logStr).To(MatchRegexp("failed_attempts:2"))
-							g.Expect(logStr).To(MatchRegexp(`app_index:"3"`))
+							g.Expect(logStr).To(ContainSubstring("backend_time:0.1"))         // 0.1 seconds delay from slow backend app
+							g.Expect(logStr).To(ContainSubstring("failed_attempts_time:0.2")) // plus 0.2 seconds from dial attempts
+							g.Expect(logStr).To(ContainSubstring("response_time:0.3"))        // makes 0.3 seconds total response time
+							g.Expect(logStr).To(ContainSubstring("gorouter_time:0.0"))
+							g.Expect(logStr).To(ContainSubstring("failed_attempts:2"))
+							g.Expect(logStr).To(ContainSubstring(`app_index:"3"`))
 						}, "20s").Should(Succeed())
 					})
 					It("shows no backend_time or other attempt details if all endpoints are broken", func() {
@@ -1729,14 +1729,14 @@ var _ = Describe("Proxy", func() {
 						Expect(strings.HasPrefix(logStr, "fully-broken-ws-app - [")).To(BeTrue())
 						Expect(logStr).To(ContainSubstring("response_time:"))
 						Expect(logStr).To(ContainSubstring("gorouter_time:"))
-						Expect(logStr).To(MatchRegexp("failed_attempts:3"))
-						Expect(logStr).To(MatchRegexp("failed_attempts_time:0.3"))
-						Expect(logStr).To(MatchRegexp("response_time:0.3"))
-						Expect(logStr).To(MatchRegexp("gorouter_time:0.0"))
-						Expect(logStr).To(MatchRegexp(`backend_time:"-"`))
-						Expect(logStr).To(MatchRegexp(`dns_time:"-"`))
-						Expect(logStr).To(MatchRegexp(`dial_time:"-"`))
-						Expect(logStr).To(MatchRegexp(`tls_time:"-"`))
+						Expect(logStr).To(ContainSubstring("failed_attempts:3"))
+						Expect(logStr).To(ContainSubstring("failed_attempts_time:0.3"))
+						Expect(logStr).To(ContainSubstring("response_time:0.3"))
+						Expect(logStr).To(ContainSubstring("gorouter_time:0.0"))
+						Expect(logStr).To(ContainSubstring(`backend_time:"-"`))
+						Expect(logStr).To(ContainSubstring(`dns_time:"-"`))
+						Expect(logStr).To(ContainSubstring(`dial_time:"-"`))
+						Expect(logStr).To(ContainSubstring(`tls_time:"-"`))
 					})
 				})
 			})
@@ -1775,9 +1775,9 @@ var _ = Describe("Proxy", func() {
 				Expect(strings.HasPrefix(logStr, "does-not-exist - [")).To(BeTrue())
 				Expect(logStr).To(ContainSubstring("response_time:"))
 				Expect(logStr).To(ContainSubstring("gorouter_time:"))
-				Expect(logStr).To(MatchRegexp("response_time:0"))
-				Expect(logStr).To(MatchRegexp("gorouter_time:0"))
-				Expect(logStr).To(MatchRegexp(`backend_time:"-"`))
+				Expect(logStr).To(ContainSubstring("response_time:0"))
+				Expect(logStr).To(ContainSubstring("gorouter_time:0"))
+				Expect(logStr).To(ContainSubstring(`backend_time:"-"`))
 			})
 			It("logs no backend_time on invalid X-CF-App-Instance header", func() {
 				conn := dialProxy(proxyServer)
@@ -1807,9 +1807,9 @@ var _ = Describe("Proxy", func() {
 				Expect(strings.HasPrefix(logStr, "invalid-app-instance-header - [")).To(BeTrue())
 				Expect(logStr).To(ContainSubstring("response_time:"))
 				Expect(logStr).To(ContainSubstring("gorouter_time:"))
-				Expect(logStr).To(MatchRegexp("response_time:0"))
-				Expect(logStr).To(MatchRegexp("gorouter_time:0"))
-				Expect(logStr).To(MatchRegexp(`backend_time:"-"`))
+				Expect(logStr).To(ContainSubstring("response_time:0"))
+				Expect(logStr).To(ContainSubstring("gorouter_time:0"))
+				Expect(logStr).To(ContainSubstring(`backend_time:"-"`))
 			})
 			It("logs no backend_time on empty pools (404 status)", func() {
 				test_util.RegisterAddr(r, "empty-pool-app", "10.255.255.1:1234", test_util.RegisterConfig{StaleThreshold: 1})
@@ -1849,9 +1849,9 @@ var _ = Describe("Proxy", func() {
 				Expect(strings.HasPrefix(logStr, "empty-pool-app - [")).To(BeTrue())
 				Expect(logStr).To(ContainSubstring("response_time:"))
 				Expect(logStr).To(ContainSubstring("gorouter_time:"))
-				Expect(logStr).To(MatchRegexp("response_time:0"))
-				Expect(logStr).To(MatchRegexp("gorouter_time:0"))
-				Expect(logStr).To(MatchRegexp(`backend_time:"-"`))
+				Expect(logStr).To(ContainSubstring("response_time:0"))
+				Expect(logStr).To(ContainSubstring("gorouter_time:0"))
+				Expect(logStr).To(ContainSubstring(`backend_time:"-"`))
 			})
 			Context("when EmptyPoolResponseCode503 is enabled", func() {
 				BeforeEach(func() {
@@ -1896,9 +1896,9 @@ var _ = Describe("Proxy", func() {
 					Expect(strings.HasPrefix(logStr, "empty-pool-app - [")).To(BeTrue())
 					Expect(logStr).To(ContainSubstring("response_time:"))
 					Expect(logStr).To(ContainSubstring("gorouter_time:"))
-					Expect(logStr).To(MatchRegexp("response_time:0"))
-					Expect(logStr).To(MatchRegexp("gorouter_time:0"))
-					Expect(logStr).To(MatchRegexp(`backend_time:"-"`))
+					Expect(logStr).To(ContainSubstring("response_time:0"))
+					Expect(logStr).To(ContainSubstring("gorouter_time:0"))
+					Expect(logStr).To(ContainSubstring(`backend_time:"-"`))
 				})
 			})
 		})


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

The test system can be a little slow at times which causes some tests to fail that rely on specific timings.
In the case of logging `gorouter_time` and `response_time` we had very strict tests that sometimes cause issues when the host system takes a few ms longer to process. 

The issue can be seen in [this test](https://ci.funtime.lol/teams/networking/pipelines/routing-release/jobs/unit-and-integration-tests/builds/60):
```
• [FAILED] [0.141 seconds]
Proxy Access Logging A slow response body [It] shows in response_time, not gorouter_time
/tmp/build/bc27c051/repo/src/code.cloudfoundry.org/gorouter/proxy/proxy_test.go:1440

  Timeline >>
  {"log_level":1,"timestamp":1699484373.1161623,"message":"route-registered","source":"test","data":{"uri":"slow-response-app"}}
  {"log_level":0,"timestamp":1699484373.1166515,"message":"uri-added","source":"test","data":{"uri":"slow-response-app"}}
  {"log_level":1,"timestamp":1699484373.117095,"message":"endpoint-registered","source":"test","data":{"uri":"slow-response-app","route_service_url":"","backend":"127.0.0.1:32937","application_id":"","instance_id":"","server_cert_domain_san":"","protocol":"","modification_tag":{"guid":"","index":0},"isolation_segment":"-","isTLS":false}}
  {"log_level":0,"timestamp":1699484373.118712,"message":"vcap-request-id-header-set","source":"test","data":{"VcapRequestIdHeader":"05a3287a-84bc-4b12-7945-7c6f7d25416a"}}
  {"log_level":0,"timestamp":1699484373.128653,"message":"backend","source":"test","data":{"route-endpoint":{"ApplicationId":"","Addr":"127.0.0.1:32937","Tags":null,"RouteServiceUrl":""},"attempt":1}}
  [FAILED] in [It] - /tmp/build/bc27c051/repo/src/code.cloudfoundry.org/gorouter/proxy/proxy_test.go:1485 @ 11/08/23 22:59:33.248
  << Timeline

  [FAILED] Expected
      <string>: slow-response-app - [2023-11-08T22:59:33.118432803Z] "GET / HTTP/1.1" 200 0 25 "-" "Go-http-client/1.1" "127.0.0.1:44130" "127.0.0.1:32937" x_forwarded_for:"127.0.0.1" x_forwarded_proto:"http" vcap_request_id:"05a3287a-84bc-4b12-7945-7c6f7d25416a" response_time:0.119914 gorouter_time:0.010132 app_id:"-" app_index:"2" instance_id:"-" x_cf_routererror:"-"
      
  to match regular expression
      <string>: gorouter_time:0.00
  In [It] at: /tmp/build/bc27c051/repo/src/code.cloudfoundry.org/gorouter/proxy/proxy_test.go:1485 @ 11/08/23 22:59:33.248
```

The measured `gorouter_time` was `0.010132`s while the expected `gorouter_time` had to match a faster time of `0.00x`s

* An explanation of the use cases your change solves

The PR relaxes the `gorouter_time` constraints a bit so that the slower test system is accounted for while retaining the original semantics of the test.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

Run test suite a couple times before and after applying the fix on the test system at https://ci.funtime.lol

* Expected result after the change

The tests for logging `gorouter_time` should pass more consistently, ideally 100% of the time.

* Current result before the change

The tests for logging `gorouter_time` fail occasionally and have to be retried.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
