### PR TITLE
TLS enabled healtchecks now support non-default ciphers

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -136,6 +136,10 @@ func NewRouter(
 			},
 			HealthCheck: healthCheck,
 		}
+		if cfg.EnableHTTP2 {
+			healthTLSListener.TLSConfig.NextProtos = []string{"h2", "http/1.1"}
+		}
+
 		if err := healthTLSListener.ListenAndServe(); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
