### PR TITLE
test: fix govet for pool.Endpoint.Equals() tests

### DIFF
--- a/route/pool_benchmark_test.go
+++ b/route/pool_benchmark_test.go
@@ -32,8 +32,19 @@ var (
 		UpdatedAt:            time.Time{},
 		RoundTripperInit:     sync.Once{},
 	}
-	endpoint3 = endpoint1
-	result    = false
+	endpoint3 = route.Endpoint{
+		ApplicationId:        "abc",
+		Protocol:             "http2",
+		Tags:                 map[string]string{"tag1": "value1", "tag2": "value2"},
+		ServerCertDomainSAN:  "host.domain.tld",
+		PrivateInstanceId:    "1234-5678-91011-0000",
+		PrivateInstanceIndex: "",
+		Stats:                nil,
+		IsolationSegment:     "",
+		UpdatedAt:            time.Time{},
+		RoundTripperInit:     sync.Once{},
+	}
+	result = false
 )
 
 func BenchmarkEndpointEquals(b *testing.B) {
@@ -49,4 +60,3 @@ func BenchmarkEndpointNotEquals(b *testing.B) {
 	}
 	b.ReportAllocs()
 }
-


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

https://github.com/cloudfoundry/gorouter/pull/375 contained issues with the `govet` check (copying a mutex) that was accidentally introduced when refactoring the code before review.

* Links to any other associated PRs

https://github.com/cloudfoundry/gorouter/pull/375

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
