### PR TITLE
fix: Don't retry more often than endpoints available

### DIFF
--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -163,12 +163,12 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 	var selectEndpointErr error
 	var maxAttempts int
 	if reqInfo.RouteServiceURL == nil {
-		maxAttempts = rt.config.Backends.MaxAttempts
+		maxAttempts = max(min(rt.config.Backends.MaxAttempts, reqInfo.RoutePool.NumEndpoints()), 1)
 	} else {
 		maxAttempts = rt.config.RouteServiceConfig.MaxAttempts
 	}
 
-	for attempt := 1; attempt <= maxAttempts || maxAttempts == 0; attempt++ {
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		logger := rt.logger
 
 		// Reset the trace to prepare for new times and prevent old data from polluting our results.

--- a/route/pool.go
+++ b/route/pool.go
@@ -125,6 +125,9 @@ func (e *Endpoint) Equal(e2 *Endpoint) bool {
 
 //go:generate counterfeiter -o fakes/fake_endpoint_iterator.go . EndpointIterator
 type EndpointIterator interface {
+	// Next MUST either return the next endpoint available or nil. It MUST NOT return the same endpoint.
+	// All available endpoints MUST have been used before any can be used again.
+	// ProxyRoundTripper will not retry more often than endpoints available.
 	Next(attempt int) *Endpoint
 	EndpointFailed(err error)
 	PreRequest(e *Endpoint)


### PR DESCRIPTION
* A short explanation of the proposed change:

Fixes [issue 385](https://github.com/cloudfoundry/routing-release/issues/385)

- Remove unlimited retries as it is dangerous. [companion PR for spec on routing-release](https://github.com/cloudfoundry/routing-release/pull/390)
- Minimum number of attempts is 1
- Do not attempt more often than endpoints available on the route
- Fixed test suite to actually use the number of backends as claimed in the tests (instead of trying 5 times on one endpoint, we will now actually try on 5 different endpoints)

* An explanation of the use cases your change solves

With [a change](https://github.com/cloudfoundry/gorouter/commit/b820e884e3d11755e306ca2e14e83c207855091a) to error classifications, errors such as "IdempotentEOF" are no longer prunable. They only are retry-able now (which is correct, because we don't know for sure if the endpoint is unusable and must be pruned).

This has the side-effect that apps that are slow and buggy tend to exhaust `config.backends.maxAttempts`, which can be dangerous if `maxAttempts` is set to a high value or even unlimited, which could cause Gorouter to take extremely long to respond. This is because prior to this PR, Gorouter would have only stopped trying once `maxAttempts` had been reached, regardless whether or not all of the endpoints were non-working.

This PR makes it so that Gorouter will at most try the number of endpoints in the route before giving up. If there is only one endpoint and it's broken, there is no point in trying it 5 times in a row, it just slows everything down.

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

1. Deploy an app with 3 endpoints, all of them unresponsive
2. Set `config.backends.maxAttempts` to 5
3. Curl the app

* Expected result after the change

Gorouter tries 3 times until all endpoints are exhausted

* Current result before the change

Gorouter tries 5 times, retrying endoints it already tried and failed

* Links to any other associated PRs

[routing-release PR](https://github.com/cloudfoundry/routing-release/pull/390)

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `main` branch

* [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
