### PR TITLE
feat: Use fixed port for local route services server.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -433,6 +433,7 @@ type Config struct {
 	RouteServiceRecommendHttps        bool             `yaml:"route_services_recommend_https,omitempty"`
 	RouteServicesHairpinning          bool             `yaml:"route_services_hairpinning"`
 	RouteServicesHairpinningAllowlist []string         `yaml:"route_services_hairpinning_allowlist,omitempty"`
+	RouteServicesServerPort           uint16           `yaml:"route_services_internal_server_port"`
 	// These fields are populated by the `Process` function.
 	Ip                          string        `yaml:"-"`
 	RouteServiceEnabled         bool          `yaml:"-"`
@@ -480,19 +481,20 @@ type Config struct {
 }
 
 var defaultConfig = Config{
-	Status:        defaultStatusConfig,
-	Nats:          defaultNatsConfig,
-	Logging:       defaultLoggingConfig,
-	Port:          8081,
-	Index:         0,
-	GoMaxProcs:    -1,
-	EnablePROXY:   false,
-	EnableSSL:     false,
-	SSLPort:       443,
-	DisableHTTP:   false,
-	EnableHTTP2:   true,
-	MinTLSVersion: tls.VersionTLS12,
-	MaxTLSVersion: tls.VersionTLS12,
+	Status:                  defaultStatusConfig,
+	Nats:                    defaultNatsConfig,
+	Logging:                 defaultLoggingConfig,
+	Port:                    8081,
+	Index:                   0,
+	GoMaxProcs:              -1,
+	EnablePROXY:             false,
+	EnableSSL:               false,
+	SSLPort:                 443,
+	DisableHTTP:             false,
+	EnableHTTP2:             true,
+	MinTLSVersion:           tls.VersionTLS12,
+	MaxTLSVersion:           tls.VersionTLS12,
+	RouteServicesServerPort: 7070,
 
 	EndpointTimeout:                60 * time.Second,
 	EndpointDialTimeout:            5 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1111,6 +1111,25 @@ load_balancer_healthy_threshold: 10s
 						Expect(config.RouteServiceEnabled).To(BeFalse())
 					})
 				})
+
+				Context("when the route service server port is not set", func() {
+					It("uses the default route service server port", func() {
+						Expect(config.RouteServicesServerPort).To(Equal(uint16(7070)))
+					})
+				})
+
+				Context("when the route service server port is set", func() {
+					BeforeEach(func() {
+						cfgForSnippet.RouteServicesServerPort = 7878
+						err := config.Initialize(createYMLSnippet(cfgForSnippet))
+						Expect(err).ToNot(HaveOccurred())
+						Expect(config.Process()).To(Succeed())
+					})
+
+					It("uses the route service server port", func() {
+						Expect(config.RouteServicesServerPort).To(Equal(uint16(7878)))
+					})
+				})
 			})
 		})
 

