### PR TITLE
Remove use of net.Error's Temporary() function as it is deprecated an…

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1360,11 +1360,6 @@ var _ = Describe("Proxy", func() {
 					for {
 						conn, err := nl.Accept()
 						if err != nil {
-							if ne, ok := err.(net.Error); ok && ne.Temporary() {
-								fmt.Printf("http: Accept error: %v; retrying in %v\n", err, 5*time.Second)
-								time.Sleep(5 * time.Second)
-								continue
-							}
 							break
 						}
 						go func() {

--- a/test_util/helpers.go
+++ b/test_util/helpers.go
@@ -136,23 +136,9 @@ type RegisterConfig struct {
 }
 
 func runBackendInstance(ln net.Listener, handler connHandler) {
-	var tempDelay time.Duration // how long to sleep on accept failure
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
-			if ne, ok := err.(net.Error); ok && ne.Temporary() {
-				if tempDelay == 0 {
-					tempDelay = 5 * time.Millisecond
-				} else {
-					tempDelay *= 2
-				}
-				if max := 1 * time.Second; tempDelay > max {
-					tempDelay = max
-				}
-				fmt.Printf("http: Accept error: %v; retrying in %v\n", err, tempDelay)
-				time.Sleep(tempDelay)
-				continue
-			}
 			break
 		}
 		go func() {


### PR DESCRIPTION
…d should not be trusted. Removing the retries did not seem to impact test flakiness.

<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
