### PR TITLE
Remove deprecated ResponseWriter.CloseNotifier()

### DIFF
--- a/proxy/utils/responsewriter.go
+++ b/proxy/utils/responsewriter.go
@@ -17,7 +17,6 @@ type ProxyResponseWriter interface {
 	Status() int
 	SetStatus(status int)
 	Size() int
-	CloseNotify() <-chan bool
 	AddHeaderRewriter(HeaderRewriter)
 }
 
@@ -39,13 +38,6 @@ func NewProxyResponseWriter(w http.ResponseWriter) *proxyResponseWriter {
 	}
 
 	return proxyWriter
-}
-
-func (p *proxyResponseWriter) CloseNotify() <-chan bool {
-	if closeNotifier, ok := p.w.(http.CloseNotifier); ok {
-		return closeNotifier.CloseNotify()
-	}
-	return make(chan bool)
 }
 
 func (p *proxyResponseWriter) Header() http.Header {


### PR DESCRIPTION
The underlying method is deprecated in favor of using Context. We don't appear to use the function anywhere, and all tests are passing after removing it outright.

<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
