### PR TITLE
Add localhost-only listener for /routes endpoint

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,8 +5,9 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"go.step.sm/crypto/pemutil"
 	"net/url"
+
+	"go.step.sm/crypto/pemutil"
 
 	"code.cloudfoundry.org/gorouter/logger"
 	"github.com/uber-go/zap"
@@ -69,17 +70,25 @@ func (ss StringSet) MarshalYAML() (interface{}, error) {
 }
 
 type StatusConfig struct {
-	Host string `yaml:"host"`
+	Host   string             `yaml:"host"`
+	Port   uint16             `yaml:"port"`
+	User   string             `yaml:"user"`
+	Pass   string             `yaml:"pass"`
+	Routes StatusRoutesConfig `yaml:"routes"`
+}
+
+type StatusRoutesConfig struct {
 	Port uint16 `yaml:"port"`
-	User string `yaml:"user"`
-	Pass string `yaml:"pass"`
 }
 
 var defaultStatusConfig = StatusConfig{
 	Host: "0.0.0.0",
-	Port: 8082,
+	Port: 8080,
 	User: "",
 	Pass: "",
+	Routes: StatusRoutesConfig{
+		Port: 8082,
+	},
 }
 
 type PrometheusConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -61,6 +61,8 @@ status:
   port: 1234
   user: user
   pass: pass
+  routes:
+    port: 8082
 `)
 
 			err := config.Initialize(b)
@@ -69,7 +71,7 @@ status:
 			Expect(config.Status.Port).To(Equal(uint16(1234)))
 			Expect(config.Status.User).To(Equal("user"))
 			Expect(config.Status.Pass).To(Equal("pass"))
-
+			Expect(config.Status.Routes.Port).To(Equal(uint16(8082)))
 		})
 		It("sets MaxHeaderBytes", func() {
 			var b = []byte(`

