### PR TITLE
Improve pool.Endpoint.Equals() peformance

### DIFF
--- a/registry/registry_benchmark_test.go
+++ b/registry/registry_benchmark_test.go
@@ -69,6 +69,7 @@ func BenchmarkRegisterWith100KRoutes(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		r.Register("foo50000.example.com", fooEndpoint)
 	}
+	b.ReportAllocs()
 }
 
 func BenchmarkRegisterWithOneRoute(b *testing.B) {
@@ -81,4 +82,5 @@ func BenchmarkRegisterWithOneRoute(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		r.Register("foo.example.com", fooEndpoint)
 	}
+	b.ReportAllocs()
 }

--- a/route/pool.go
+++ b/route/pool.go
@@ -3,6 +3,7 @@ package route
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math/rand"
 	"net/http"
 	"sync"
@@ -108,7 +109,7 @@ func (e *Endpoint) Equal(e2 *Endpoint) bool {
 	return e.ApplicationId == e2.ApplicationId &&
 		e.addr == e2.addr &&
 		e.Protocol == e2.Protocol &&
-		fmt.Sprint(e.Tags) == fmt.Sprint(e2.Tags) &&
+		maps.Equal(e.Tags, e2.Tags) &&
 		e.ServerCertDomainSAN == e2.ServerCertDomainSAN &&
 		e.PrivateInstanceId == e2.PrivateInstanceId &&
 		e.StaleThreshold == e2.StaleThreshold &&

--- a/route/pool_bench_test.go
+++ b/route/pool_bench_test.go
@@ -1,0 +1,52 @@
+package route_test
+
+import (
+	"code.cloudfoundry.org/gorouter/route"
+	"sync"
+	"testing"
+	"time"
+)
+
+var (
+	endpoint1 = route.Endpoint{
+		ApplicationId:        "abc",
+		Protocol:             "http2",
+		Tags:                 map[string]string{"tag1": "value1", "tag2": "value2"},
+		ServerCertDomainSAN:  "host.domain.tld",
+		PrivateInstanceId:    "1234-5678-91011-0000",
+		PrivateInstanceIndex: "",
+		Stats:                nil,
+		IsolationSegment:     "",
+		UpdatedAt:            time.Time{},
+		RoundTripperInit:     sync.Once{},
+	}
+	endpoint2 = route.Endpoint{
+		ApplicationId:        "def",
+		Protocol:             "http2",
+		Tags:                 map[string]string{"tag1": "value1", "tag2": "value2"},
+		ServerCertDomainSAN:  "host.domain.tld",
+		PrivateInstanceId:    "1234-5678-91011-0000",
+		PrivateInstanceIndex: "",
+		Stats:                nil,
+		IsolationSegment:     "",
+		UpdatedAt:            time.Time{},
+		RoundTripperInit:     sync.Once{},
+	}
+	endpoint3 = endpoint1
+	result    = false
+)
+
+func BenchmarkEndpointEquals(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		result = endpoint1.Equal(&endpoint3)
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkEndpointNotEquals(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		result = endpoint1.Equal(&endpoint2)
+	}
+	b.ReportAllocs()
+}
+


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

The change improves the `Endpoint.Equal()` function to use less time and no allocations during comparison. In profiler runs, @domdom82 identified that a lot of time is spent on the two `fmt.Sprintf` calls for comparison of the `tags` maps.

* An explanation of the use cases your change solves

Route registration messages that happen on route refresh are compared with the existing endpoints in the route registry for every received `router.register` message. This happens for every route by default every 20 seconds. In our scenarios we have up to 70k routes (on each gorouter) and such comparisons add up.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

Functionality is not changed. A benchmark has been added to show the changes.

* Expected result after the change

Route registration (and re-registration) should be a little faster. This will have measurable effect for large numbers of routes and route registration messages only.

* Current result before the change

Route registration takes about 8% of the processing time in Gorouter in our profiling examples. See https://github.com/cloudfoundry/routing-release/issues/366.

* Links to any other associated PRs


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
