### PR TITLE
Add ability to disable non-tls LB health check for gorouter, default TLS

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,13 +70,14 @@ func (ss StringSet) MarshalYAML() (interface{}, error) {
 }
 
 type StatusConfig struct {
-	Host    string             `yaml:"host"`
-	Port    uint16             `yaml:"port"`
-	TLSCert tls.Certificate    `yaml:"-"`
-	TLS     StatusTLSConfig    `yaml:"tls"`
-	User    string             `yaml:"user"`
-	Pass    string             `yaml:"pass"`
-	Routes  StatusRoutesConfig `yaml:"routes"`
+	Host                     string             `yaml:"host"`
+	Port                     uint16             `yaml:"port"`
+	EnableNonTLSHealthChecks bool               `yaml:"enable_nontls_health_checks"`
+	TLSCert                  tls.Certificate    `yaml:"-"`
+	TLS                      StatusTLSConfig    `yaml:"tls"`
+	User                     string             `yaml:"user"`
+	Pass                     string             `yaml:"pass"`
+	Routes                   StatusRoutesConfig `yaml:"routes"`
 }
 
 type StatusTLSConfig struct {
@@ -90,10 +91,14 @@ type StatusRoutesConfig struct {
 }
 
 var defaultStatusConfig = StatusConfig{
-	Host: "0.0.0.0",
-	Port: 8080,
-	User: "",
-	Pass: "",
+	Host:                     "0.0.0.0",
+	Port:                     8080,
+	User:                     "",
+	Pass:                     "",
+	EnableNonTLSHealthChecks: true,
+	TLS: StatusTLSConfig{
+		Port: 8443,
+	},
 	Routes: StatusRoutesConfig{
 		Port: 8082,
 	},
@@ -610,24 +615,20 @@ func (c *Config) Process() error {
 	}
 
 	healthTLS := c.Status.TLS
-	if healthTLS.Port != 0 {
-		if healthTLS.Key == "" {
-			return fmt.Errorf("If router.status.tls.port is specified, key must be provided")
-		}
-		if healthTLS.Certificate == "" {
-			return fmt.Errorf("If router.status.tls.port is specified, certificate must be provided")
-		}
+	if healthTLS.Key == "" {
+		return fmt.Errorf("router.status.tls.key must be provided")
 	}
-	if healthTLS.Key != "" && healthTLS.Certificate != "" {
-		if healthTLS.Port == 0 {
-			return fmt.Errorf("If router.status.tls.certificate/key are specified, port must not be 0")
-		}
-		certificate, err := tls.X509KeyPair([]byte(healthTLS.Certificate), []byte(healthTLS.Key))
-		if err != nil {
-			return fmt.Errorf("Error loading router.status TLS key pair: %s", err.Error())
-		}
-		c.Status.TLSCert = certificate
+	if healthTLS.Certificate == "" {
+		return fmt.Errorf("router.status.tls.certificate must be provided")
 	}
+	if healthTLS.Port == 0 {
+		return fmt.Errorf("router.status.tls.port must not be 0")
+	}
+	certificate, err := tls.X509KeyPair([]byte(healthTLS.Certificate), []byte(healthTLS.Key))
+	if err != nil {
+		return fmt.Errorf("Error loading router.status.tls certificate/key pair: %s", err.Error())
+	}
+	c.Status.TLSCert = certificate
 
 	if c.EnableSSL {
 		switch c.ClientCertificateValidationString {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,13 +18,20 @@ import (
 )
 
 var _ = Describe("Config", func() {
-	var config *Config
+	var config, cfgForSnippet *Config
 
 	BeforeEach(func() {
 		var err error
 		config, err = DefaultConfig()
 		Expect(err).ToNot(HaveOccurred())
+		cfgForSnippet = baseConfigFixture()
 	})
+
+	createYMLSnippet := func(snippet *Config) []byte {
+		cfgBytes, err := yaml.Marshal(snippet)
+		Expect(err).ToNot(HaveOccurred())
+		return cfgBytes
+	}
 
 	Describe("Initialize", func() {
 
@@ -47,10 +54,8 @@ balancing_algorithm: least-connection
 			It("does not allow an invalid load balance strategy", func() {
 				cfg, err := DefaultConfig()
 				Expect(err).ToNot(HaveOccurred())
-				var b = []byte(`
-balancing_algorithm: foo-bar
-`)
-				cfg.Initialize(b)
+				cfgForSnippet.LoadBalance = "foo-bar"
+				cfg.Initialize(createYMLSnippet(cfgForSnippet))
 				Expect(cfg.Process()).To(MatchError("Invalid load balancing algorithm foo-bar. Allowed values are [round-robin least-connection]"))
 			})
 		})
@@ -75,32 +80,21 @@ status:
 			Expect(config.Status.Routes.Port).To(Equal(uint16(8082)))
 		})
 		Context("when tls is specified for the status config", func() {
-			var cfgBytes, certPEM, keyPEM []byte
+			var certPEM, keyPEM []byte
 			var tlsPort uint16
-
-			createYMLSnippet := func(snippet *Config) []byte {
-				cfgBytes, err := yaml.Marshal(snippet)
-				Expect(err).ToNot(HaveOccurred())
-				return cfgBytes
-			}
 
 			BeforeEach(func() {
 				keyPEM, certPEM = test_util.CreateKeyPair("default")
 				tlsPort = 8443
 			})
 			JustBeforeEach(func() {
-				cfgSnippet := &Config{
-					Status: StatusConfig{
-						TLS: StatusTLSConfig{
-							Port:        tlsPort,
-							Certificate: string(certPEM),
-							Key:         string(keyPEM),
-						},
-					},
+				cfgForSnippet.Status.TLS = StatusTLSConfig{
+					Port:        tlsPort,
+					Certificate: string(certPEM),
+					Key:         string(keyPEM),
 				}
-				cfgBytes = createYMLSnippet(cfgSnippet)
 
-				err := config.Initialize(cfgBytes)
+				err := config.Initialize(createYMLSnippet(cfgForSnippet))
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("parses the cert + key", func() {
@@ -122,7 +116,7 @@ status:
 				It("throws an error", func() {
 					err := config.Process()
 					Expect(err).To(HaveOccurred())
-					Expect(err).To(MatchError(ContainSubstring("Error loading router.status TLS key pair")))
+					Expect(err).To(MatchError(ContainSubstring("Error loading router.status.tls certificate/key pair")))
 				})
 			})
 			Context("and the key is invalid", func() {
@@ -132,7 +126,7 @@ status:
 				It("throws an error", func() {
 					err := config.Process()
 					Expect(err).To(HaveOccurred())
-					Expect(err).To(MatchError(ContainSubstring("Error loading router.status TLS key pair")))
+					Expect(err).To(MatchError(ContainSubstring("Error loading router.status.tls certificate/key pair")))
 				})
 			})
 			Context("and the cert is missing", func() {
@@ -142,7 +136,7 @@ status:
 				It("throws an error", func() {
 					err := config.Process()
 					Expect(err).To(HaveOccurred())
-					Expect(err).To(MatchError(ContainSubstring("If router.status.tls.port is specified, certificate must be provided")))
+					Expect(err).To(MatchError(ContainSubstring("router.status.tls.certificate must be provided")))
 				})
 			})
 			Context("and the key is missing", func() {
@@ -152,19 +146,8 @@ status:
 				It("throws an error", func() {
 					err := config.Process()
 					Expect(err).To(HaveOccurred())
-					Expect(err).To(MatchError(ContainSubstring("If router.status.tls.port is specified, key must be provided")))
+					Expect(err).To(MatchError(ContainSubstring("router.status.tls.key must be provided")))
 				})
-			})
-			Context("and the port is missing", func() {
-				BeforeEach(func() {
-					tlsPort = 0
-				})
-				It("throws an error", func() {
-					err := config.Process()
-					Expect(err).To(HaveOccurred())
-					Expect(err).To(MatchError(ContainSubstring("If router.status.tls.certificate/key are specified, port must not be 0")))
-				})
-
 			})
 		})
 		It("sets MaxHeaderBytes", func() {
@@ -245,10 +228,10 @@ websocket_dial_timeout: 6s
 		})
 
 		It("defaults websocket dial timeout to endpoint dial timeout if not set", func() {
-			var b = []byte(`
+			b := createYMLSnippet(cfgForSnippet)
+			b = append(b, []byte(`
 endpoint_dial_timeout: 6s
-`)
-
+`)...)
 			err := config.Initialize(b)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -325,6 +308,13 @@ nats:
 							TLSPem: TLSPem{
 								CertChain:  string(clientCertPEM),
 								PrivateKey: string(clientKeyPEM),
+							},
+						},
+						Status: StatusConfig{
+							TLS: StatusTLSConfig{
+								Port:        8443,
+								Certificate: string(clientCertPEM),
+								Key:         string(clientKeyPEM),
 							},
 						},
 					}
@@ -504,6 +494,13 @@ routing_table_sharding_mode: "segments"
 								PrivateKey: string(certChain.PrivKeyPEM),
 							},
 							CACerts: string(certChain.CACertPEM),
+						},
+						Status: StatusConfig{
+							TLS: StatusTLSConfig{
+								Port:        8443,
+								Certificate: string(certChain.CertPEM),
+								Key:         string(certChain.PrivKeyPEM),
+							},
 						},
 					}
 				})
@@ -872,7 +869,8 @@ backends:
 
 	Describe("Process", func() {
 		It("converts intervals to durations", func() {
-			var b = []byte(`
+			b := createYMLSnippet(cfgForSnippet)
+			b = append(b, []byte(`
 publish_start_message_interval: 1s
 prune_stale_droplets_interval: 2s
 droplet_stale_threshold: 30s
@@ -880,7 +878,7 @@ publish_active_apps_interval: 4s
 start_response_delay_interval: 15s
 secure_cookies: true
 token_fetcher_retry_interval: 10s
-`)
+`)...)
 
 			err := config.Initialize(b)
 			Expect(err).ToNot(HaveOccurred())
@@ -898,8 +896,14 @@ token_fetcher_retry_interval: 10s
 		})
 
 		Context("When LoadBalancerHealthyThreshold is provided", func() {
+			var b []byte
+			BeforeEach(func() {
+				b = createYMLSnippet(cfgForSnippet)
+			})
 			It("returns a meaningful error when an invalid duration string is given", func() {
-				var b = []byte("load_balancer_healthy_threshold: -5s")
+				b = append(b, []byte(`
+load_balancer_healthy_threshold: -5s
+`)...)
 				err := config.Initialize(b)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -907,26 +911,25 @@ token_fetcher_retry_interval: 10s
 			})
 
 			It("fails to initialize a non time string", func() {
-				var b = []byte("load_balancer_healthy_threshold: test")
+				b = append(b, []byte(`
+load_balancer_healthy_threshold: test
+`)...)
+
 				Expect(config.Initialize(b)).To(MatchError(ContainSubstring("cannot unmarshal")))
 			})
 
 			It("process the string into a valid duration", func() {
-				var b = []byte("load_balancer_healthy_threshold: 10s")
+				b = append(b, []byte(`
+load_balancer_healthy_threshold: 10s
+`)...)
 				err := config.Initialize(b)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
 		It("converts extra headers to log into a map", func() {
-			var b = []byte(`
-extra_headers_to_log:
-  - x-b3-trace-id
-  - something
-  - something
-`)
-
-			err := config.Initialize(b)
+			cfgForSnippet.ExtraHeadersToLog = []string{"x-b3-trace-id", "something", "something"}
+			err := config.Initialize(createYMLSnippet(cfgForSnippet))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(config.Process()).To(Succeed())
 
@@ -935,14 +938,12 @@ extra_headers_to_log:
 		})
 
 		Describe("StickySessionCookieNames", func() {
+			BeforeEach(func() {
+				cfgForSnippet.StickySessionCookieNames = StringSet{"someName": struct{}{}, "anotherName": struct{}{}}
+			})
 			It("converts the provided list to a set of StickySessionCookieNames", func() {
-				var b = []byte(`
-sticky_session_cookie_names:
-  - someName
-  - anotherName
-`)
 
-				err := config.Initialize(b)
+				err := config.Initialize(createYMLSnippet(cfgForSnippet))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(config.Process()).To(Succeed())
 
@@ -952,12 +953,12 @@ sticky_session_cookie_names:
 		})
 
 		Context("When secure cookies is set to false", func() {
+			BeforeEach(func() {
+				cfgForSnippet.SecureCookies = false
+			})
 			It("set DropletStaleThreshold equal to StartResponseDelayInterval", func() {
-				var b = []byte(`
-secure_cookies: false
-`)
 
-				err := config.Initialize(b)
+				err := config.Initialize(createYMLSnippet(cfgForSnippet))
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(config.Process()).To(Succeed())
@@ -968,19 +969,22 @@ secure_cookies: false
 		})
 
 		Describe("NatsServers", func() {
-			var b = []byte(`
-nats:
-  user: user
-  pass: pass
-  hosts:
-  - hostname: remotehost
-    port: 4223
-  - hostname: remotehost2
-    port: 4224
-`)
+			BeforeEach(func() {
+				cfgForSnippet.Nats = NatsConfig{
+					User: "user",
+					Pass: "pass",
+					Hosts: []NatsHost{{
+						Hostname: "remotehost",
+						Port:     4223,
+					}, {
+						Hostname: "remotehost2",
+						Port:     4224,
+					}},
+				}
+			})
 
 			It("returns a slice of the configured NATS servers", func() {
-				err := config.Initialize(b)
+				err := config.Initialize(createYMLSnippet(cfgForSnippet))
 				Expect(err).ToNot(HaveOccurred())
 
 				natsServers := config.NatsServers()
@@ -990,13 +994,13 @@ nats:
 		})
 
 		Describe("RouteServiceEnabled", func() {
-			var configYaml []byte
 			Context("when the route service secrets is not configured", func() {
 				BeforeEach(func() {
-					configYaml = []byte(`other_key: other_value`)
+					cfgForSnippet.RouteServiceSecret = ""
+					cfgForSnippet.RouteServiceSecretPrev = ""
 				})
 				It("disables route services", func() {
-					err := config.Initialize(configYaml)
+					err := config.Initialize(createYMLSnippet(cfgForSnippet))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(config.Process()).To(Succeed())
 					Expect(config.RouteServiceEnabled).To(BeFalse())
@@ -1006,10 +1010,8 @@ nats:
 			Context("when the route service secret is configured", func() {
 				Context("when the route service secret is set", func() {
 					BeforeEach(func() {
-						configYaml = []byte(`
-route_services_secret: my-route-service-secret
-`)
-						err := config.Initialize(configYaml)
+						cfgForSnippet.RouteServiceSecret = "my-route-service-secret"
+						err := config.Initialize(createYMLSnippet(cfgForSnippet))
 						Expect(err).ToNot(HaveOccurred())
 						Expect(config.Process()).To(Succeed())
 					})
@@ -1025,11 +1027,9 @@ route_services_secret: my-route-service-secret
 
 				Context("when the route service secret and the decrypt only route service secret are set", func() {
 					BeforeEach(func() {
-						configYaml = []byte(`
-route_services_secret: my-route-service-secret
-route_services_secret_decrypt_only: my-decrypt-only-route-service-secret
-`)
-						err := config.Initialize(configYaml)
+						cfgForSnippet.RouteServiceSecret = "my-route-service-secret"
+						cfgForSnippet.RouteServiceSecretPrev = "my-decrypt-only-route-service-secret"
+						err := config.Initialize(createYMLSnippet(cfgForSnippet))
 						Expect(err).ToNot(HaveOccurred())
 						Expect(config.Process()).To(Succeed())
 					})
@@ -1049,10 +1049,8 @@ route_services_secret_decrypt_only: my-decrypt-only-route-service-secret
 
 				Context("when only the decrypt only route service secret is set", func() {
 					BeforeEach(func() {
-						configYaml = []byte(`
-route_services_secret_decrypt_only: 1PfbARmvIn6cgyKorA1rqR2d34rBOo+z3qJGz17pi8Y=
-`)
-						err := config.Initialize(configYaml)
+						cfgForSnippet.RouteServiceSecretPrev = "1PfbARmvIn6cgyKorA1rqR2d34rBOo+z3qJGz17pi8Y="
+						err := config.Initialize(createYMLSnippet(cfgForSnippet))
 						Expect(err).ToNot(HaveOccurred())
 						Expect(config.Process()).To(Succeed())
 					})
@@ -1122,6 +1120,13 @@ route_services_secret_decrypt_only: 1PfbARmvIn6cgyKorA1rqR2d34rBOo+z3qJGz17pi8Y=
 					ClientCertificateValidationString: "none",
 					CipherString:                      "ECDHE-RSA-AES128-GCM-SHA256",
 					TLSPEM:                            expectedTLSPEMs,
+					Status: StatusConfig{
+						TLS: StatusTLSConfig{
+							Port:        8443,
+							Certificate: string(certPEM1),
+							Key:         string(keyPEM1),
+						},
+					},
 				}
 
 			})
@@ -1619,24 +1624,24 @@ route_services_secret_decrypt_only: 1PfbARmvIn6cgyKorA1rqR2d34rBOo+z3qJGz17pi8Y=
 
 		Context("When enable_ssl is set to false", func() {
 			Context("When disable_http is set to false", func() {
+				BeforeEach(func() {
+					cfgForSnippet.EnableSSL = false
+					cfgForSnippet.DisableHTTP = false
+				})
 				It("succeeds", func() {
-					var b = []byte(fmt.Sprintf(`
-enable_ssl: false
-disable_http: false
-`))
-					err := config.Initialize(b)
+					err := config.Initialize(createYMLSnippet(cfgForSnippet))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(config.Process()).To(Succeed())
 					Expect(config.DisableHTTP).To(BeFalse())
 				})
 			})
 			Context("When disable_http is set to true", func() {
+				BeforeEach(func() {
+					cfgForSnippet.EnableSSL = false
+					cfgForSnippet.DisableHTTP = true
+				})
 				It("returns a meaningful error", func() {
-					var b = []byte(fmt.Sprintf(`
-enable_ssl: false
-disable_http: true
-`))
-					err := config.Initialize(b)
+					err := config.Initialize(createYMLSnippet(cfgForSnippet))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(config.Process()).To(MatchError(HavePrefix("neither http nor https listener is enabled")))
 				})
@@ -1645,15 +1650,14 @@ disable_http: true
 
 		Context("enable_http2", func() {
 			It("defaults to true", func() {
+				config.Status.TLS = cfgForSnippet.Status.TLS
 				Expect(config.Process()).To(Succeed())
 				Expect(config.EnableHTTP2).To(BeTrue())
 			})
 
 			It("setting enable_http2 succeeds", func() {
-				var b = []byte(fmt.Sprintf(`
-enable_http2: false
-`))
-				err := config.Initialize(b)
+				cfgForSnippet.EnableHTTP2 = false
+				err := config.Initialize(createYMLSnippet(cfgForSnippet))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Process()).To(Succeed())
 				Expect(config.EnableHTTP2).To(BeFalse())
@@ -1661,11 +1665,11 @@ enable_http2: false
 		})
 
 		Context("hop_by_hop_headers_to_filter", func() {
+			BeforeEach(func() {
+				cfgForSnippet.HopByHopHeadersToFilter = []string{"X-ME", "X-Foo"}
+			})
 			It("setting hop_by_hop_headers_to_filter succeeds", func() {
-				var b = []byte(fmt.Sprintf(`
-hop_by_hop_headers_to_filter: [ "X-ME", "X-Foo" ]
-`))
-				err := config.Initialize(b)
+				err := config.Initialize(createYMLSnippet(cfgForSnippet))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Process()).To(Succeed())
 				Expect(config.HopByHopHeadersToFilter).To(Equal([]string{"X-ME", "X-Foo"}))
@@ -1674,26 +1678,27 @@ hop_by_hop_headers_to_filter: [ "X-ME", "X-Foo" ]
 
 		Context("When given a routing_table_sharding_mode that is supported ", func() {
 			Context("sharding mode `all`", func() {
+				BeforeEach(func() {
+					cfgForSnippet.RoutingTableShardingMode = "all"
+				})
 				It("succeeds", func() {
-					var b = []byte(`routing_table_sharding_mode: all`)
-					err := config.Initialize(b)
+					err := config.Initialize(createYMLSnippet(cfgForSnippet))
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(config.Process()).To(Succeed())
 				})
 			})
 			Context("sharding mode `segments`", func() {
-				var b []byte
 				BeforeEach(func() {
-					b = []byte("routing_table_sharding_mode: segments")
+					cfgForSnippet.RoutingTableShardingMode = "segments"
 				})
 
 				Context("with isolation segments provided", func() {
 					BeforeEach(func() {
-						b = append(b, []byte("\nisolation_segments: [is1, is2]")...)
+						cfgForSnippet.IsolationSegments = []string{"is1", "is2"}
 					})
 					It("succeeds", func() {
-						err := config.Initialize(b)
+						err := config.Initialize(createYMLSnippet(cfgForSnippet))
 						Expect(err).ToNot(HaveOccurred())
 
 						Expect(config.Process()).To(Succeed())
@@ -1702,7 +1707,7 @@ hop_by_hop_headers_to_filter: [ "X-ME", "X-Foo" ]
 
 				Context("without isolation segments provided", func() {
 					It("returns a meaningful error", func() {
-						err := config.Initialize(b)
+						err := config.Initialize(createYMLSnippet(cfgForSnippet))
 						Expect(err).ToNot(HaveOccurred())
 
 						Expect(config.Process()).To(MatchError("Expected isolation segments; routing table sharding mode set to segments and none provided."))
@@ -1710,17 +1715,16 @@ hop_by_hop_headers_to_filter: [ "X-ME", "X-Foo" ]
 				})
 			})
 			Context("sharding mode `shared-and-segments`", func() {
-				var b []byte
 				BeforeEach(func() {
-					b = []byte("routing_table_sharding_mode: shared-and-segments")
+					cfgForSnippet.RoutingTableShardingMode = "shared-and-segments"
 				})
 
 				Context("with isolation segments provided", func() {
 					BeforeEach(func() {
-						b = append(b, []byte("\nisolation_segments: [is1, is2]")...)
+						cfgForSnippet.IsolationSegments = []string{"is1", "is2"}
 					})
 					It("succeeds", func() {
-						err := config.Initialize(b)
+						err := config.Initialize(createYMLSnippet(cfgForSnippet))
 						Expect(err).ToNot(HaveOccurred())
 
 						Expect(config.Process()).To(Succeed())
@@ -1730,10 +1734,12 @@ hop_by_hop_headers_to_filter: [ "X-ME", "X-Foo" ]
 		})
 
 		Context("When given a routing_table_sharding_mode that is not supported ", func() {
-			var b = []byte(`routing_table_sharding_mode: foo`)
+			BeforeEach(func() {
+				cfgForSnippet.RoutingTableShardingMode = "foo"
+			})
 
 			It("returns a meaningful error", func() {
-				err := config.Initialize(b)
+				err := config.Initialize(createYMLSnippet(cfgForSnippet))
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(config.Process()).To(MatchError("Invalid sharding mode: foo. Allowed values are [all segments shared-and-segments]"))
@@ -1748,27 +1754,33 @@ hop_by_hop_headers_to_filter: [ "X-ME", "X-Foo" ]
 
 		Context("When given a forwarded_client_cert value that is supported", func() {
 			Context("when forwarded_client_cert is always_forward", func() {
+				BeforeEach(func() {
+					cfgForSnippet.ForwardedClientCert = "always_forward"
+				})
 				It("correctly sets the value", func() {
-					var b = []byte(`forwarded_client_cert: always_forward`)
-					err := config.Initialize(b)
+					err := config.Initialize(createYMLSnippet(cfgForSnippet))
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(config.ForwardedClientCert).To(Equal("always_forward"))
 				})
 			})
 			Context("when forwarded_client_cert is forward", func() {
+				BeforeEach(func() {
+					cfgForSnippet.ForwardedClientCert = "forward"
+				})
 				It("correctly sets the value", func() {
-					var b = []byte(`forwarded_client_cert: forward`)
-					err := config.Initialize(b)
+					err := config.Initialize(createYMLSnippet(cfgForSnippet))
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(config.ForwardedClientCert).To(Equal("forward"))
 				})
 			})
 			Context("when forwarded_client_cert is sanitize_set", func() {
+				BeforeEach(func() {
+					cfgForSnippet.ForwardedClientCert = "sanitize_set"
+				})
 				It("correctly sets the value", func() {
-					var b = []byte(`forwarded_client_cert: sanitize_set`)
-					err := config.Initialize(b)
+					err := config.Initialize(createYMLSnippet(cfgForSnippet))
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(config.ForwardedClientCert).To(Equal("sanitize_set"))
@@ -1777,10 +1789,12 @@ hop_by_hop_headers_to_filter: [ "X-ME", "X-Foo" ]
 		})
 
 		Context("When given a forwarded_client_cert value that is not supported ", func() {
-			var b = []byte(`forwarded_client_cert: foo`)
+			BeforeEach(func() {
+				cfgForSnippet.ForwardedClientCert = "foo"
+			})
 
 			It("returns a meaningful error", func() {
-				err := config.Initialize(b)
+				err := config.Initialize(createYMLSnippet(cfgForSnippet))
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(config.Process()).To(MatchError("Invalid forwarded client cert mode: foo. Allowed values are [always_forward forward sanitize_set]"))
@@ -1788,16 +1802,19 @@ hop_by_hop_headers_to_filter: [ "X-ME", "X-Foo" ]
 		})
 
 		Describe("Timeout", func() {
+			var b []byte
+			BeforeEach(func() {
+				b = createYMLSnippet((cfgForSnippet))
+			})
 			It("converts timeouts to a duration", func() {
-				var b = []byte(`
+				b = append(b, []byte(`
 endpoint_timeout: 10s
 endpoint_dial_timeout: 6s
 websocket_dial_timeout: 8s
 route_services_timeout: 10s
 drain_timeout: 15s
 tls_handshake_timeout: 9s
-`)
-
+`)...)
 				err := config.Initialize(b)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1812,10 +1829,9 @@ tls_handshake_timeout: 9s
 			})
 
 			It("defaults to the EndpointTimeout when not set", func() {
-				var b = []byte(`
+				b = append(b, []byte(`
 endpoint_timeout: 10s
-`)
-
+`)...)
 				err := config.Initialize(b)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1827,11 +1843,11 @@ endpoint_timeout: 10s
 			})
 
 			It("lets drain_timeout be 60 if it wants", func() {
-				var b = []byte(`
+				b = append(b, []byte(`
 endpoint_timeout: 10s
 route_services_timeout: 11s
 drain_timeout: 60s
-`)
+`)...)
 				err := config.Initialize(b)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1845,7 +1861,6 @@ drain_timeout: 60s
 			Context("when provided PEM for backends cert_chain and private_key", func() {
 				var expectedTLSPEM TLSPem
 				var certChain test_util.CertChain
-				var cfgYaml []byte
 
 				BeforeEach(func() {
 					certChain = test_util.CreateSignedCertWithRootCA(test_util.CertNames{SANs: test_util.SubjectAltNames{DNS: "spinach.com"}})
@@ -1853,14 +1868,13 @@ drain_timeout: 60s
 						CertChain:  string(certChain.CertPEM),
 						PrivateKey: string(certChain.PrivKeyPEM),
 					}
-					cfg := map[string]interface{}{
-						"backends": expectedTLSPEM,
+					cfgForSnippet.Backends = BackendConfig{
+						TLSPem: expectedTLSPEM,
 					}
-					cfgYaml, _ = yaml.Marshal(cfg)
 				})
 
 				It("populates the ClientAuthCertificates", func() {
-					err := config.Initialize(cfgYaml)
+					err := config.Initialize(createYMLSnippet(cfgForSnippet))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(config.Backends.TLSPem).To(Equal(expectedTLSPEM))
 
@@ -1870,16 +1884,16 @@ drain_timeout: 60s
 
 				Context("cert or key are invalid", func() {
 					BeforeEach(func() {
-						cfgYaml, _ = yaml.Marshal(map[string]interface{}{
-							"backends": map[string]string{
-								"cert_chain":  "invalid-cert",
-								"private_key": "invalid-key",
+						cfgForSnippet.Backends = BackendConfig{
+							TLSPem: TLSPem{
+								CertChain:  "invalid-cert",
+								PrivateKey: "invalid-key",
 							},
-						})
+						}
 					})
 
 					It("returns a meaningful error", func() {
-						err := config.Initialize(cfgYaml)
+						err := config.Initialize(createYMLSnippet(cfgForSnippet))
 						Expect(err).ToNot(HaveOccurred())
 
 						Expect(config.Process()).To(MatchError("Error loading key pair: tls: failed to find any PEM data in certificate input"))
@@ -1890,3 +1904,17 @@ drain_timeout: 60s
 
 	})
 })
+
+func baseConfigFixture() *Config {
+	key, cert := test_util.CreateKeyPair("healthTLSEndpoint")
+	cfg := &Config{
+		Status: StatusConfig{
+			TLS: StatusTLSConfig{
+				Port:        8443,
+				Certificate: string(cert),
+				Key:         string(key),
+			},
+		},
+	}
+	return cfg
+}

--- a/integration/common_integration_test.go
+++ b/integration/common_integration_test.go
@@ -65,7 +65,7 @@ func (s *testState) SetOnlyTrustClientCACertsTrue() {
 
 func NewTestState() *testState {
 	// TODO: don't hide so much behind these test_util methods
-	cfg, clientTLSConfig := test_util.SpecSSLConfig(test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort())
+	cfg, clientTLSConfig := test_util.SpecSSLConfig(test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort())
 	cfg.SkipSSLValidation = false
 	cfg.RouteServicesHairpinning = false
 	cfg.CipherString = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384"

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -43,13 +43,13 @@ import (
 var _ = Describe("Router Integration", func() {
 
 	var (
-		cfg                                                        *config.Config
-		cfgFile                                                    string
-		tmpdir                                                     string
-		natsPort, statusPort, statusRoutesPort, proxyPort, sslPort uint16
-		natsRunner                                                 *test_util.NATSRunner
-		gorouterSession                                            *Session
-		oauthServerURL                                             string
+		cfg                                                                       *config.Config
+		cfgFile                                                                   string
+		tmpdir                                                                    string
+		natsPort, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort uint16
+		natsRunner                                                                *test_util.NATSRunner
+		gorouterSession                                                           *Session
+		oauthServerURL                                                            string
 	)
 
 	BeforeEach(func() {
@@ -59,6 +59,7 @@ var _ = Describe("Router Integration", func() {
 		cfgFile = filepath.Join(tmpdir, "config.yml")
 
 		statusPort = test_util.NextAvailPort()
+		statusTLSPort = test_util.NextAvailPort()
 		statusRoutesPort = test_util.NextAvailPort()
 		proxyPort = test_util.NextAvailPort()
 		natsPort = test_util.NextAvailPort()
@@ -96,7 +97,7 @@ var _ = Describe("Router Integration", func() {
 
 	Context("IsolationSegments", func() {
 		BeforeEach(func() {
-			createIsoSegConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 1, false, []string{"is1", "is2"}, natsPort)
+			createIsoSegConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 1, false, []string{"is1", "is2"}, natsPort)
 		})
 
 		It("logs retrieved IsolationSegments", func() {
@@ -120,7 +121,7 @@ var _ = Describe("Router Integration", func() {
 			mbusClient      *nats.Conn
 		)
 		BeforeEach(func() {
-			cfg, clientTLSConfig = createSSLConfig(statusPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
 
 		})
 		JustBeforeEach(func() {
@@ -206,7 +207,7 @@ var _ = Describe("Router Integration", func() {
 
 				Context("when the client knows about a CA in the ClientCACerts", func() {
 					BeforeEach(func() {
-						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromClientCACerts, statusPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromClientCACerts, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
 					})
 					It("can reach the gorouter successfully", func() {
 						curlAppWithCustomClientTLSConfig(http.StatusOK)
@@ -215,7 +216,7 @@ var _ = Describe("Router Integration", func() {
 
 				Context("when the client knows about a CA in the CACerts", func() {
 					BeforeEach(func() {
-						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromCACerts, statusPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromCACerts, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
 					})
 					It("can reach the gorouter succ", func() {
 						curlAppWithCustomClientTLSConfig(http.StatusOK)
@@ -230,7 +231,7 @@ var _ = Describe("Router Integration", func() {
 
 				Context("when the client presents a cert signed by a CA in ClientCACerts", func() {
 					BeforeEach(func() {
-						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromClientCACerts, statusPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromClientCACerts, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
 					})
 
 					It("can reach the gorouter successfully", func() {
@@ -240,7 +241,7 @@ var _ = Describe("Router Integration", func() {
 
 				Context("when the client presents a cert signed by a CA in CACerts", func() {
 					BeforeEach(func() {
-						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromCACerts, statusPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromCACerts, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
 					})
 
 					It("cannot reach the gorouter", func() {
@@ -257,7 +258,7 @@ var _ = Describe("Router Integration", func() {
 			mbusClient      *nats.Conn
 		)
 		BeforeEach(func() {
-			cfg, clientTLSConfig = createSSLConfig(statusPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
 			clientTLSConfig.InsecureSkipVerify = true
 		})
 
@@ -311,7 +312,7 @@ var _ = Describe("Router Integration", func() {
 		)
 
 		BeforeEach(func() {
-			cfg, clientTLSConfig = createSSLConfig(statusPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
 		})
 
 		JustBeforeEach(func() {
@@ -399,7 +400,7 @@ var _ = Describe("Router Integration", func() {
 
 	Context("Drain", func() {
 		BeforeEach(func() {
-			cfg = createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 1, false, 0, natsPort)
+			cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 1, false, 0, natsPort)
 		})
 
 		JustBeforeEach(func() {
@@ -562,7 +563,7 @@ var _ = Describe("Router Integration", func() {
 
 		Context("when ssl is enabled", func() {
 			BeforeEach(func() {
-				tempCfg, _ := createSSLConfig(statusPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+				tempCfg, _ := createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
 				writeConfig(tempCfg, cfgFile)
 			})
 
@@ -597,7 +598,7 @@ var _ = Describe("Router Integration", func() {
 
 	Context("When Dropsonde is misconfigured", func() {
 		It("fails to start", func() {
-			tempCfg := createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 			tempCfg.Logging.MetronAddress = ""
 			writeConfig(tempCfg, cfgFile)
 
@@ -608,7 +609,7 @@ var _ = Describe("Router Integration", func() {
 	})
 
 	It("logs component logs", func() {
-		createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+		createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 
 		gorouterSession = startGorouterSession(cfgFile)
 
@@ -628,7 +629,7 @@ var _ = Describe("Router Integration", func() {
 		})
 
 		It("emits route registration latency metrics, but only after a waiting period", func() {
-			tempCfg := createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 			tempCfg.Logging.MetronAddress = fakeMetron.Address()
 			tempCfg.RouteLatencyMetricMuzzleDuration = 2 * time.Second
 			writeConfig(tempCfg, cfgFile)
@@ -696,7 +697,7 @@ var _ = Describe("Router Integration", func() {
 
 	Describe("prometheus metrics", func() {
 		It("starts a prometheus https server", func() {
-			c := createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			c := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 			metricsPort := test_util.NextAvailPort()
 			serverCAPath, serverCertPath, serverKeyPath, clientCert := tls_helpers.GenerateCaAndMutualTlsCerts()
 
@@ -744,7 +745,7 @@ var _ = Describe("Router Integration", func() {
 
 		BeforeEach(func() {
 
-			cfg, clientTLSConfig = createSSLConfig(statusPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
 			cfg.RouteServiceSecret = "route-service-secret"
 			cfg.RouteServiceSecretPrev = "my-previous-route-service-secret"
 
@@ -916,7 +917,7 @@ var _ = Describe("Router Integration", func() {
 	Context("when no oauth config is specified", func() {
 		Context("and routing api is disabled", func() {
 			It("is able to start up", func() {
-				tempCfg := createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+				tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 				tempCfg.OAuth = config.OAuthConfig{}
 				writeConfig(tempCfg, cfgFile)
 
@@ -929,7 +930,7 @@ var _ = Describe("Router Integration", func() {
 
 	Context("when routing api is disabled", func() {
 		BeforeEach(func() {
-			cfg = createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 			writeConfig(cfg, cfgFile)
 		})
 
@@ -948,7 +949,7 @@ var _ = Describe("Router Integration", func() {
 		)
 
 		BeforeEach(func() {
-			cfg = createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 
 			responseBytes = []byte(`[{
 				"guid": "abc123",
@@ -1137,7 +1138,7 @@ var _ = Describe("Router Integration", func() {
 
 		BeforeEach(func() {
 			var clientTLSConfig *tls.Config
-			cfg, clientTLSConfig = createSSLConfig(statusPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
 			writeConfig(cfg, cfgFile)
 			var err error
 			mbusClient, err = newMessageBus(cfg)
@@ -1219,7 +1220,7 @@ var _ = Describe("Router Integration", func() {
 		)
 
 		BeforeEach(func() {
-			cfg, clientTLSConfig = createSSLConfig(statusPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
 			writeConfig(cfg, cfgFile)
 			var err error
 			mbusClient, err = newMessageBus(cfg)

--- a/integration/nats_test.go
+++ b/integration/nats_test.go
@@ -24,12 +24,12 @@ import (
 var _ = Describe("NATS Integration", func() {
 
 	var (
-		cfg                                               *config.Config
-		cfgFile                                           string
-		tmpdir                                            string
-		natsPort, statusPort, statusRoutesPort, proxyPort uint16
-		natsRunner                                        *test_util.NATSRunner
-		gorouterSession                                   *Session
+		cfg                                                              *config.Config
+		cfgFile                                                          string
+		tmpdir                                                           string
+		natsPort, statusPort, statusTLSPort, statusRoutesPort, proxyPort uint16
+		natsRunner                                                       *test_util.NATSRunner
+		gorouterSession                                                  *Session
 	)
 
 	BeforeEach(func() {
@@ -39,6 +39,7 @@ var _ = Describe("NATS Integration", func() {
 		cfgFile = filepath.Join(tmpdir, "config.yml")
 
 		statusPort = test_util.NextAvailPort()
+		statusTLSPort = test_util.NextAvailPort()
 		proxyPort = test_util.NextAvailPort()
 		natsPort = test_util.NextAvailPort()
 
@@ -62,7 +63,7 @@ var _ = Describe("NATS Integration", func() {
 		SetDefaultEventuallyTimeout(5 * time.Second)
 		defer SetDefaultEventuallyTimeout(1 * time.Second)
 
-		tempCfg := createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+		tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 
 		gorouterSession = startGorouterSession(cfgFile)
 
@@ -138,7 +139,7 @@ var _ = Describe("NATS Integration", func() {
 
 	Context("when nats server shuts down and comes back up", func() {
 		It("should not panic, log the disconnection, and reconnect", func() {
-			tempCfg := createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 			tempCfg.NatsClientPingInterval = 100 * time.Millisecond
 			writeConfig(tempCfg, cfgFile)
 			gorouterSession = startGorouterSession(cfgFile)
@@ -166,7 +167,7 @@ var _ = Describe("NATS Integration", func() {
 
 			pruneInterval = 2 * time.Second
 			pruneThreshold = 10 * time.Second
-			cfg = createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, pruneInterval, pruneThreshold, 0, false, 0, natsPort, natsPort2)
+			cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, pruneInterval, pruneThreshold, 0, false, 0, natsPort, natsPort2)
 		})
 
 		AfterEach(func() {
@@ -232,7 +233,7 @@ var _ = Describe("NATS Integration", func() {
 				pruneInterval = 200 * time.Millisecond
 				pruneThreshold = 1000 * time.Millisecond
 				suspendPruningIfNatsUnavailable := true
-				cfg = createConfig(statusPort, statusRoutesPort, proxyPort, cfgFile, pruneInterval, pruneThreshold, 0, suspendPruningIfNatsUnavailable, 0, natsPort, natsPort2)
+				cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, pruneInterval, pruneThreshold, 0, suspendPruningIfNatsUnavailable, 0, natsPort, natsPort2)
 				cfg.NatsClientPingInterval = 200 * time.Millisecond
 			})
 

--- a/integration/test_utils_test.go
+++ b/integration/test_utils_test.go
@@ -22,8 +22,8 @@ const defaultPruneInterval = 50 * time.Millisecond
 const defaultPruneThreshold = 100 * time.Millisecond
 const localIP = "127.0.0.1"
 
-func createConfig(statusPort, statusRoutesPort, proxyPort uint16, cfgFile string, pruneInterval time.Duration, pruneThreshold time.Duration, drainWait int, suspendPruning bool, maxBackendConns int64, natsPorts ...uint16) *config.Config {
-	tempCfg := test_util.SpecConfig(statusPort, statusRoutesPort, proxyPort, natsPorts...)
+func createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort uint16, cfgFile string, pruneInterval time.Duration, pruneThreshold time.Duration, drainWait int, suspendPruning bool, maxBackendConns int64, natsPorts ...uint16) *config.Config {
+	tempCfg := test_util.SpecConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, natsPorts...)
 
 	configDrainSetup(tempCfg, pruneInterval, pruneThreshold, drainWait)
 
@@ -89,22 +89,22 @@ func stopGorouter(gorouterSession *Session) {
 	Eventually(gorouterSession, 5).Should(Exit(0))
 }
 
-func createCustomSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int, statusPort, statusRoutesPort, proxyPort, sslPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
-	tempCfg, clientTLSConfig := test_util.CustomSpecSSLConfig(onlyTrustClientCACerts, TLSClientConfigOption, statusPort, statusRoutesPort, proxyPort, sslPort, natsPorts...)
+func createCustomSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
+	tempCfg, clientTLSConfig := test_util.CustomSpecSSLConfig(onlyTrustClientCACerts, TLSClientConfigOption, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPorts...)
 
 	configDrainSetup(tempCfg, defaultPruneInterval, defaultPruneThreshold, 0)
 	return tempCfg, clientTLSConfig
 }
 
-func createSSLConfig(statusPort, statusRoutesPort, proxyPort, sslPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
-	tempCfg, clientTLSConfig := test_util.SpecSSLConfig(statusPort, statusRoutesPort, proxyPort, sslPort, natsPorts...)
+func createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
+	tempCfg, clientTLSConfig := test_util.SpecSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPorts...)
 
 	configDrainSetup(tempCfg, defaultPruneInterval, defaultPruneThreshold, 0)
 	return tempCfg, clientTLSConfig
 }
 
-func createIsoSegConfig(statusPort, statusRoutesPort, proxyPort uint16, cfgFile string, pruneInterval, pruneThreshold time.Duration, drainWait int, suspendPruning bool, isoSegs []string, natsPorts ...uint16) *config.Config {
-	tempCfg := test_util.SpecConfig(statusPort, statusRoutesPort, proxyPort, natsPorts...)
+func createIsoSegConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort uint16, cfgFile string, pruneInterval, pruneThreshold time.Duration, drainWait int, suspendPruning bool, isoSegs []string, natsPorts ...uint16) *config.Config {
+	tempCfg := test_util.SpecConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, natsPorts...)
 
 	configDrainSetup(tempCfg, pruneInterval, pruneThreshold, drainWait)
 

--- a/router/router_drain_test.go
+++ b/router/router_drain_test.go
@@ -158,6 +158,7 @@ var _ = Describe("Router", func() {
 
 		proxyPort := test_util.NextAvailPort()
 		statusPort := test_util.NextAvailPort()
+		statusTlsPort := test_util.NextAvailPort()
 		statusRoutesPort := test_util.NextAvailPort()
 
 		sslPort := test_util.NextAvailPort()
@@ -165,7 +166,7 @@ var _ = Describe("Router", func() {
 		defaultCert := test_util.CreateCert("default")
 		cert2 := test_util.CreateCert("default")
 
-		config = test_util.SpecConfig(statusPort, statusRoutesPort, proxyPort, natsPort)
+		config = test_util.SpecConfig(statusPort, statusTlsPort, statusRoutesPort, proxyPort, natsPort)
 		config.EnableSSL = true
 		config.SSLPort = sslPort
 		config.SSLCertificates = []tls.Certificate{defaultCert, cert2}
@@ -418,6 +419,7 @@ var _ = Describe("Router", func() {
 				h.SetHealth(health.Healthy)
 				config.HealthCheckUserAgent = "HTTP-Monitor/1.1"
 				config.Status.Port = test_util.NextAvailPort()
+				config.Status.TLS.Port = test_util.NextAvailPort()
 				config.Status.Routes.Port = test_util.NextAvailPort()
 				rt := &sharedfakes.RoundTripper{}
 				p := proxy.NewProxy(logger, &accesslog.NullAccessLogger{}, nil, ew, config, registry, combinedReporter,


### PR DESCRIPTION
health check to on.

<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