--- a/integration/common_integration_test.go
+++ b/integration/common_integration_test.go
@@ -65,7 +65,7 @@ func (s *testState) SetOnlyTrustClientCACertsTrue() {
 
 func NewTestState() *testState {
 	// TODO: don't hide so much behind these test_util methods
-	cfg, clientTLSConfig := test_util.SpecSSLConfig(test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort())
+	cfg, clientTLSConfig := test_util.SpecSSLConfig(test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort())
 	cfg.SkipSSLValidation = false
 	cfg.RouteServicesHairpinning = false
 	cfg.CipherString = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384"

--- a/integration/nats_test.go
+++ b/integration/nats_test.go
@@ -24,12 +24,12 @@ import (
 var _ = Describe("NATS Integration", func() {
 
 	var (
-		cfg                             *config.Config
-		cfgFile                         string
-		tmpdir                          string
-		natsPort, statusPort, proxyPort uint16
-		natsRunner                      *test_util.NATSRunner
-		gorouterSession                 *Session
+		cfg                                               *config.Config
+		cfgFile                                           string
+		tmpdir                                            string
+		natsPort, statusPort, statusRoutesPort, proxyPort uint16
+		natsRunner                                        *test_util.NATSRunner
+		gorouterSession                                   *Session
 	)
 
 	BeforeEach(func() {
@@ -62,7 +62,7 @@ var _ = Describe("NATS Integration", func() {
 		SetDefaultEventuallyTimeout(5 * time.Second)
 		defer SetDefaultEventuallyTimeout(1 * time.Second)
 
-		tempCfg := createConfig(statusPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+		tempCfg := createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 
 		gorouterSession = startGorouterSession(cfgFile)
 
@@ -138,7 +138,7 @@ var _ = Describe("NATS Integration", func() {
 
 	Context("when nats server shuts down and comes back up", func() {
 		It("should not panic, log the disconnection, and reconnect", func() {
-			tempCfg := createConfig(statusPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			tempCfg := createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 			tempCfg.NatsClientPingInterval = 100 * time.Millisecond
 			writeConfig(tempCfg, cfgFile)
 			gorouterSession = startGorouterSession(cfgFile)
@@ -166,7 +166,7 @@ var _ = Describe("NATS Integration", func() {
 
 			pruneInterval = 2 * time.Second
 			pruneThreshold = 10 * time.Second
-			cfg = createConfig(statusPort, proxyPort, cfgFile, pruneInterval, pruneThreshold, 0, false, 0, natsPort, natsPort2)
+			cfg = createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, pruneInterval, pruneThreshold, 0, false, 0, natsPort, natsPort2)
 		})
 
 		AfterEach(func() {
@@ -232,7 +232,7 @@ var _ = Describe("NATS Integration", func() {
 				pruneInterval = 200 * time.Millisecond
 				pruneThreshold = 1000 * time.Millisecond
 				suspendPruningIfNatsUnavailable := true
-				cfg = createConfig(statusPort, proxyPort, cfgFile, pruneInterval, pruneThreshold, 0, suspendPruningIfNatsUnavailable, 0, natsPort, natsPort2)
+				cfg = createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, pruneInterval, pruneThreshold, 0, suspendPruningIfNatsUnavailable, 0, natsPort, natsPort2)
 				cfg.NatsClientPingInterval = 200 * time.Millisecond
 			})
 

--- a/integration/test_utils_test.go
+++ b/integration/test_utils_test.go
@@ -22,8 +22,8 @@ const defaultPruneInterval = 50 * time.Millisecond
 const defaultPruneThreshold = 100 * time.Millisecond
 const localIP = "127.0.0.1"
 
-func createConfig(statusPort, proxyPort uint16, cfgFile string, pruneInterval time.Duration, pruneThreshold time.Duration, drainWait int, suspendPruning bool, maxBackendConns int64, natsPorts ...uint16) *config.Config {
-	tempCfg := test_util.SpecConfig(statusPort, proxyPort, natsPorts...)
+func createConfig(statusPort, statusRoutesPort, proxyPort uint16, cfgFile string, pruneInterval time.Duration, pruneThreshold time.Duration, drainWait int, suspendPruning bool, maxBackendConns int64, natsPorts ...uint16) *config.Config {
+	tempCfg := test_util.SpecConfig(statusPort, statusRoutesPort, proxyPort, natsPorts...)
 
 	configDrainSetup(tempCfg, pruneInterval, pruneThreshold, drainWait)
 
@@ -89,22 +89,22 @@ func stopGorouter(gorouterSession *Session) {
 	Eventually(gorouterSession, 5).Should(Exit(0))
 }
 
-func createCustomSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int, statusPort, proxyPort, sslPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
-	tempCfg, clientTLSConfig := test_util.CustomSpecSSLConfig(onlyTrustClientCACerts, TLSClientConfigOption, statusPort, proxyPort, sslPort, natsPorts...)
+func createCustomSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int, statusPort, statusRoutesPort, proxyPort, sslPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
+	tempCfg, clientTLSConfig := test_util.CustomSpecSSLConfig(onlyTrustClientCACerts, TLSClientConfigOption, statusPort, statusRoutesPort, proxyPort, sslPort, natsPorts...)
 
 	configDrainSetup(tempCfg, defaultPruneInterval, defaultPruneThreshold, 0)
 	return tempCfg, clientTLSConfig
 }
 
-func createSSLConfig(statusPort, proxyPort, sslPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
-	tempCfg, clientTLSConfig := test_util.SpecSSLConfig(statusPort, proxyPort, sslPort, natsPorts...)
+func createSSLConfig(statusPort, statusRoutesPort, proxyPort, sslPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
+	tempCfg, clientTLSConfig := test_util.SpecSSLConfig(statusPort, statusRoutesPort, proxyPort, sslPort, natsPorts...)
 
 	configDrainSetup(tempCfg, defaultPruneInterval, defaultPruneThreshold, 0)
 	return tempCfg, clientTLSConfig
 }
 
-func createIsoSegConfig(statusPort, proxyPort uint16, cfgFile string, pruneInterval, pruneThreshold time.Duration, drainWait int, suspendPruning bool, isoSegs []string, natsPorts ...uint16) *config.Config {
-	tempCfg := test_util.SpecConfig(statusPort, proxyPort, natsPorts...)
+func createIsoSegConfig(statusPort, statusRoutesPort, proxyPort uint16, cfgFile string, pruneInterval, pruneThreshold time.Duration, drainWait int, suspendPruning bool, isoSegs []string, natsPorts ...uint16) *config.Config {
+	tempCfg := test_util.SpecConfig(statusPort, statusRoutesPort, proxyPort, natsPorts...)
 
 	configDrainSetup(tempCfg, pruneInterval, pruneThreshold, drainWait)
 

--- a/router/router_drain_test.go
+++ b/router/router_drain_test.go
@@ -158,13 +158,14 @@ var _ = Describe("Router", func() {
 
 		proxyPort := test_util.NextAvailPort()
 		statusPort := test_util.NextAvailPort()
+		statusRoutesPort := test_util.NextAvailPort()
 
 		sslPort := test_util.NextAvailPort()
 
 		defaultCert := test_util.CreateCert("default")
 		cert2 := test_util.CreateCert("default")
 
-		config = test_util.SpecConfig(statusPort, proxyPort, natsPort)
+		config = test_util.SpecConfig(statusPort, statusRoutesPort, proxyPort, natsPort)
 		config.EnableSSL = true
 		config.SSLPort = sslPort
 		config.SSLCertificates = []tls.Certificate{defaultCert, cert2}
@@ -417,6 +418,7 @@ var _ = Describe("Router", func() {
 				h.SetHealth(health.Healthy)
 				config.HealthCheckUserAgent = "HTTP-Monitor/1.1"
 				config.Status.Port = test_util.NextAvailPort()
+				config.Status.Routes.Port = test_util.NextAvailPort()
 				rt := &sharedfakes.RoundTripper{}
 				p := proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, nil, ew, config, registry, combinedReporter,
 					&routeservice.RouteServiceConfig{}, &tls.Config{}, &tls.Config{}, h, rt)

--- a/router/routes_listener.go
+++ b/router/routes_listener.go
@@ -1,0 +1,60 @@
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	common "code.cloudfoundry.org/gorouter/common/http"
+	"code.cloudfoundry.org/gorouter/config"
+)
+
+type RoutesListener struct {
+	Config        *config.Config
+	RouteRegistry json.Marshaler
+
+	listener net.Listener
+}
+
+func (rl *RoutesListener) ListenAndServe() error {
+	hs := http.NewServeMux()
+	hs.HandleFunc("/routes", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Connection", "close")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		enc := json.NewEncoder(w)
+		enc.Encode(rl.RouteRegistry)
+	})
+
+	f := func(user, password string) bool {
+		return user == rl.Config.Status.User && password == rl.Config.Status.Pass
+	}
+
+	addr := fmt.Sprintf("127.0.0.1:%d", rl.Config.Status.Routes.Port)
+	s := &http.Server{
+		Addr:         addr,
+		Handler:      &common.BasicAuth{Handler: hs, Authenticator: f},
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	rl.listener = l
+
+	go func() {
+		err = s.Serve(l)
+	}()
+	return nil
+}
+
+func (rl *RoutesListener) Stop() {
+	if rl.listener != nil {
+		rl.listener.Close()
+	}
+}

--- a/router/routes_listener_test.go
+++ b/router/routes_listener_test.go
@@ -1,0 +1,135 @@
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+
+	"code.cloudfoundry.org/gorouter/config"
+	"code.cloudfoundry.org/gorouter/test_util"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type MarshalableValue struct {
+	Value map[string]string
+}
+
+func (m *MarshalableValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.Value)
+}
+
+var _ = Describe("RoutesListener", func() {
+	var (
+		routesListener *RoutesListener
+		registry       *MarshalableValue
+		addr           string
+		req            *http.Request
+		port           uint16
+	)
+
+	BeforeEach(func() {
+		port = test_util.NextAvailPort()
+		addr = "127.0.0.1"
+		registry = &MarshalableValue{
+			Value: map[string]string{
+				"route1": "endpoint1",
+			},
+		}
+		cfg := &config.Config{
+			Status: config.StatusConfig{
+				User: "test-user",
+				Pass: "test-pass",
+				Routes: config.StatusRoutesConfig{
+					Port: port,
+				},
+			},
+		}
+
+		routesListener = &RoutesListener{
+			Config:        cfg,
+			RouteRegistry: registry,
+		}
+		err := routesListener.ListenAndServe()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		routesListener.Stop()
+	})
+
+	JustBeforeEach(func() {
+		var err error
+		req, err = http.NewRequest("GET", fmt.Sprintf("http://%s:%d/routes", addr, port), nil)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("returns the route list", func() {
+		req.SetBasicAuth("test-user", "test-pass")
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp).ToNot(BeNil())
+
+		Expect(resp.StatusCode).To(Equal(200))
+		Expect(resp.Header.Get("Content-Type")).To(Equal("application/json"))
+
+		body, err := io.ReadAll(resp.Body)
+		defer resp.Body.Close()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(body)).To(Equal(`{"route1":"endpoint1"}` + "\n"))
+	})
+	It("stops listening", func() {
+		routesListener.Stop()
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("dial tcp 127.0.0.1:%d: connect: connection refused", port))))
+		Expect(resp).To(BeNil())
+	})
+
+	Context("when connecting to non-localhost IP", func() {
+		BeforeEach(func() {
+			conn, err := net.Dial("udp", "8.8.8.8:80")
+			Expect(err).ToNot(HaveOccurred())
+			defer conn.Close()
+			addr = conn.LocalAddr().(*net.UDPAddr).IP.String()
+		})
+		It("doesn't respond", func() {
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("dial tcp %s:%d: connect: connection refused", addr, port))))
+			Expect(resp).To(BeNil())
+		})
+	})
+	Context("when no creds are provided", func() {
+		It("returns a 401", func() {
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp).ToNot(BeNil())
+
+			Expect(resp.StatusCode).To(Equal(401))
+
+			body, err := io.ReadAll(resp.Body)
+			defer resp.Body.Close()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(body)).To(Equal("401 Unauthorized\n"))
+		})
+	})
+	Context("when invalid creds are provided", func() {
+		It("retuns a 401", func() {
+			req.SetBasicAuth("bad-user", "bad-pass")
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp).ToNot(BeNil())
+
+			Expect(resp.StatusCode).To(Equal(401))
+
+			body, err := io.ReadAll(resp.Body)
+			defer resp.Body.Close()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(body)).To(Equal("401 Unauthorized\n"))
+		})
+	})
+})

--- a/test_util/helpers.go
+++ b/test_util/helpers.go
@@ -12,7 +12,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"golang.org/x/net/websocket"
 	"io/ioutil"
 	"math/big"
 	"net"
@@ -21,6 +20,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/net/websocket"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -161,12 +162,12 @@ func runBackendInstance(ln net.Listener, handler connHandler) {
 	}
 }
 
-func SpecConfig(statusPort, proxyPort uint16, natsPorts ...uint16) *config.Config {
-	return generateConfig(statusPort, proxyPort, natsPorts...)
+func SpecConfig(statusPort, statusRoutesPort, proxyPort uint16, natsPorts ...uint16) *config.Config {
+	return generateConfig(statusPort, statusRoutesPort, proxyPort, natsPorts...)
 }
 
-func SpecSSLConfig(statusPort, proxyPort, SSLPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
-	c := generateConfig(statusPort, proxyPort, natsPorts...)
+func SpecSSLConfig(statusPort, statusRoutesPort, proxyPort, SSLPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
+	c := generateConfig(statusPort, statusRoutesPort, proxyPort, natsPorts...)
 
 	c.EnableSSL = true
 
@@ -203,8 +204,8 @@ const (
 	TLSConfigFromUnknownCA     = 3
 )
 
-func CustomSpecSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int, statusPort, proxyPort, SSLPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
-	c := generateConfig(statusPort, proxyPort, natsPorts...)
+func CustomSpecSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int, statusPort, statusRoutesPort, proxyPort, SSLPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
+	c := generateConfig(statusPort, statusRoutesPort, proxyPort, natsPorts...)
 
 	c.EnableSSL = true
 
@@ -257,7 +258,7 @@ func CustomSpecSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int,
 	return c, clientTLSConfig
 }
 
-func generateConfig(statusPort, proxyPort uint16, natsPorts ...uint16) *config.Config {
+func generateConfig(statusPort, statusRoutesPort, proxyPort uint16, natsPorts ...uint16) *config.Config {
 	c, err := config.DefaultConfig()
 	Expect(err).ToNot(HaveOccurred())
 
@@ -282,6 +283,9 @@ func generateConfig(statusPort, proxyPort uint16, natsPorts ...uint16) *config.C
 		Port: statusPort,
 		User: "user",
 		Pass: "pass",
+		Routes: config.StatusRoutesConfig{
+			Port: statusRoutesPort,
+		},
 	}
 
 	natsHosts := make([]config.NatsHost, len(natsPorts))


### PR DESCRIPTION
This is part of a larger effort to remove unencrypted non-localhost TCP listeners from routing-release. Currently the listener for /routes on `router.status.port` listens on all interfaces, and sits alongside the deprecated /varz + /healthz endpoints, as well as the LB healthcheck endpoint.

To work toward the desired state, we're adding a localhost-only listener for /routes, and will turn `router.status.port` to only a LB-healthcheck endpoint.

[#186497108](https://www.pivotaltracker.com/story/show/186497108)

<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
