### PR TITLE
Stop using deprecated httputil.ClientConn

### DIFF
--- a/router/router_suite_test.go
+++ b/router/router_suite_test.go
@@ -2,6 +2,7 @@ package router_test
 
 import (
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/cloudfoundry/dropsonde"
@@ -18,7 +19,10 @@ func TestRouter(t *testing.T) {
 	RunSpecs(t, "Router Suite")
 }
 
+var originalDefaultTransport *http.Transport
+
 var _ = SynchronizedBeforeSuite(func() []byte {
+	originalDefaultTransport = http.DefaultTransport.(*http.Transport)
 	fakeEmitter := fake.NewFakeEventEmitter("fake")
 	dropsonde.InitializeWithEmitter(fakeEmitter)
 	return nil

--- a/test/greet_app.go
+++ b/test/greet_app.go
@@ -22,5 +22,5 @@ func headerHandler(w http.ResponseWriter, r *http.Request) {
 	io.WriteString(w, fmt.Sprintf("%+v", r.Header.Get("X-Forwarded-Proto")))
 }
 func greetHandler(w http.ResponseWriter, r *http.Request) {
-	io.WriteString(w, "Hello, world")
+	io.WriteString(w, fmt.Sprintf("Hello, %s", r.RemoteAddr))
 }


### PR DESCRIPTION
<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
