### PR TITLE
Optimistic route registry locks

### DIFF
--- a/route/pool.go
+++ b/route/pool.go
@@ -302,6 +302,7 @@ func (p *EndpointPool) RouteServiceUrl() string {
 
 func (p *EndpointPool) PruneEndpoints() []*Endpoint {
 	p.Lock()
+	defer p.Unlock()
 
 	last := len(p.endpoints)
 	now := time.Now()
@@ -327,7 +328,6 @@ func (p *EndpointPool) PruneEndpoints() []*Endpoint {
 		}
 	}
 
-	p.Unlock()
 	return prunedEndpoints
 }
 
@@ -418,10 +418,10 @@ func (p *EndpointPool) IsOverloaded() bool {
 
 func (p *EndpointPool) MarkUpdated(t time.Time) {
 	p.Lock()
+	defer p.Unlock()
 	for _, e := range p.endpoints {
 		e.updated = t
 	}
-	p.Unlock()
 }
 
 func (p *EndpointPool) EndpointFailed(endpoint *Endpoint, err error) {


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

This PR reduces the time spent in exclusive write locks for the RouteRegistry.

A lot of the work that is currently done with an exclusive write lock is to look up and determine, _whether_ a change is necessary at all. This PR carries out such lookup tasks with a read lock and acquires the write lock only when necessary.

* An explanation of the use cases your change solves

The main issue with write locking is that this impacts parallel execution, e.g. of Gorouter requests. This is particularly prevalent when a large number of routes and their corresponding route.register messages are arriving at each Gorouter.

Having the lookup and decision part, whether a change is necessary under a read lock, allows other routines (e.g. serving requests) to be executed in parallel.

As Gorouter is ultimately an "eventually consistent" system, there is no hard requirement for sequential processing. While it is desirable that a route register or deregister message is processed as quickly as possible, there is no hard requirement for "correct" sequence of execution. Using a message bus and multiple participants in registering routes, the order, arrival or delay/latency of information propagation are not guaranteed.

By relaxing and decoupling the "do I need to change anything" from regular work and look-ups improves the 95% case of Gorouter's work, while not impacting route registry functionality.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

This is a "drop in" performance improvement. Gorouter is to be operated as before, but should be able to do more work concurrently, especially with large numbers of routes in the route registry update cycle.

* Expected result after the change

A benchmark was added in addition to the change. This benchmark measures the throughput of `Register` in the route registry, while concurrently there are 10 goroutines that do `Lookup` as quickly as possible in parallel.

This simulates the regular Gorouter case of having to look up endpoints to proxy requests to a target, while route register messages are coming in, in parallel.

The go benchmarking tool anneals to an optimal benchmarking iteration size. This can be seen by the outputs of different log messages of the lookup goroutines running in parallel. Only the last output of those is relevant for the displayed timing.

Please also note that the time and memory metrics of the benchmark include the concurrently running goroutines. As a lookup is (currently) requiring an allocation, the more lookups are done, the more allocations will still show up in the benchmark result. These allocations are _not_ part of the `Register` workload that is measured.

Benchmark result:
```
goos: linux
goarch: amd64
pkg: code.cloudfoundry.org/gorouter/registry
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
BenchmarkRegisterWith100KRoutes-4                       	  545870	      2217 ns/op	    1440 B/op	       7 allocs/op
BenchmarkRegisterWithOneRoute-4                         	  915207	      1550 ns/op	    1440 B/op	       7 allocs/op
BenchmarkRegisterWithConcurrentLookupWith100kRoutes-4   	  628071	     10911 ns/op	    2525 B/op	      40 allocs/op
--- BENCH: BenchmarkRegisterWithConcurrentLookupWith100kRoutes-4
    registry_benchmark_test.go:139: Looked up 0 routes concurrently, registered 1
    registry_benchmark_test.go:139: Looked up 1011 routes concurrently, registered 100
    registry_benchmark_test.go:139: Looked up 70499 routes concurrently, registered 10000
    registry_benchmark_test.go:139: Looked up 21307628 routes concurrently, registered 628071
PASS
ok  	code.cloudfoundry.org/gorouter/registry	34.591s
```

* Current result before the change

When applying only the commit with the Benchmark and the existing implementation:
```
goos: linux
goarch: amd64
pkg: code.cloudfoundry.org/gorouter/registry
cpu: Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
BenchmarkRegisterWith100KRoutes-4                       	  623066	      2097 ns/op	    1440 B/op	       7 allocs/op
BenchmarkRegisterWithOneRoute-4                         	  858085	      1388 ns/op	    1440 B/op	       7 allocs/op
BenchmarkRegisterWithConcurrentLookupWith100kRoutes-4   	   94538	     18422 ns/op	    1904 B/op	      21 allocs/op
--- BENCH: BenchmarkRegisterWithConcurrentLookupWith100kRoutes-4
    registry_benchmark_test.go:139: Looked up 0 routes concurrently, registered 1
    registry_benchmark_test.go:139: Looked up 1993 routes concurrently, registered 100
    registry_benchmark_test.go:139: Looked up 131009 routes concurrently, registered 10000
    registry_benchmark_test.go:139: Looked up 1373364 routes concurrently, registered 94538
PASS
ok  	code.cloudfoundry.org/gorouter/registry	29.733s
```

As stated above, only the last output line is the "maximum" achieved. The other lines are the warm-up and calibration done by the Go benchmarking framework.

Comparison:
| Metric |`Register` | `Lookup`* |
| -------|---------:|--------:|
| Existing  | `94538` |  `1373364` |
| This PR | `628071` | `21307628 |

\* (sum of 10 concurrent goroutines)

**Please note**, this is a micro-benchmark, so the values may fluctuate between runs depending on other load, and depending on the type of machine used. Route registration is only part of Gorouter's work. The improvement in reduced concurrent lock times and resulting throughput is clearly visible in either case, however.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