--- a/integration/common_integration_test.go
+++ b/integration/common_integration_test.go
@@ -65,7 +65,7 @@ func (s *testState) SetOnlyTrustClientCACertsTrue() {
 
 func NewTestState() *testState {
 	// TODO: don't hide so much behind these test_util methods
-	cfg, clientTLSConfig := test_util.SpecSSLConfig(test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort())
+	cfg, clientTLSConfig := test_util.SpecSSLConfig(test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort(), test_util.NextAvailPort())
 	cfg.SkipSSLValidation = false
 	cfg.RouteServicesHairpinning = false
 	cfg.CipherString = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384"

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -43,10 +43,10 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	pathStruct := Path{path, test}
 	reqBodyBytes := new(bytes.Buffer)
 	json.NewEncoder(reqBodyBytes).Encode(pathStruct)
-	return []byte(reqBodyBytes.Bytes())
+	return reqBodyBytes.Bytes()
 }, func(data []byte) {
 	res := Path{}
-	json.Unmarshal([]byte(string(data)), &res)
+	json.Unmarshal(data, &res)
 	gorouterPath = res.Gorouter
 	testAssets = res.Test
 	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -43,13 +43,13 @@ import (
 var _ = Describe("Router Integration", func() {
 
 	var (
-		cfg                                                                       *config.Config
-		cfgFile                                                                   string
-		tmpdir                                                                    string
-		natsPort, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort uint16
-		natsRunner                                                                *test_util.NATSRunner
-		gorouterSession                                                           *Session
-		oauthServerURL                                                            string
+		cfg                                                                                               *config.Config
+		cfgFile                                                                                           string
+		tmpdir                                                                                            string
+		natsPort, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort uint16
+		natsRunner                                                                                        *test_util.NATSRunner
+		gorouterSession                                                                                   *Session
+		oauthServerURL                                                                                    string
 	)
 
 	BeforeEach(func() {
@@ -64,6 +64,7 @@ var _ = Describe("Router Integration", func() {
 		proxyPort = test_util.NextAvailPort()
 		natsPort = test_util.NextAvailPort()
 		sslPort = test_util.NextAvailPort()
+		routeServiceServerPort = test_util.NextAvailPort()
 
 		natsRunner = test_util.NewNATSRunner(int(natsPort))
 		natsRunner.Start()
@@ -97,7 +98,7 @@ var _ = Describe("Router Integration", func() {
 
 	Context("IsolationSegments", func() {
 		BeforeEach(func() {
-			createIsoSegConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 1, false, []string{"is1", "is2"}, natsPort)
+			createIsoSegConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 1, false, []string{"is1", "is2"}, natsPort)
 		})
 
 		It("logs retrieved IsolationSegments", func() {
@@ -121,7 +122,7 @@ var _ = Describe("Router Integration", func() {
 			mbusClient      *nats.Conn
 		)
 		BeforeEach(func() {
-			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort, natsPort)
 
 		})
 		JustBeforeEach(func() {
@@ -207,7 +208,7 @@ var _ = Describe("Router Integration", func() {
 
 				Context("when the client knows about a CA in the ClientCACerts", func() {
 					BeforeEach(func() {
-						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromClientCACerts, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromClientCACerts, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort, natsPort)
 					})
 					It("can reach the gorouter successfully", func() {
 						curlAppWithCustomClientTLSConfig(http.StatusOK)
@@ -216,7 +217,7 @@ var _ = Describe("Router Integration", func() {
 
 				Context("when the client knows about a CA in the CACerts", func() {
 					BeforeEach(func() {
-						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromCACerts, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromCACerts, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort, natsPort)
 					})
 					It("can reach the gorouter succ", func() {
 						curlAppWithCustomClientTLSConfig(http.StatusOK)
@@ -231,7 +232,7 @@ var _ = Describe("Router Integration", func() {
 
 				Context("when the client presents a cert signed by a CA in ClientCACerts", func() {
 					BeforeEach(func() {
-						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromClientCACerts, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromClientCACerts, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort, natsPort)
 					})
 
 					It("can reach the gorouter successfully", func() {
@@ -241,7 +242,7 @@ var _ = Describe("Router Integration", func() {
 
 				Context("when the client presents a cert signed by a CA in CACerts", func() {
 					BeforeEach(func() {
-						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromCACerts, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+						cfg, clientTLSConfig = createCustomSSLConfig(onlyTrustClientCACerts, test_util.TLSConfigFromCACerts, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort, natsPort)
 					})
 
 					It("cannot reach the gorouter", func() {
@@ -258,7 +259,7 @@ var _ = Describe("Router Integration", func() {
 			mbusClient      *nats.Conn
 		)
 		BeforeEach(func() {
-			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort, natsPort)
 			clientTLSConfig.InsecureSkipVerify = true
 		})
 
@@ -312,7 +313,7 @@ var _ = Describe("Router Integration", func() {
 		)
 
 		BeforeEach(func() {
-			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort, natsPort)
 		})
 
 		JustBeforeEach(func() {
@@ -400,7 +401,7 @@ var _ = Describe("Router Integration", func() {
 
 	Context("Drain", func() {
 		BeforeEach(func() {
-			cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 1, false, 0, natsPort)
+			cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 1, false, 0, natsPort)
 		})
 
 		JustBeforeEach(func() {
@@ -563,7 +564,7 @@ var _ = Describe("Router Integration", func() {
 
 		Context("when ssl is enabled", func() {
 			BeforeEach(func() {
-				tempCfg, _ := createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+				tempCfg, _ := createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort, natsPort)
 				writeConfig(tempCfg, cfgFile)
 			})
 
@@ -598,7 +599,7 @@ var _ = Describe("Router Integration", func() {
 
 	Context("When Dropsonde is misconfigured", func() {
 		It("fails to start", func() {
-			tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 			tempCfg.Logging.MetronAddress = ""
 			writeConfig(tempCfg, cfgFile)
 
@@ -609,7 +610,7 @@ var _ = Describe("Router Integration", func() {
 	})
 
 	It("no longer logs component logs as that disabled by default", func() {
-		createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+		createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 
 		gorouterSession = startGorouterSession(cfgFile)
 
@@ -632,7 +633,7 @@ var _ = Describe("Router Integration", func() {
 		})
 
 		It("emits route registration latency metrics, but only after a waiting period", func() {
-			tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 			tempCfg.Logging.MetronAddress = fakeMetron.Address()
 			tempCfg.RouteLatencyMetricMuzzleDuration = 2 * time.Second
 			writeConfig(tempCfg, cfgFile)
@@ -700,7 +701,7 @@ var _ = Describe("Router Integration", func() {
 
 	Describe("prometheus metrics", func() {
 		It("starts a prometheus https server", func() {
-			c := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			c := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 			metricsPort := test_util.NextAvailPort()
 			serverCAPath, serverCertPath, serverKeyPath, clientCert := tls_helpers.GenerateCaAndMutualTlsCerts()
 
@@ -748,7 +749,7 @@ var _ = Describe("Router Integration", func() {
 
 		BeforeEach(func() {
 
-			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort, natsPort)
 			cfg.RouteServiceSecret = "route-service-secret"
 			cfg.RouteServiceSecretPrev = "my-previous-route-service-secret"
 
@@ -920,7 +921,7 @@ var _ = Describe("Router Integration", func() {
 	Context("when no oauth config is specified", func() {
 		Context("and routing api is disabled", func() {
 			It("is able to start up", func() {
-				tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+				tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 				tempCfg.OAuth = config.OAuthConfig{}
 				writeConfig(tempCfg, cfgFile)
 
@@ -933,7 +934,7 @@ var _ = Describe("Router Integration", func() {
 
 	Context("when routing api is disabled", func() {
 		BeforeEach(func() {
-			cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 			writeConfig(cfg, cfgFile)
 		})
 
@@ -952,7 +953,7 @@ var _ = Describe("Router Integration", func() {
 		)
 
 		BeforeEach(func() {
-			cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 
 			responseBytes = []byte(`[{
 				"guid": "abc123",
@@ -1141,7 +1142,7 @@ var _ = Describe("Router Integration", func() {
 
 		BeforeEach(func() {
 			var clientTLSConfig *tls.Config
-			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort, natsPort)
 			writeConfig(cfg, cfgFile)
 			var err error
 			mbusClient, err = newMessageBus(cfg)
@@ -1223,7 +1224,7 @@ var _ = Describe("Router Integration", func() {
 		)
 
 		BeforeEach(func() {
-			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPort)
+			cfg, clientTLSConfig = createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort, natsPort)
 			writeConfig(cfg, cfgFile)
 			var err error
 			mbusClient, err = newMessageBus(cfg)

--- a/integration/nats_test.go
+++ b/integration/nats_test.go
@@ -23,12 +23,12 @@ import (
 var _ = Describe("NATS Integration", func() {
 
 	var (
-		cfg                                                              *config.Config
-		cfgFile                                                          string
-		tmpdir                                                           string
-		natsPort, statusPort, statusTLSPort, statusRoutesPort, proxyPort uint16
-		natsRunner                                                       *test_util.NATSRunner
-		gorouterSession                                                  *Session
+		cfg                                                                                      *config.Config
+		cfgFile                                                                                  string
+		tmpdir                                                                                   string
+		natsPort, statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort uint16
+		natsRunner                                                                               *test_util.NATSRunner
+		gorouterSession                                                                          *Session
 	)
 
 	BeforeEach(func() {
@@ -42,6 +42,7 @@ var _ = Describe("NATS Integration", func() {
 		statusRoutesPort = test_util.NextAvailPort()
 		proxyPort = test_util.NextAvailPort()
 		natsPort = test_util.NextAvailPort()
+		routeServiceServerPort = test_util.NextAvailPort()
 
 		natsRunner = test_util.NewNATSRunner(int(natsPort))
 		natsRunner.Start()
@@ -63,7 +64,7 @@ var _ = Describe("NATS Integration", func() {
 		SetDefaultEventuallyTimeout(5 * time.Second)
 		defer SetDefaultEventuallyTimeout(1 * time.Second)
 
-		tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+		tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 
 		gorouterSession = startGorouterSession(cfgFile)
 
@@ -139,7 +140,7 @@ var _ = Describe("NATS Integration", func() {
 
 	Context("when nats server shuts down and comes back up", func() {
 		It("should not panic, log the disconnection, and reconnect", func() {
-			tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
+			tempCfg := createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, cfgFile, defaultPruneInterval, defaultPruneThreshold, 0, false, 0, natsPort)
 			tempCfg.NatsClientPingInterval = 100 * time.Millisecond
 			writeConfig(tempCfg, cfgFile)
 			gorouterSession = startGorouterSession(cfgFile)
@@ -167,7 +168,7 @@ var _ = Describe("NATS Integration", func() {
 
 			pruneInterval = 2 * time.Second
 			pruneThreshold = 10 * time.Second
-			cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, pruneInterval, pruneThreshold, 0, false, 0, natsPort, natsPort2)
+			cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, cfgFile, pruneInterval, pruneThreshold, 0, false, 0, natsPort, natsPort2)
 		})
 
 		AfterEach(func() {
@@ -230,7 +231,7 @@ var _ = Describe("NATS Integration", func() {
 				pruneInterval = 200 * time.Millisecond
 				pruneThreshold = 1000 * time.Millisecond
 				suspendPruningIfNatsUnavailable := true
-				cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, cfgFile, pruneInterval, pruneThreshold, 0, suspendPruningIfNatsUnavailable, 0, natsPort, natsPort2)
+				cfg = createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, cfgFile, pruneInterval, pruneThreshold, 0, suspendPruningIfNatsUnavailable, 0, natsPort, natsPort2)
 				cfg.NatsClientPingInterval = 200 * time.Millisecond
 			})
 

--- a/integration/test_utils_test.go
+++ b/integration/test_utils_test.go
@@ -22,8 +22,8 @@ const defaultPruneInterval = 50 * time.Millisecond
 const defaultPruneThreshold = 100 * time.Millisecond
 const localIP = "127.0.0.1"
 
-func createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort uint16, cfgFile string, pruneInterval time.Duration, pruneThreshold time.Duration, drainWait int, suspendPruning bool, maxBackendConns int64, natsPorts ...uint16) *config.Config {
-	tempCfg := test_util.SpecConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, natsPorts...)
+func createConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort uint16, cfgFile string, pruneInterval time.Duration, pruneThreshold time.Duration, drainWait int, suspendPruning bool, maxBackendConns int64, natsPorts ...uint16) *config.Config {
+	tempCfg := test_util.SpecConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, natsPorts...)
 
 	configDrainSetup(tempCfg, pruneInterval, pruneThreshold, drainWait)
 
@@ -89,22 +89,22 @@ func stopGorouter(gorouterSession *Session) {
 	Eventually(gorouterSession, 5).Should(Exit(0))
 }
 
-func createCustomSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
-	tempCfg, clientTLSConfig := test_util.CustomSpecSSLConfig(onlyTrustClientCACerts, TLSClientConfigOption, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPorts...)
+func createCustomSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
+	tempCfg, clientTLSConfig := test_util.CustomSpecSSLConfig(onlyTrustClientCACerts, TLSClientConfigOption, statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort, natsPorts...)
 
 	configDrainSetup(tempCfg, defaultPruneInterval, defaultPruneThreshold, 0)
 	return tempCfg, clientTLSConfig
 }
 
-func createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
-	tempCfg, clientTLSConfig := test_util.SpecSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, natsPorts...)
+func createSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
+	tempCfg, clientTLSConfig := test_util.SpecSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, sslPort, routeServiceServerPort, natsPorts...)
 
 	configDrainSetup(tempCfg, defaultPruneInterval, defaultPruneThreshold, 0)
 	return tempCfg, clientTLSConfig
 }
 
-func createIsoSegConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort uint16, cfgFile string, pruneInterval, pruneThreshold time.Duration, drainWait int, suspendPruning bool, isoSegs []string, natsPorts ...uint16) *config.Config {
-	tempCfg := test_util.SpecConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, natsPorts...)
+func createIsoSegConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort uint16, cfgFile string, pruneInterval, pruneThreshold time.Duration, drainWait int, suspendPruning bool, isoSegs []string, natsPorts ...uint16) *config.Config {
+	tempCfg := test_util.SpecConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, natsPorts...)
 
 	configDrainSetup(tempCfg, pruneInterval, pruneThreshold, drainWait)
 

--- a/main.go
+++ b/main.go
@@ -181,7 +181,7 @@ func main() {
 		MaxVersion:         c.MaxTLSVersion,
 	}
 
-	rss, err := router.NewRouteServicesServer()
+	rss, err := router.NewRouteServicesServer(c)
 	if err != nil {
 		logger.Fatal("new-route-services-server", zap.Error(err))
 	}

--- a/router/route_service_server.go
+++ b/router/route_service_server.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"code.cloudfoundry.org/gorouter/config"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -32,7 +33,7 @@ type RouteServicesServer struct {
 	servers    []*http.Server
 }
 
-func NewRouteServicesServer() (*RouteServicesServer, error) {
+func NewRouteServicesServer(cfg *config.Config) (*RouteServicesServer, error) {
 	caCert, caPriv, err := createCA()
 	if err != nil {
 		return nil, fmt.Errorf("create ca: %s", err)
@@ -50,7 +51,7 @@ func NewRouteServicesServer() (*RouteServicesServer, error) {
 		return nil, fmt.Errorf("create server certificate: %s", err)
 	}
 
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", cfg.RouteServicesServerPort))
 	if err != nil {
 		return nil, fmt.Errorf("starting local listener: %s", err)
 	}

--- a/router/route_service_server_test.go
+++ b/router/route_service_server_test.go
@@ -3,6 +3,7 @@ package router_test
 import (
 	"net/http"
 
+	"code.cloudfoundry.org/gorouter/config"
 	"code.cloudfoundry.org/gorouter/router"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,6 +16,7 @@ var _ = Describe("RouteServicesServer", func() {
 		handler http.Handler
 		errChan chan error
 		req     *http.Request
+		cfg     *config.Config
 	)
 
 	BeforeEach(func() {
@@ -23,7 +25,9 @@ var _ = Describe("RouteServicesServer", func() {
 		})
 
 		var err error
-		rss, err = router.NewRouteServicesServer()
+		cfg, err = config.DefaultConfig()
+		Expect(err).NotTo(HaveOccurred())
+		rss, err = router.NewRouteServicesServer(cfg)
 		Expect(err).NotTo(HaveOccurred())
 
 		errChan = make(chan error)

--- a/test_util/helpers.go
+++ b/test_util/helpers.go
@@ -162,12 +162,12 @@ func runBackendInstance(ln net.Listener, handler connHandler) {
 	}
 }
 
-func SpecConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort uint16, natsPorts ...uint16) *config.Config {
-	return generateConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, natsPorts...)
+func SpecConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort uint16, natsPorts ...uint16) *config.Config {
+	return generateConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, natsPorts...)
 }
 
-func SpecSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, SSLPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
-	c := generateConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, natsPorts...)
+func SpecSSLConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, SSLPort, routeServiceServerPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
+	c := generateConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, natsPorts...)
 
 	c.EnableSSL = true
 
@@ -204,8 +204,8 @@ const (
 	TLSConfigFromUnknownCA     = 3
 )
 
-func CustomSpecSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int, statusPort, statusTLSPort, statusRoutesPort, proxyPort, SSLPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
-	c := generateConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, natsPorts...)
+func CustomSpecSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int, statusPort, statusTLSPort, statusRoutesPort, proxyPort, SSLPort, routeServiceServerPort uint16, natsPorts ...uint16) (*config.Config, *tls.Config) {
+	c := generateConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort, natsPorts...)
 
 	c.EnableSSL = true
 
@@ -258,7 +258,7 @@ func CustomSpecSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int,
 	return c, clientTLSConfig
 }
 
-func generateConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort uint16, natsPorts ...uint16) *config.Config {
+func generateConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort, routeServiceServerPort uint16, natsPorts ...uint16) *config.Config {
 	c, err := config.DefaultConfig()
 	Expect(err).ToNot(HaveOccurred())
 
@@ -325,6 +325,7 @@ func generateConfig(statusPort, statusTLSPort, statusRoutesPort, proxyPort uint1
 
 	c.Backends.MaxAttempts = 3
 	c.RouteServiceConfig.MaxAttempts = 3
+	c.RouteServicesServerPort = routeServiceServerPort
 
 	return c
 }


### PR DESCRIPTION
* A short explanation of the proposed change:

Fixes [issue 342 on routing-release](https://github.com/cloudfoundry/routing-release/issues/342)

* An explanation of the use cases your change solves

- Select dedicated port for the internal route service server
- Adjust tests and config accordingly

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

1. Deploy gorouter
2. `netstat -ant | grep LISTEN` should show port 7070 opened on 127.0.0.1 next to the other dedicated ports

* Expected result after the change

- Gorouter opens a dedicated port for the internal route service server

* Current result before the change

- Gorouter uses a random high port for the internal route service server

* Links to any other associated PRs

- Routing-release [companion PR](https://github.com/cloudfoundry/routing-release/pull/382)

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
