### PR TITLE
Replace codegangsta/cli with urfave/cli

### DIFF
--- a/test_util/rss/commands/generate.go
+++ b/test_util/rss/commands/generate.go
@@ -8,7 +8,7 @@ import (
 
 	"code.cloudfoundry.org/gorouter/routeservice"
 	"code.cloudfoundry.org/gorouter/test_util/rss/common"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 func GenerateSignature(c *cli.Context) {

--- a/test_util/rss/commands/read.go
+++ b/test_util/rss/commands/read.go
@@ -7,7 +7,7 @@ import (
 
 	"code.cloudfoundry.org/gorouter/routeservice"
 	"code.cloudfoundry.org/gorouter/test_util/rss/common"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 func ReadSignature(c *cli.Context) {

--- a/test_util/rss/common/utils.go
+++ b/test_util/rss/common/utils.go
@@ -7,7 +7,7 @@ import (
 	"os/user"
 
 	"code.cloudfoundry.org/gorouter/common/secure"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 func CreateCrypto(c *cli.Context) (*secure.AesGCM, error) {

--- a/test_util/rss/main.go
+++ b/test_util/rss/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"code.cloudfoundry.org/gorouter/test_util/rss/commands"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 var keyFlag = cli.StringFlag{


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
A replace directive is being used [here](https://github.com/cloudfoundry/routing-release/blob/bc125319b8be3c3b405ed932b40929ef500b9501/src/code.cloudfoundry.org/go.mod#L9) to pin `codegangsta/cli`'s version. [codegangsta/cli](https://github.com/cloudfoundry-incubator/spiff/blob/master/vendor/github.com/codegangsta/cli/README.md) has been archived, but [urfave/cli](https://github.com/urfave/cli) has the same APIs while still being maintained and `routing-release` also currently uses `negroni`, another package from `urfave` [here](https://github.com/cloudfoundry/routing-release/blob/bc125319b8be3c3b405ed932b40929ef500b9501/src/code.cloudfoundry.org/go.mod#L48)

This PR removes the replaces `codegangsta/cli` with `urfave/cli` and is a companion PR to https://github.com/cloudfoundry/routing-release/pull/423

Backward Compatibility
---------------
Breaking Change? **No**
