### PR TITLE
Experiment: `http.ResponseController.EnableFullDuplex()`

### DIFF
--- a/integration/retry_test.go
+++ b/integration/retry_test.go
@@ -109,25 +109,16 @@ var _ = Describe("Retries", func() {
 			badApp.SetHandlers(handlers)
 			badApp.Listen()
 
-			successSeen := false
-			// we need to retry the entire http request many times to get a success until https://github.com/golang/go/issues/31259
-			// is resolved.
-			for i := 0; i < 100; i++ {
-				req := testState.newPostRequest(
-					fmt.Sprintf("http://%s", appURL),
-					bytes.NewReader([]byte(payload)),
-				)
-				resp, err := testState.client.Do(req)
-				Expect(err).NotTo(HaveOccurred())
-				if resp.StatusCode == http.StatusOK {
-					successSeen = true
-					break
-				}
-				if resp.Body != nil {
-					resp.Body.Close()
-				}
+			req := testState.newPostRequest(
+				fmt.Sprintf("http://%s", appURL),
+				bytes.NewReader([]byte(payload)),
+			)
+			resp, err := testState.client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(200))
+			if resp.Body != nil {
+				resp.Body.Close()
 			}
-			Expect(successSeen).To(BeTrue())
 		})
 	})
 })

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -214,6 +214,13 @@ func (p *proxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.Requ
 	logger := handlers.LoggerWithTraceInfo(p.logger, request)
 	proxyWriter := responseWriter.(utils.ProxyResponseWriter)
 
+	rc := http.NewResponseController(responseWriter)
+
+	err := rc.EnableFullDuplex()
+	if err != nil {
+		logger.Panic("woopteedoo", zap.Error(err))
+	}
+
 	reqInfo, err := handlers.ContextRequestInfo(request)
 	if err != nil {
 		logger.Panic("request-info-err", zap.Error(err))

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -793,7 +793,7 @@ var _ = Describe("Proxy", func() {
 			defer good.Close()
 
 			// FIXME: This used to be Consistently, but moved to eventually to work around flakiness in this test
-			Eventually(func() int {
+			Consistently(func() int {
 				conn := dialProxy(proxyServer)
 
 				req := test_util.NewRequest("POST", "retry-test", "/", strings.NewReader("some body"))


### PR DESCRIPTION
Experiments with `http.ResponseController.EnableFullDuplex()`.