### PR TITLE
fix: preserve x-forwarded-host for expect-100-continue req

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -312,8 +312,11 @@ func (p *proxy) setupProxyRequestClose100Continue(target *httputil.ProxyRequest)
 
 	target.Out.Header["X-Forwarded-For"] = target.In.Header["X-Forwarded-For"]
 	target.Out.Header["Forwarded"] = target.In.Header["Forwarded"]
+	// Takes care of setting the X-Forwarded-For header properly. Also sets the X-Forwarded-Proto
+	// which we overwrite again.
 	target.SetXForwarded()
 	target.Out.Header["X-Forwarded-Proto"] = target.In.Header["X-Forwarded-Proto"]
+	target.Out.Header["X-Forwarded-Host"] = target.In.Header["X-Forwarded-Host"]
 }
 
 func setRequestXRequestStart(request *http.Request) {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -497,6 +497,16 @@ var _ = Describe("Proxy", func() {
 			})
 		})
 
+		Describe("X-Forwarded-Host", func() {
+			Context("for expect-100-continue requests", func() {
+				It("preserves the X-Forwarded-Host header", func() {
+					req.Header.Add("X-Forwarded-Host", "foobar.com")
+					req.Header.Add("Expect", "100-continue")
+					Expect(getProxiedHeaders(req).Get("X-Forwarded-Host")).To(Equal("foobar.com"))
+				})
+			})
+		})
+
 		Describe("X-Request-Start", func() {
 			It("appends X-Request-Start", func() {
 				Expect(getProxiedHeaders(req).Get("X-Request-Start")).To(MatchRegexp("^\\d{10}\\d{3}$")) // unix timestamp millis


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The new code path for `Expect : 100-continue` requests causes the X-Forwarded-Host header to be overwritten to the value of the Host header.

This commit will also copy the X-Forwarded-Host from the incoming to the outgoing request to align the behaviour with non-expect-100-continue requests.

Resolves: cloudfoundry/routing-release#420

Backward Compatibility
---------------
Breaking Change? **No**
