### PR TITLE
Fix nil panic

### DIFF
--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -248,7 +248,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 	}
 
 	// if the client disconnects before response is sent then return context.Canceled (499) instead of the gateway error
-	if err != nil && originalRequest.Context().Err() == context.Canceled && err != context.Canceled {
+	if err != nil && errors.Is(originalRequest.Context().Err(), context.Canceled) && !errors.Is(err, context.Canceled) {
 		rt.logger.Error("gateway-error-and-original-request-context-cancelled", zap.Error(err))
 		err = originalRequest.Context().Err()
 		originalRequest.Body.Close()

--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -251,7 +251,9 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 	if err != nil && errors.Is(originalRequest.Context().Err(), context.Canceled) && !errors.Is(err, context.Canceled) {
 		rt.logger.Error("gateway-error-and-original-request-context-cancelled", zap.Error(err))
 		err = originalRequest.Context().Err()
-		originalRequest.Body.Close()
+		if originalRequest.Body != nil {
+			_ = originalRequest.Body.Close()
+		}
 	}
 
 	// If we have an error from the round trip, we prefer it over errors


### PR DESCRIPTION
* A short explanation of the proposed change: Only call close on the original requests body if it is non-nil, otherwise this will cause a panic.

* An explanation of the use cases your change solves: Prevent panics.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change: No panic if we have a client request without a body and the client disconnects early.

* Current result before the change: gorouter panics if we have a client request without a body and the client disconnects early.

* Links to any other associated PRs: #333

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
