### PR TITLE
feat: tracing

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,42 @@
+# Troubleshooting gorouter
+
+## Profiling and Tracing
+
+A pprof endpoint is exposed via the [debugserver](https://github.com/cloudfoundry/debugserver)
+package and can be configured using the `debug_addr` property. The endpoint allows operators to
+enable profiling or tracing and extract data without changing gorouter itself. The
+[net/http/pprof](https://pkg.go.dev/net/http/pprof#hdr-Usage_examples) package contains examples on
+how to collect the various profiling / tracing data.
+
+After collecting data it can be visualized using the `go` CLI. For best results you should copy the
+gorouter binary which was used to collect the profiles. When working with profiles the results can
+be displayed in a browser like so:
+
+```
+go tool pprof -http localhost:8081 ./gorouter ./profile0.out
+```
+
+Use `go tool pprof -h` to view all available options.
+
+The web server will listen on localhost on port 8081 and your default browser will be launched to
+display the results.
+
+When collecting and analyzing traces the results can be viewed like so:
+
+```
+go tool trace ./trace0.out
+```
+
+Note: HTML based UI can be viewed in any browser, but the trace viewer is from the Chrome/Chromium
+project and might not work on other browsers.
+
+Use `go tool trace -h` to view all available options.
+
+Gorouter already contains a set of trace points as there is only little built-in tracing in the go
+standard library and code has to explicitly instrumented. The tracing currently focuses on request
+handling and operations on the route registry. Each request is record as task with the name
+`request [vcap-id]` and each route (un-)register message is recorded by its route key.
+
+Other resources:
+- [The Go Blog: Profiling Go Programs](https://go.dev/blog/pprof)
+- [runtime/trace](https://pkg.go.dev/runtime/trace)

--- a/handlers/access_log.go
+++ b/handlers/access_log.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"io"
 	"net/http"
+	"runtime/trace"
 	"sync/atomic"
 	"time"
 
@@ -40,6 +41,8 @@ func NewAccessLog(
 }
 
 func (a *accessLog) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	defer trace.StartRegion(r.Context(), "accessLog.ServeHTTP").End()
+
 	proxyWriter := rw.(utils.ProxyResponseWriter)
 
 	alr := &schema.AccessLogRecord{

--- a/handlers/clientcert.go
+++ b/handlers/clientcert.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"runtime/trace"
 	"strings"
 
 	"code.cloudfoundry.org/gorouter/config"
@@ -42,6 +43,8 @@ func NewClientCert(
 }
 
 func (c *clientCert) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	defer trace.StartRegion(r.Context(), "clientCert.ServeHTTP").End()
+
 	logger := LoggerWithTraceInfo(c.logger, r)
 	skip := c.skipSanitization(r)
 	if !skip {

--- a/handlers/http_rewrite.go
+++ b/handlers/http_rewrite.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"runtime/trace"
 
 	"github.com/urfave/negroni/v3"
 
@@ -43,6 +44,8 @@ func NewHTTPRewriteHandler(cfg config.HTTPRewrite, headersToAlwaysRemove []strin
 }
 
 func (p *httpRewriteHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	defer trace.StartRegion(r.Context(), "httpRewriteHandler.ServerHTTP").End()
+
 	proxyWriter := rw.(utils.ProxyResponseWriter)
 	for _, rewriter := range p.responseHeaderRewriters {
 		proxyWriter.AddHeaderRewriter(rewriter)

--- a/handlers/max_request_size.go
+++ b/handlers/max_request_size.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"runtime/trace"
 
 	router_http "code.cloudfoundry.org/gorouter/common/http"
 	"code.cloudfoundry.org/gorouter/config"
@@ -40,6 +41,8 @@ func NewMaxRequestSize(cfg *config.Config, logger logger.Logger) *MaxRequestSize
 }
 
 func (m *MaxRequestSize) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	defer trace.StartRegion(r.Context(), "MaxRequestSize.ServeHTTP").End()
+
 	logger := LoggerWithTraceInfo(m.logger, r)
 	reqSize := len(r.Method) + len(r.URL.RequestURI()) + len(r.Proto) + 5 // add 5 bytes for space-separation of method, URI, protocol, and /r/n
 

--- a/handlers/reporter.go
+++ b/handlers/reporter.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"runtime/trace"
 	"time"
 
 	"code.cloudfoundry.org/gorouter/metrics"
@@ -28,6 +29,8 @@ func NewReporter(reporter metrics.ProxyReporter, logger logger.Logger) negroni.H
 
 // ServeHTTP handles reporting the response after the request has been completed
 func (rh *reporterHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	defer trace.StartRegion(r.Context(), "reporterHandler.ServeHTTP").End()
+
 	logger := LoggerWithTraceInfo(rh.logger, r)
 	next(rw, r)
 

--- a/handlers/request_id.go
+++ b/handlers/request_id.go
@@ -2,8 +2,10 @@ package handlers
 
 import (
 	"net/http"
+	"runtime/trace"
 
 	"code.cloudfoundry.org/gorouter/logger"
+
 	"github.com/uber-go/zap"
 	"github.com/urfave/negroni/v3"
 )
@@ -42,6 +44,10 @@ func (s *setVcapRequestIdHeader) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 
 	r.Header.Set(VcapRequestIdHeader, traceInfo.UUID)
 	logger.Debug("vcap-request-id-header-set", zap.String("VcapRequestIdHeader", traceInfo.UUID))
+
+	ctx, task := trace.NewTask(r.Context(), "request: "+traceInfo.UUID)
+	defer task.End()
+	r = r.WithContext(ctx)
 
 	next(rw, r)
 }

--- a/handlers/routeservice.go
+++ b/handlers/routeservice.go
@@ -6,16 +6,17 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"runtime/trace"
 	"strings"
 
 	"code.cloudfoundry.org/gorouter/errorwriter"
 	"code.cloudfoundry.org/gorouter/logger"
 	"code.cloudfoundry.org/gorouter/registry"
+	"code.cloudfoundry.org/gorouter/route"
 	"code.cloudfoundry.org/gorouter/routeservice"
+
 	"github.com/uber-go/zap"
 	"github.com/urfave/negroni/v3"
-
-	"code.cloudfoundry.org/gorouter/route"
 )
 
 type RouteService struct {
@@ -48,6 +49,8 @@ func NewRouteService(
 }
 
 func (r *RouteService) ServeHTTP(rw http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	defer trace.StartRegion(req.Context(), "RouteService.ServeHTTP").End()
+
 	logger := LoggerWithTraceInfo(r.logger, req)
 	reqInfo, err := ContextRequestInfo(req)
 	if err != nil {

--- a/handlers/x_forwarded_proto.go
+++ b/handlers/x_forwarded_proto.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"runtime/trace"
 )
 
 type XForwardedProto struct {
@@ -11,6 +12,8 @@ type XForwardedProto struct {
 }
 
 func (h *XForwardedProto) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	defer trace.StartRegion(r.Context(), "XForwardedProto.ServeHTTP").End()
+
 	newReq := new(http.Request)
 	*newReq = *r
 	skip := h.SkipSanitization(r)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"runtime/trace"
 	"strings"
 	"time"
 
@@ -211,6 +212,8 @@ func ForceDeleteXFCCHeader(routeServiceValidator RouteServiceValidator, forwarde
 }
 
 func (p *proxy) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request, next http.HandlerFunc) {
+	defer trace.StartRegion(request.Context(), "proxy.ServeHTTP").End()
+
 	logger := handlers.LoggerWithTraceInfo(p.logger, request)
 	proxyWriter := responseWriter.(utils.ProxyResponseWriter)
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -22,6 +22,7 @@ type Registry interface {
 	Register(uri route.Uri, endpoint *route.Endpoint)
 	Unregister(uri route.Uri, endpoint *route.Endpoint)
 	Lookup(uri route.Uri) *route.EndpointPool
+	LookupCtx(ctx context.Context, uri route.Uri) *route.EndpointPool
 	LookupWithInstance(uri route.Uri, appID, appIndex string) *route.EndpointPool
 }
 
@@ -222,6 +223,12 @@ func (r *RouteRegistry) unregisterCtx(ctx context.Context, uri route.Uri, endpoi
 }
 
 func (r *RouteRegistry) Lookup(uri route.Uri) *route.EndpointPool {
+	return r.LookupCtx(context.Background(), uri)
+}
+
+func (r *RouteRegistry) LookupCtx(ctx context.Context, uri route.Uri) *route.EndpointPool {
+	defer trace.StartRegion(ctx, "RouteRegistry.Lookup").End()
+
 	started := time.Now()
 
 	pool := r.lookup(uri)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -272,8 +272,14 @@ func (r *RouteRegistry) endpointInRouterShard(endpoint *route.Endpoint) bool {
 }
 
 func (r *RouteRegistry) LookupWithInstance(uri route.Uri, appID string, appIndex string) *route.EndpointPool {
+	return r.LookupWithInstanceCtx(context.Background(), uri, appID, appIndex)
+}
+
+func (r *RouteRegistry) LookupWithInstanceCtx(ctx context.Context, uri route.Uri, appID string, appIndex string) *route.EndpointPool {
+	defer trace.StartRegion(ctx, "RouteRegistry.LookupWithInstance").End()
+
 	uri = uri.RouteKey()
-	p := r.Lookup(uri)
+	p := r.LookupCtx(ctx, uri)
 
 	if p == nil {
 		return nil

--- a/route/pool.go
+++ b/route/pool.go
@@ -1,11 +1,13 @@
 package route
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"maps"
 	"math/rand"
 	"net/http"
+	"runtime/trace"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -251,6 +253,11 @@ func (p *EndpointPool) Update() {
 }
 
 func (p *EndpointPool) Put(endpoint *Endpoint) PoolPutResult {
+	return p.PutCtx(context.Background(), endpoint)
+}
+
+func (p *EndpointPool) PutCtx(ctx context.Context, endpoint *Endpoint) PoolPutResult {
+	defer trace.StartRegion(ctx, "EndpointPool.Put").End()
 	p.Lock()
 	defer p.Unlock()
 
@@ -337,8 +344,13 @@ func (p *EndpointPool) PruneEndpoints() []*Endpoint {
 	return prunedEndpoints
 }
 
-// Returns true if the endpoint was removed from the EndpointPool, false otherwise.
 func (p *EndpointPool) Remove(endpoint *Endpoint) bool {
+	return p.RemoveCtx(context.Background(), endpoint)
+}
+
+// Returns true if the endpoint was removed from the EndpointPool, false otherwise.
+func (p *EndpointPool) RemoveCtx(ctx context.Context, endpoint *Endpoint) bool {
+	defer trace.StartRegion(ctx, "EndpointPool.Remove").End()
 	var e *endpointElem
 
 	p.Lock()


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

From time to time we have to investigate situations in which customers complain about individual requests taking a long time (up to 100ms) to pass through gorouter. While investigating ways to find out what causes such delays we came across the built-in tracing functionality of GoLang. Unfortunately the tracing is relatively useless if you don't instruct your code to record certain trace points.

This PR proposes to add an initial set of trace points. Since we don't really know what we are looking for the trace points are a bit scattered around. Please let me know if you think that certain trace points are pointless or if there's any other sections that should have tracing.

Since we have benchmarks in the registry I checked what the impact of the tracing points would be:

| Benchmark | Impact (relative increase in avg of ns/op) |
|---|---|
|BenchmarkRegisterWith100KRoutes-12 | +19% |
|BenchmarkRegisterWithOneRoute-12 | +15% |
|BenchmarkRegisterWithConcurrentLookupWith100kRoutes-12 | +3% |

Note: tracing is *not* enabled, this is just due to the trace points existing and being part of the execution path, they are not recording data.

Given that `BenchmarkRegisterWithConcurrentLookupWith100kRoutes-12` is the closest to what gorouter actually does and it only increases the time per register by ~3% I don't expect any major impact by this change.

Once we have the opportunity to collect some traces on our productive systems we will have more insights into which regions should be traced and which ones are less interesting. We should then re-visit the topic and adjust the trace points accordingly.

Backward Compatibility
---------------

Breaking Change? **No**
