### PR TITLE
Enable full duplex mode for HTTP/1 requests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -359,29 +359,30 @@ func InitClientCertMetadataRules(rules []VerifyClientCertificateMetadataRule, ce
 }
 
 type Config struct {
-	Status          StatusConfig      `yaml:"status,omitempty"`
-	Nats            NatsConfig        `yaml:"nats,omitempty"`
-	Logging         LoggingConfig     `yaml:"logging,omitempty"`
-	Port            uint16            `yaml:"port,omitempty"`
-	Prometheus      PrometheusConfig  `yaml:"prometheus,omitempty"`
-	Index           uint              `yaml:"index,omitempty"`
-	Zone            string            `yaml:"zone,omitempty"`
-	GoMaxProcs      int               `yaml:"go_max_procs,omitempty"`
-	Tracing         Tracing           `yaml:"tracing,omitempty"`
-	TraceKey        string            `yaml:"trace_key,omitempty"`
-	AccessLog       AccessLog         `yaml:"access_log,omitempty"`
-	DebugAddr       string            `yaml:"debug_addr,omitempty"`
-	EnablePROXY     bool              `yaml:"enable_proxy,omitempty"`
-	EnableSSL       bool              `yaml:"enable_ssl,omitempty"`
-	SSLPort         uint16            `yaml:"ssl_port,omitempty"`
-	DisableHTTP     bool              `yaml:"disable_http,omitempty"`
-	EnableHTTP2     bool              `yaml:"enable_http2"`
-	SSLCertificates []tls.Certificate `yaml:"-"`
-	TLSPEM          []TLSPem          `yaml:"tls_pem,omitempty"`
-	CACerts         []string          `yaml:"ca_certs,omitempty"`
-	CAPool          *x509.CertPool    `yaml:"-"`
-	ClientCACerts   string            `yaml:"client_ca_certs,omitempty"`
-	ClientCAPool    *x509.CertPool    `yaml:"-"`
+	Status                         StatusConfig      `yaml:"status,omitempty"`
+	Nats                           NatsConfig        `yaml:"nats,omitempty"`
+	Logging                        LoggingConfig     `yaml:"logging,omitempty"`
+	Port                           uint16            `yaml:"port,omitempty"`
+	Prometheus                     PrometheusConfig  `yaml:"prometheus,omitempty"`
+	Index                          uint              `yaml:"index,omitempty"`
+	Zone                           string            `yaml:"zone,omitempty"`
+	GoMaxProcs                     int               `yaml:"go_max_procs,omitempty"`
+	Tracing                        Tracing           `yaml:"tracing,omitempty"`
+	TraceKey                       string            `yaml:"trace_key,omitempty"`
+	AccessLog                      AccessLog         `yaml:"access_log,omitempty"`
+	DebugAddr                      string            `yaml:"debug_addr,omitempty"`
+	EnablePROXY                    bool              `yaml:"enable_proxy,omitempty"`
+	EnableSSL                      bool              `yaml:"enable_ssl,omitempty"`
+	SSLPort                        uint16            `yaml:"ssl_port,omitempty"`
+	DisableHTTP                    bool              `yaml:"disable_http,omitempty"`
+	EnableHTTP2                    bool              `yaml:"enable_http2"`
+	EnableHTTP1ConcurrentReadWrite bool              `yaml:"enable_http1_concurrent_read_write"`
+	SSLCertificates                []tls.Certificate `yaml:"-"`
+	TLSPEM                         []TLSPem          `yaml:"tls_pem,omitempty"`
+	CACerts                        []string          `yaml:"ca_certs,omitempty"`
+	CAPool                         *x509.CertPool    `yaml:"-"`
+	ClientCACerts                  string            `yaml:"client_ca_certs,omitempty"`
+	ClientCAPool                   *x509.CertPool    `yaml:"-"`
 
 	SkipSSLValidation        bool     `yaml:"skip_ssl_validation,omitempty"`
 	ForwardedClientCert      string   `yaml:"forwarded_client_cert,omitempty"`
@@ -482,20 +483,21 @@ type Config struct {
 }
 
 var defaultConfig = Config{
-	Status:                  defaultStatusConfig,
-	Nats:                    defaultNatsConfig,
-	Logging:                 defaultLoggingConfig,
-	Port:                    8081,
-	Index:                   0,
-	GoMaxProcs:              -1,
-	EnablePROXY:             false,
-	EnableSSL:               false,
-	SSLPort:                 443,
-	DisableHTTP:             false,
-	EnableHTTP2:             true,
-	MinTLSVersion:           tls.VersionTLS12,
-	MaxTLSVersion:           tls.VersionTLS12,
-	RouteServicesServerPort: 7070,
+	Status:                         defaultStatusConfig,
+	Nats:                           defaultNatsConfig,
+	Logging:                        defaultLoggingConfig,
+	Port:                           8081,
+	Index:                          0,
+	GoMaxProcs:                     -1,
+	EnablePROXY:                    false,
+	EnableSSL:                      false,
+	SSLPort:                        443,
+	DisableHTTP:                    false,
+	EnableHTTP2:                    true,
+	EnableHTTP1ConcurrentReadWrite: false,
+	MinTLSVersion:                  tls.VersionTLS12,
+	MaxTLSVersion:                  tls.VersionTLS12,
+	RouteServicesServerPort:        7070,
 
 	EndpointTimeout:                60 * time.Second,
 	EndpointDialTimeout:            5 * time.Second,

--- a/handlers/access_log.go
+++ b/handlers/access_log.go
@@ -13,7 +13,7 @@ import (
 	"code.cloudfoundry.org/gorouter/proxy/utils"
 
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 type accessLog struct {

--- a/handlers/access_log_test.go
+++ b/handlers/access_log_test.go
@@ -15,7 +15,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 var _ = Describe("AccessLog", func() {

--- a/handlers/clientcert.go
+++ b/handlers/clientcert.go
@@ -12,7 +12,7 @@ import (
 	"code.cloudfoundry.org/gorouter/logger"
 	"code.cloudfoundry.org/gorouter/routeservice"
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 const xfcc = "X-Forwarded-Client-Cert"

--- a/handlers/clientcert_test.go
+++ b/handlers/clientcert_test.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 var _ = Describe("Clientcert", func() {

--- a/handlers/http_rewrite.go
+++ b/handlers/http_rewrite.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 
 	"code.cloudfoundry.org/gorouter/config"
 	"code.cloudfoundry.org/gorouter/proxy/utils"

--- a/handlers/http_rewrite_test.go
+++ b/handlers/http_rewrite_test.go
@@ -8,7 +8,7 @@ import (
 	"code.cloudfoundry.org/gorouter/handlers"
 	logger_fakes "code.cloudfoundry.org/gorouter/logger/fakes"
 
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/handlers/httplatencyprometheus.go
+++ b/handlers/httplatencyprometheus.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	metrics "code.cloudfoundry.org/go-metric-registry"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 type Registry interface {

--- a/handlers/httplatencyprometheus_test.go
+++ b/handlers/httplatencyprometheus_test.go
@@ -14,7 +14,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 var _ = Describe("Http Prometheus Latency", func() {

--- a/handlers/httpstartstop.go
+++ b/handlers/httpstartstop.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cloudfoundry/sonde-go/events"
 	uuid "github.com/nu7hatch/gouuid"
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/handlers/httpstartstop_test.go
+++ b/handlers/httpstartstop_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 func findEnvelope(fakeEmitter *fake.FakeEventEmitter, eventType events.Envelope_EventType) *events.Envelope {

--- a/handlers/lookup.go
+++ b/handlers/lookup.go
@@ -14,7 +14,7 @@ import (
 	"code.cloudfoundry.org/gorouter/registry"
 	"code.cloudfoundry.org/gorouter/route"
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 const CfAppInstance = "X-CF-APP-INSTANCE"

--- a/handlers/lookup_test.go
+++ b/handlers/lookup_test.go
@@ -16,7 +16,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 var _ = Describe("Lookup", func() {

--- a/handlers/max_request_size_test.go
+++ b/handlers/max_request_size_test.go
@@ -14,7 +14,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 var _ = Describe("MaxRequestSize", func() {

--- a/handlers/paniccheck.go
+++ b/handlers/paniccheck.go
@@ -10,7 +10,7 @@ import (
 
 	"code.cloudfoundry.org/gorouter/logger"
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 type panicCheck struct {

--- a/handlers/paniccheck_test.go
+++ b/handlers/paniccheck_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 var _ = Describe("Paniccheck", func() {

--- a/handlers/protocolcheck.go
+++ b/handlers/protocolcheck.go
@@ -10,7 +10,7 @@ import (
 
 	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/logger"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 type protocolCheck struct {

--- a/handlers/protocolcheck_test.go
+++ b/handlers/protocolcheck_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 var _ = Describe("Protocolcheck", func() {

--- a/handlers/proxy_healthcheck.go
+++ b/handlers/proxy_healthcheck.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"code.cloudfoundry.org/gorouter/common/health"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 type proxyHealthcheck struct {

--- a/handlers/proxy_healthcheck_test.go
+++ b/handlers/proxy_healthcheck_test.go
@@ -11,7 +11,7 @@ import (
 	"code.cloudfoundry.org/gorouter/test_util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 var _ = Describe("Proxy Healthcheck", func() {

--- a/handlers/proxywriter.go
+++ b/handlers/proxywriter.go
@@ -5,7 +5,7 @@ import (
 
 	"code.cloudfoundry.org/gorouter/logger"
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 
 	"code.cloudfoundry.org/gorouter/proxy/utils"
 )

--- a/handlers/proxywriter_test.go
+++ b/handlers/proxywriter_test.go
@@ -13,7 +13,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 var _ = Describe("ProxyWriter", func() {

--- a/handlers/query_param.go
+++ b/handlers/query_param.go
@@ -8,7 +8,7 @@ import (
 	"code.cloudfoundry.org/gorouter/logger"
 
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 type queryParam struct {

--- a/handlers/query_param_test.go
+++ b/handlers/query_param_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 var _ = Describe("QueryParamHandler", func() {

--- a/handlers/reporter.go
+++ b/handlers/reporter.go
@@ -9,7 +9,7 @@ import (
 
 	"code.cloudfoundry.org/gorouter/logger"
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 type reporterHandler struct {

--- a/handlers/reporter_test.go
+++ b/handlers/reporter_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 var _ = Describe("Reporter Handler", func() {

--- a/handlers/request_id.go
+++ b/handlers/request_id.go
@@ -5,7 +5,7 @@ import (
 
 	"code.cloudfoundry.org/gorouter/logger"
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 const (

--- a/handlers/request_id_test.go
+++ b/handlers/request_id_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 const UUIDRegex = "^(urn\\:uuid\\:)?\\{?([a-z0-9]{8})-([a-z0-9]{4})-([1-5][a-z0-9]{3})-([a-z0-9]{4})-([a-z0-9]{12})\\}?$"

--- a/handlers/requestinfo.go
+++ b/handlers/requestinfo.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/openzipkin/zipkin-go/idgenerator"
 	"github.com/openzipkin/zipkin-go/model"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 type key string

--- a/handlers/requestinfo_test.go
+++ b/handlers/requestinfo_test.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 var _ = Describe("RequestInfoHandler", func() {

--- a/handlers/routeservice.go
+++ b/handlers/routeservice.go
@@ -13,7 +13,7 @@ import (
 	"code.cloudfoundry.org/gorouter/registry"
 	"code.cloudfoundry.org/gorouter/routeservice"
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 
 	"code.cloudfoundry.org/gorouter/route"
 )

--- a/handlers/routeservice_test.go
+++ b/handlers/routeservice_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 )
 
 var _ = Describe("Route Service Handler", func() {

--- a/handlers/w3c.go
+++ b/handlers/w3c.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 
 	"code.cloudfoundry.org/gorouter/logger"
 )

--- a/handlers/zipkin.go
+++ b/handlers/zipkin.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/openzipkin/zipkin-go/propagation/b3"
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 
 	"code.cloudfoundry.org/gorouter/logger"
 )

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -214,7 +214,7 @@ func (p *proxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.Requ
 	logger := handlers.LoggerWithTraceInfo(p.logger, request)
 	proxyWriter := responseWriter.(utils.ProxyResponseWriter)
 
-	if request.ProtoMajor < 2 {
+	if p.config.EnableHTTP1ConcurrentReadWrite && request.ProtoMajor == 1 {
 		rc := http.NewResponseController(proxyWriter)
 
 		err := rc.EnableFullDuplex()

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/cloudfoundry/dropsonde"
 	"github.com/uber-go/zap"
-	"github.com/urfave/negroni"
+	"github.com/urfave/negroni/v3"
 
 	"code.cloudfoundry.org/gorouter/accesslog"
 	router_http "code.cloudfoundry.org/gorouter/common/http"
@@ -213,6 +213,15 @@ func ForceDeleteXFCCHeader(routeServiceValidator RouteServiceValidator, forwarde
 func (p *proxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request, next http.HandlerFunc) {
 	logger := handlers.LoggerWithTraceInfo(p.logger, request)
 	proxyWriter := responseWriter.(utils.ProxyResponseWriter)
+
+	if request.ProtoMajor < 2 {
+		rc := http.NewResponseController(proxyWriter)
+
+		err := rc.EnableFullDuplex()
+		if err != nil {
+			logger.Panic("enable-full-duplex-err", zap.Error(err))
+		}
+	}
 
 	reqInfo, err := handlers.ContextRequestInfo(request)
 	if err != nil {

--- a/proxy/proxy_suite_test.go
+++ b/proxy/proxy_suite_test.go
@@ -83,6 +83,7 @@ var _ = BeforeEach(func() {
 	conf.EnableHTTP2 = false
 	conf.Backends.MaxAttempts = 3
 	conf.RouteServiceConfig.MaxAttempts = 3
+	conf.DisableKeepAlives = false
 	fakeReporter = &fakes.FakeCombinedReporter{}
 	fakeRegistry = fake_registry.NewMetricsRegistry()
 	skipSanitization = func(*http.Request) bool { return false }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -765,6 +765,63 @@ var _ = Describe("Proxy", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		})
 
+		It("can simultaneously read request and write response", func() {
+			contentLength := len("message 0\n") * 10
+			ln := test_util.RegisterConnHandler(r, "read-write", func(conn *test_util.HttpConn) {
+				defer conn.Close()
+
+				req, err := http.ReadRequest(conn.Reader)
+				Expect(err).NotTo(HaveOccurred())
+				defer req.Body.Close()
+
+				conn.Writer.WriteString("HTTP/1.1 200 OK\r\n" +
+					"Connection: keep-alive\r\n" +
+					"Content-Type: text/plain\r\n" +
+					fmt.Sprintf("Content-Length: %d\r\n", contentLength) +
+					"\r\n")
+				conn.Writer.Flush()
+				reader := bufio.NewReader(req.Body)
+
+				for i := 0; i < 10; i++ {
+					// send back the received message
+					line, err := reader.ReadString('\n')
+					if err != nil {
+						break
+					}
+					conn.Writer.Write([]byte(line))
+					conn.Writer.Flush()
+				}
+			})
+			defer ln.Close()
+
+			conn := dialProxy(proxyServer)
+			// the test is hanging when fix is not implemented
+			conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+
+			conn.Writer.Write([]byte("GET / HTTP/1.1\r\n" +
+				"Host: read-write\r\n" +
+				"Connection: keep-alive\r\n" +
+				"Content-Type: text/plain\r\n" +
+				fmt.Sprintf("Content-Length: %d\r\n", contentLength) +
+				"\r\n",
+			))
+			conn.Writer.Flush()
+
+			resp, err := http.ReadResponse(conn.Reader, &http.Request{})
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			reader := bufio.NewReader(resp.Body)
+
+			for i := 0; i < 10; i++ {
+				message := fmt.Sprintf("message %d\n", i)
+				conn.Writer.Write([]byte(message))
+				conn.Writer.Flush()
+				line, err := reader.ReadString('\n')
+				Expect(err).NotTo(HaveOccurred())
+				Expect(line).To(Equal(message))
+			}
+		})
+
 		It("retries on POST requests if nothing was written", func() {
 			//FIXME: this test is flakey. we can't skip/pend this test since CI will fail on any skipped/pending
 			//       tests

--- a/proxy/utils/responsewriter.go
+++ b/proxy/utils/responsewriter.go
@@ -118,6 +118,11 @@ func (p *proxyResponseWriter) Size() int {
 	return p.size
 }
 
+// Satisfy http.ResponseController support (Go 1.20+)
+func (p *proxyResponseWriter) Unwrap() http.ResponseWriter {
+	return p.w
+}
+
 func (p *proxyResponseWriter) AddHeaderRewriter(r HeaderRewriter) {
 	p.headerRewriters = append(p.headerRewriters, r)
 }

--- a/proxy/utils/responsewriter_test.go
+++ b/proxy/utils/responsewriter_test.go
@@ -218,4 +218,11 @@ var _ = Describe("ProxyWriter", func() {
 		Expect(r2.rewriteHeaderCalled).To(BeTrue())
 		Expect(r2.rewriteHeaderHeader).To(HaveKey("Foo"))
 	})
+
+	Describe("Unwrap", func() {
+		It("returns the underlying ResponseWriter", func() {
+			responseWriter := proxy.Unwrap()
+			Expect(responseWriter).To(Equal(fake))
+		})
+	})
 })


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

Go 1.20+ added support for full duplex mode which allows HTTP server handlers to concurrently read from the request and write response. Enable full duplex mode for HTTP/1 requests (HTTP/2 already supports it and EnableFullDuplex fails for HTTP/2)

Add Unwrap to utils.ResponseWriter to satisfy http.ResponseController support (Go 1.20+) https://pkg.go.dev/net/http#NewResponseController

Bump negroni to v3 to get Unwrap on negroni.ResponseWriter as well. The release change PR is [here](https://github.com/cloudfoundry/routing-release/pull/389)

* An explanation of the use cases your change solves

Stream processing, early validation to cancel large requests, 100 Continue scenarios.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

Push an app that validates custom header in request and sends 400 response before reading the request body. Have a client that sends HTTP/1 request without closing its body, gets response and cancels request if 401. An example of such client is [here](https://github.com/cloudfoundry/gorouter/blob/fullduplex/proxy/proxy_test.go#L768)

* Expected result after the change

Request is canceled before the request body is written.

* Current result before the change

Gorouter is waiting for the full request body first before sending response back.

* Links to any other associated PRs

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `main` branch

* [X] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
