### PR TITLE
Disable /varz, /routes, and /healthz endpoints on the health status listener

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,14 +70,15 @@ func (ss StringSet) MarshalYAML() (interface{}, error) {
 }
 
 type StatusConfig struct {
-	Host                     string             `yaml:"host"`
-	Port                     uint16             `yaml:"port"`
-	EnableNonTLSHealthChecks bool               `yaml:"enable_nontls_health_checks"`
-	TLSCert                  tls.Certificate    `yaml:"-"`
-	TLS                      StatusTLSConfig    `yaml:"tls"`
-	User                     string             `yaml:"user"`
-	Pass                     string             `yaml:"pass"`
-	Routes                   StatusRoutesConfig `yaml:"routes"`
+	Host                                 string             `yaml:"host"`
+	Port                                 uint16             `yaml:"port"`
+	EnableNonTLSHealthChecks             bool               `yaml:"enable_nontls_health_checks"`
+	EnableDeprecatedVarzHealthzEndpoints bool               `yaml:"enable_deprecated_varz_healthz_endpoints"`
+	TLSCert                              tls.Certificate    `yaml:"-"`
+	TLS                                  StatusTLSConfig    `yaml:"tls"`
+	User                                 string             `yaml:"user"`
+	Pass                                 string             `yaml:"pass"`
+	Routes                               StatusRoutesConfig `yaml:"routes"`
 }
 
 type StatusTLSConfig struct {

--- a/integration/common_integration_test.go
+++ b/integration/common_integration_test.go
@@ -248,7 +248,7 @@ func (s *testState) registerAndWait(rm mbus.RegistryMessage) {
 	b, _ := json.Marshal(rm)
 	s.mbusClient.Publish("router.register", b)
 
-	routesUri := fmt.Sprintf("http://%s:%s@127.0.0.1:%d/routes", s.cfg.Status.User, s.cfg.Status.Pass, s.cfg.Status.Port)
+	routesUri := fmt.Sprintf("http://%s:%s@127.0.0.1:%d/routes", s.cfg.Status.User, s.cfg.Status.Pass, s.cfg.Status.Routes.Port)
 	Eventually(func() (bool, error) {
 		return routeExists(routesUri, string(rm.Uris[0]))
 	}).Should(BeTrue())

--- a/integration/gdpr_test.go
+++ b/integration/gdpr_test.go
@@ -64,7 +64,7 @@ var _ = Describe("GDPR", func() {
 		It("omits x-forwarded-for from stdout", func() {
 			testState.cfg.Status.Pass = "pass"
 			testState.cfg.Status.User = "user"
-			testState.cfg.Status.Port = 6705
+			testState.cfg.Status.Routes.Port = 6705
 			testState.cfg.Logging.DisableLogForwardedFor = true
 			testState.StartGorouterOrFail()
 
@@ -73,7 +73,7 @@ var _ = Describe("GDPR", func() {
 			wsApp.Listen()
 			wsApp.WaitUntilReady()
 
-			routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Port)
+			routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Routes.Port)
 
 			Eventually(func() bool { return appRegistered(routesURI, wsApp) }, "2s").Should(BeTrue())
 
@@ -130,7 +130,7 @@ var _ = Describe("GDPR", func() {
 		It("omits RemoteAddr from stdout", func() {
 			testState.cfg.Status.Pass = "pass"
 			testState.cfg.Status.User = "user"
-			testState.cfg.Status.Port = 6706
+			testState.cfg.Status.Routes.Port = 6706
 			testState.cfg.Logging.DisableLogSourceIP = true
 			testState.StartGorouterOrFail()
 
@@ -139,7 +139,7 @@ var _ = Describe("GDPR", func() {
 			wsApp.Listen()
 			wsApp.WaitUntilReady()
 
-			routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Port)
+			routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Routes.Port)
 
 			Eventually(func() bool { return appRegistered(routesURI, wsApp) }, "2s").Should(BeTrue())
 

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -608,12 +608,15 @@ var _ = Describe("Router Integration", func() {
 		})
 	})
 
-	It("logs component logs", func() {
+	It("no longer logs component logs as that disabled by default", func() {
 		createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 
 		gorouterSession = startGorouterSession(cfgFile)
 
-		Eventually(gorouterSession.Out.Contents).Should(ContainSubstring("Component Router registered successfully"))
+		contentsFunc := func() string {
+			return string(gorouterSession.Out.Contents())
+		}
+		Consistently(contentsFunc).ShouldNot(ContainSubstring("Component Router registered successfully"))
 	})
 
 	Describe("loggregator metrics emitted", func() {

--- a/integration/nats_test.go
+++ b/integration/nats_test.go
@@ -12,7 +12,6 @@ import (
 	"code.cloudfoundry.org/gorouter/route"
 	"code.cloudfoundry.org/gorouter/test"
 	"code.cloudfoundry.org/gorouter/test_util"
-	"code.cloudfoundry.org/localip"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,6 +39,7 @@ var _ = Describe("NATS Integration", func() {
 
 		statusPort = test_util.NextAvailPort()
 		statusTLSPort = test_util.NextAvailPort()
+		statusRoutesPort = test_util.NextAvailPort()
 		proxyPort = test_util.NextAvailPort()
 		natsPort = test_util.NextAvailPort()
 
@@ -86,7 +86,7 @@ var _ = Describe("NATS Integration", func() {
 		runningApp.Register()
 		runningApp.Listen()
 
-		routesUri := fmt.Sprintf("http://%s:%s@%s:%d/routes", tempCfg.Status.User, tempCfg.Status.Pass, localIP, statusPort)
+		routesUri := fmt.Sprintf("http://%s:%s@%s:%d/routes", tempCfg.Status.User, tempCfg.Status.Pass, "localhost", statusRoutesPort)
 
 		Eventually(func() bool { return appRegistered(routesUri, zombieApp) }).Should(BeTrue())
 		Eventually(func() bool { return appRegistered(routesUri, runningApp) }).Should(BeTrue())
@@ -179,9 +179,6 @@ var _ = Describe("NATS Integration", func() {
 		})
 
 		It("fails over to second nats server before pruning", func() {
-			localIP, err := localip.LocalIP()
-			Expect(err).ToNot(HaveOccurred())
-
 			mbusClient, err := newMessageBus(cfg)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -189,7 +186,7 @@ var _ = Describe("NATS Integration", func() {
 			runningApp.Register()
 			runningApp.Listen()
 
-			routesUri := fmt.Sprintf("http://%s:%s@%s:%d/routes", cfg.Status.User, cfg.Status.Pass, localIP, statusPort)
+			routesUri := fmt.Sprintf("http://%s:%s@%s:%d/routes", cfg.Status.User, cfg.Status.Pass, "localhost", statusRoutesPort)
 
 			Eventually(func() bool { return appRegistered(routesUri, runningApp) }).Should(BeTrue())
 
@@ -238,9 +235,6 @@ var _ = Describe("NATS Integration", func() {
 			})
 
 			It("does not prune routes when nats is unavailable", func() {
-				localIP, err := localip.LocalIP()
-				Expect(err).ToNot(HaveOccurred())
-
 				mbusClient, err := newMessageBus(cfg)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -248,7 +242,7 @@ var _ = Describe("NATS Integration", func() {
 				runningApp.Register()
 				runningApp.Listen()
 
-				routesUri := fmt.Sprintf("http://%s:%s@%s:%d/routes", cfg.Status.User, cfg.Status.Pass, localIP, statusPort)
+				routesUri := fmt.Sprintf("http://%s:%s@%s:%d/routes", cfg.Status.User, cfg.Status.Pass, "localhost", statusRoutesPort)
 
 				Eventually(func() bool { return appRegistered(routesUri, runningApp) }).Should(BeTrue())
 

--- a/integration/tls_to_backends_test.go
+++ b/integration/tls_to_backends_test.go
@@ -40,7 +40,7 @@ var _ = Describe("TLS to backends", func() {
 
 	Context("websockets and TLS interaction", func() {
 		assertWebsocketSuccess := func(wsApp *common.TestApp) {
-			routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Port)
+			routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Routes.Port)
 
 			Eventually(func() bool { return appRegistered(routesURI, wsApp) }, "2s", "500ms").Should(BeTrue())
 
@@ -86,7 +86,7 @@ var _ = Describe("TLS to backends", func() {
 			wsApp.Register()
 			wsApp.Listen()
 
-			routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, localIP, testState.cfg.Status.Port)
+			routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, localIP, testState.cfg.Status.Routes.Port)
 
 			Eventually(func() bool { return appRegistered(routesURI, wsApp) }, "2s").Should(BeTrue())
 
@@ -126,7 +126,7 @@ var _ = Describe("TLS to backends", func() {
 		runningApp1.TlsRegister(testState.trustedBackendServerCertSAN)
 		runningApp1.TlsListen(testState.trustedBackendTLSConfig)
 
-		routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Port)
+		routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Routes.Port)
 
 		Eventually(func() bool { return appRegistered(routesURI, runningApp1) }, "2s").Should(BeTrue())
 		runningApp1.VerifyAppStatus(200)
@@ -137,7 +137,7 @@ var _ = Describe("TLS to backends", func() {
 		runningApp1 := test.NewGreetApp([]route.Uri{"some-app-expecting-client-certs." + test_util.LocalhostDNS}, testState.cfg.Port, testState.mbusClient, nil)
 		runningApp1.TlsRegister(testState.trustedBackendServerCertSAN)
 		runningApp1.TlsListen(testState.trustedBackendTLSConfig)
-		routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Port)
+		routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Routes.Port)
 		Eventually(func() bool { return appRegistered(routesURI, runningApp1) }, "2s").Should(BeTrue())
 		runningApp1.VerifyAppStatus(200)
 

--- a/integration/web_socket_test.go
+++ b/integration/web_socket_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Websockets", func() {
 
 	Context("When gorouter attempts to connect to a websocket app that fails", func() {
 		assertWebsocketFailure := func(wsApp *common.TestApp) {
-			routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Port)
+			routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Routes.Port)
 
 			Eventually(func() bool { return appRegistered(routesURI, wsApp) }, "2s", "500ms").Should(BeTrue())
 


### PR DESCRIPTION
…istener by default

/routes remains alive on the specific routes localhost-only listener

[#186471679](https://www.pivotaltracker.com/story/show/186471679)

<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
