### PR TITLE
Revert to using Director() based rproxy for most requests

### DIFF
--- a/handlers/proxy_picker.go
+++ b/handlers/proxy_picker.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"strings"
+
+	"github.com/urfave/negroni/v3"
+)
+
+type proxyPicker struct {
+	directorProxy           *httputil.ReverseProxy
+	expect100ContinueRProxy *httputil.ReverseProxy
+}
+
+// Creates a per-request decision on which reverse proxy to use, based on whether
+// a request contained an `Expect: 100-continue` header
+func NewProxyPicker(directorProxy *httputil.ReverseProxy, expect100ContinueRProxy *httputil.ReverseProxy) negroni.Handler {
+	return &proxyPicker{
+		directorProxy:           directorProxy,
+		expect100ContinueRProxy: expect100ContinueRProxy,
+	}
+}
+
+func (pp *proxyPicker) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	pickedProxy := pp.directorProxy
+	if strings.ToLower(r.Header.Get("Expect")) == "100-continue" {
+		pickedProxy = pp.expect100ContinueRProxy
+	}
+
+	pickedProxy.ServeHTTP(rw, r)
+	next(rw, r)
+}

--- a/handlers/proxy_picker_test.go
+++ b/handlers/proxy_picker_test.go
@@ -1,0 +1,83 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+
+	"code.cloudfoundry.org/gorouter/handlers"
+	"code.cloudfoundry.org/gorouter/test_util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/urfave/negroni/v3"
+)
+
+var _ = Describe("Proxy Picker", func() {
+	var (
+		handler                                                 negroni.Handler
+		resp                                                    *httptest.ResponseRecorder
+		req                                                     *http.Request
+		nextHandler                                             http.HandlerFunc
+		nextCalled, rproxyCalled, expect100ContinueRProxyCalled bool
+		rproxy, expect100ContinueRProxy                         *httputil.ReverseProxy
+	)
+	BeforeEach(func() {
+		req = test_util.NewRequest("GET", "example.com", "/", nil)
+		resp = httptest.NewRecorder()
+
+		rproxy = &httputil.ReverseProxy{
+			Director: func(r *http.Request) {
+				rproxyCalled = true
+			},
+		}
+		expect100ContinueRProxy = &httputil.ReverseProxy{
+			Rewrite: func(t *httputil.ProxyRequest) {
+				expect100ContinueRProxyCalled = true
+			},
+		}
+
+		nextCalled = false
+		rproxyCalled = false
+		expect100ContinueRProxyCalled = false
+
+		handler = handlers.NewProxyPicker(rproxy, expect100ContinueRProxy)
+		nextHandler = http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			nextCalled = true
+		})
+
+	})
+
+	Context("when the request has an Expect: 100-continue", func() {
+		BeforeEach(func() {
+			req.Header.Set("Expect", "100-continue")
+		})
+		It("Chooses the expect100ContinueRProxy", func() {
+			handler.ServeHTTP(resp, req, nextHandler)
+			Expect(expect100ContinueRProxyCalled).To(BeTrue())
+			Expect(rproxyCalled).To(BeFalse())
+		})
+
+		Context("when upper/lower case mixtures", func() {
+			BeforeEach(func() {
+				req.Header.Set("Expect", "100-CoNTiNuE")
+			})
+			It("is case insensitive", func() {
+				handler.ServeHTTP(resp, req, nextHandler)
+				Expect(expect100ContinueRProxyCalled).To(BeTrue())
+				Expect(rproxyCalled).To(BeFalse())
+			})
+		})
+	})
+	Context("when the request does not have an Expect: 100-continue", func() {
+		It("Chooses the main rproxy", func() {
+			handler.ServeHTTP(resp, req, nextHandler)
+			Expect(expect100ContinueRProxyCalled).To(BeFalse())
+			Expect(rproxyCalled).To(BeTrue())
+		})
+
+	})
+	It("calls next()", func() {
+		handler.ServeHTTP(resp, req, nextHandler)
+		Expect(nextCalled).To(BeTrue())
+	})
+})


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Revert to previous Director() based proxy logic for all requests that are not 'Expect: 100-continue', and also use that logic when KeepAlive100Continue is enabled.

Differences between Director() and Rewrite() are very low level, and this mitigates against the risk of any untested behaviors causing breaking changes, while opting into closing connections on 100-continue based requests.

Backward Compatibility
---------------
Reverts the httputil.ReverseProxy behavior as closely as possible to how it was previously.