### PR TITLE
Fix metric counting incorrect `Content-Length` headers

### DIFF
--- a/handlers/reporter.go
+++ b/handlers/reporter.go
@@ -38,7 +38,7 @@ func (rh *reporterHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, ne
 		return
 	}
 	if !validContentLength(r.Header) {
-		rh.reporter.CaptureMissingContentLengthHeader()
+		rh.reporter.CaptureEmptyContentLengthHeader()
 	}
 
 	next(rw, r)

--- a/metrics/compositereporter.go
+++ b/metrics/compositereporter.go
@@ -26,7 +26,7 @@ type ProxyReporter interface {
 	CaptureBackendTLSHandshakeFailed()
 	CaptureBadRequest()
 	CaptureBadGateway()
-	CaptureMissingContentLengthHeader()
+	CaptureEmptyContentLengthHeader()
 	CaptureRoutingRequest(b *route.Endpoint)
 	CaptureRoutingResponse(statusCode int)
 	CaptureRoutingResponseLatency(b *route.Endpoint, statusCode int, t time.Time, d time.Duration)
@@ -65,8 +65,8 @@ func (c *CompositeReporter) CaptureBadGateway() {
 	c.ProxyReporter.CaptureBadGateway()
 }
 
-func (c *CompositeReporter) CaptureMissingContentLengthHeader() {
-	c.ProxyReporter.CaptureMissingContentLengthHeader()
+func (c *CompositeReporter) CaptureEmptyContentLengthHeader() {
+	c.ProxyReporter.CaptureEmptyContentLengthHeader()
 }
 
 func (c *CompositeReporter) CaptureRoutingRequest(b *route.Endpoint) {

--- a/metrics/fakes/fake_proxyreporter.go
+++ b/metrics/fakes/fake_proxyreporter.go
@@ -218,12 +218,12 @@ func (fake *FakeProxyReporter) CaptureBadRequestCalls(stub func()) {
 	fake.CaptureBadRequestStub = stub
 }
 
-func (fake *FakeProxyReporter) CaptureMissingContentLengthHeader() {
+func (fake *FakeProxyReporter) CaptureEmptyContentLengthHeader() {
 	fake.captureMissingContentLengthHeaderMutex.Lock()
 	fake.captureMissingContentLengthHeaderArgsForCall = append(fake.captureMissingContentLengthHeaderArgsForCall, struct {
 	}{})
 	stub := fake.CaptureMissingContentLengthHeaderStub
-	fake.recordInvocation("CaptureMissingContentLengthHeader", []interface{}{})
+	fake.recordInvocation("CaptureEmptyContentLengthHeader", []interface{}{})
 	fake.captureMissingContentLengthHeaderMutex.Unlock()
 	if stub != nil {
 		fake.CaptureMissingContentLengthHeaderStub()

--- a/metrics/metricsreporter.go
+++ b/metrics/metricsreporter.go
@@ -43,8 +43,8 @@ func (m *MetricsReporter) CaptureBadGateway() {
 	m.Batcher.BatchIncrementCounter("bad_gateways")
 }
 
-func (m *MetricsReporter) CaptureMissingContentLengthHeader() {
-	m.Batcher.BatchIncrementCounter("missing_content_length_header")
+func (m *MetricsReporter) CaptureEmptyContentLengthHeader() {
+	m.Batcher.BatchIncrementCounter("empty_content_length_header")
 }
 
 func (m *MetricsReporter) CaptureRoutingRequest(b *route.Endpoint) {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->

Go 1.22 introduced stricter checks for `Content-Length` headers. The header, if set, must not be empty.

This new strict check can be worked around with `debug.httplaxcontentlength`, which will allow empty `Content-Length` headers. In preparation for users disabling this debug flag that Gorouter turns on by default, a metric is emitted to collect requests that _would_ break when the workaround is disabled.

The metric introduced in https://github.com/cloudfoundry/gorouter/pull/412 was erroneous, see https://github.com/cloudfoundry/routing-release/issues/411.


Backward Compatibility
---------------
Breaking Change? **Yes**(ish)
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->

The metric that was recently introduced, called `missing_content_length_header` is misleadingly named and renamed in this PR to `empty_content_length_header` instead.
