### PR TITLE
revert: remove deprecated buildnametocertificate call

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -298,6 +298,11 @@ func (r *Router) serveHTTPS(server *http.Server, errChan chan error) error {
 		tlsConfig.NextProtos = []string{"h2", "http/1.1"}
 	}
 
+	// Although this functionality is deprecated there is no intention to remove it from the stdlib
+	// due to the Go 1 compatibility promise. We rely on it to prefer more specific matches (a full
+	// SNI match over wildcard matches) instead of relying on the order of certificates.
+	tlsConfig.BuildNameToCertificate()
+
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", r.config.SSLPort))
 	if err != nil {
 		r.logger.Fatal("tls-listener-error", zap.Error(err))


### PR DESCRIPTION
The refactor had unintended side-effects: when selecting a certificate the NameToCertificate map which is built using this call ensured that more specific certificates are preferred over wildcard matches. We rely on that behaviour to present the correct certificate to clients.

This reverts commit 6c6bd520ad939910fe8c0830558f6dd179e7d113.

Resolves: cloudfoundry/routing-release#401

<!-- Thanks for contributing to 'gorouter'. To speed up the process of reviewing your pull request please provide us with: -->

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Instructions to functionally test the behavior change using operator interfaces (BOSH manifest, logs, curl, and metrics)

* Expected result after the change

* Current result before the change

* Links to any other associated PRs

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `main` branch

* [ ] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

* [ ] (Optional) I have run Routing Acceptance Tests and Routing Smoke Tests

* [ ] (Optional) I have run CF Acceptance Tests
