### PR TITLE
Fix ability to start gorouter with the default config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -79,6 +79,20 @@ status:
 			Expect(config.Status.Pass).To(Equal("pass"))
 			Expect(config.Status.Routes.Port).To(Equal(uint16(8082)))
 		})
+		Context("when neither tls nor nontls health endpoints are enabled", func() {
+			JustBeforeEach(func() {
+				cfgForSnippet.Status.EnableNonTLSHealthChecks = false
+				cfgForSnippet.Status.TLS.Certificate = ""
+				cfgForSnippet.Status.TLS.Key = ""
+				err := config.Initialize(createYMLSnippet(cfgForSnippet))
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("throws an error", func() {
+				err := config.Process()
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("Neither TLS nor non-TLS health endpoints are enabled. Refusing to start gorouter."))
+			})
+		})
 		Context("when tls is specified for the status config", func() {
 			var certPEM, keyPEM []byte
 			var tlsPort uint16

--- a/router/router.go
+++ b/router/router.go
@@ -144,7 +144,7 @@ func NewRouter(
 	}
 
 	if healthListener == nil && component == nil && healthTLSListener == nil {
-		return nil, fmt.Errorf("No TLS certificates provided and non-tls health listner disabled. No health listener can start. This is a bug in gorouter. This error should have been caught when parsing the config")
+		return nil, fmt.Errorf("No TLS certificates provided and non-tls health listener disabled. No health listener can start. This is a bug in gorouter. This error should have been caught when parsing the config")
 	}
 
 	routesListener := &RoutesListener{

--- a/router/router.go
+++ b/router/router.go
@@ -126,23 +126,25 @@ func NewRouter(
 		}
 	}
 
-	healthTLSListener := &HealthListener{
-		Port: cfg.Status.TLS.Port,
-		TLSConfig: &tls.Config{
-			Certificates: []tls.Certificate{cfg.Status.TLSCert},
-			CipherSuites: cfg.CipherSuites,
-			MinVersion:   cfg.MinTLSVersion,
-			MaxVersion:   cfg.MaxTLSVersion,
-		},
-		HealthCheck: healthCheck,
-	}
-
-	if cfg.Status.TLSCert.PrivateKey == nil {
-		return nil, fmt.Errorf("No TLS certificates provided. Health Listener cannot start. This is a bug in gorouter. This error should have been caught when parsing the config")
-	} else {
+	var healthTLSListener *HealthListener
+	if len(cfg.Status.TLSCert.Certificate) != 0 {
+		healthTLSListener = &HealthListener{
+			Port: cfg.Status.TLS.Port,
+			TLSConfig: &tls.Config{
+				Certificates: []tls.Certificate{cfg.Status.TLSCert},
+				CipherSuites: cfg.CipherSuites,
+				MinVersion:   cfg.MinTLSVersion,
+				MaxVersion:   cfg.MaxTLSVersion,
+			},
+			HealthCheck: healthCheck,
+		}
 		if err := healthTLSListener.ListenAndServe(); err != nil {
 			return nil, err
 		}
+	}
+
+	if healthListener == nil && component == nil && healthTLSListener == nil {
+		return nil, fmt.Errorf("No TLS certificates provided and non-tls health listner disabled. No health listener can start. This is a bug in gorouter. This error should have been caught when parsing the config")
 	}
 
 	routesListener := &RoutesListener{


### PR DESCRIPTION
- No longer require health listtener TLS cert configs when launching gorouter with a default config in test-mode
- Throw errors in config parsing + router logic if neither http nor https health listeners are enabled.
- Fix test names and bad URL mgmt for health listener tests.

routing-release requires the TLS certificate to be set still. cf-deployment generates this and passes it in. This change should only affect testing of gorouter.

