### PR TITLE
Log az details with endpoints

### DIFF
--- a/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/proxy/round_tripper/proxy_round_tripper_test.go
@@ -131,6 +131,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 				Port:                 9090,
 				PrivateInstanceId:    "instanceId",
 				PrivateInstanceIndex: "1",
+				AvailabilityZone:     AZ,
 			})
 
 			added := routePool.Put(endpoint)
@@ -262,6 +263,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 							Port:                 9090,
 							PrivateInstanceId:    fmt.Sprintf("instanceID%d", i),
 							PrivateInstanceIndex: fmt.Sprintf("%d", i),
+							AvailabilityZone:     AZ,
 						})
 
 						Expect(routePool.Put(endpoint)).To(Equal(route.ADDED))
@@ -282,6 +284,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 						if strings.Contains(errorLogs[i], "backend-endpoint-failed") {
 							count++
 						}
+						Expect(errorLogs[i]).To(ContainSubstring(AZ))
 					}
 					Expect(count).To(Equal(2))
 					Expect(res.StatusCode).To(Equal(http.StatusTeapot))

--- a/route/pool.go
+++ b/route/pool.go
@@ -515,8 +515,8 @@ func (e *Endpoint) CanonicalAddr() string {
 	return e.addr
 }
 
-func (rm *Endpoint) Component() string {
-	return rm.Tags["component"]
+func (e *Endpoint) Component() string {
+	return e.Tags["component"]
 }
 
 func (e *Endpoint) ToLogData() []zap.Field {
@@ -525,6 +525,7 @@ func (e *Endpoint) ToLogData() []zap.Field {
 		zap.String("Addr", e.addr),
 		zap.Object("Tags", e.Tags),
 		zap.String("RouteServiceUrl", e.RouteServiceUrl),
+		zap.String("AZ", e.AvailabilityZone),
 	}
 }
 


### PR DESCRIPTION
* A short explanation of the proposed change:

- Add AZ information with endpoint logs (missing)

* An explanation of the use cases your change solves

This seems to be a missing part of the az-aware routing change. Whenever load balancer logs endpoint errors, it will now also log the availability zone.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

Error logs should now contain a `"AZ: <az name>"` field.

* Expected result after the change

Error logs should now contain a `"AZ: <az name>"` field.

* Current result before the change

Error logs do not contain a `"AZ: <az name>"` field for endpoints.

* Links to any other associated PRs

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
