### PR TITLE
Generic Per-Route Options incl. Load Balancing Algorithm

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"code.cloudfoundry.org/localip"
+	"slices"
 )
 
 const (
@@ -558,6 +559,10 @@ func DefaultConfig() (*Config, error) {
 	return &c, nil
 }
 
+func IsLoadBalancingAlgorithmValid(lbAlgo string) bool {
+	return slices.Contains(LoadBalancingStrategies, lbAlgo)
+}
+
 func (c *Config) Process() error {
 	if c.GoMaxProcs == -1 {
 		c.GoMaxProcs = runtime.NumCPU()
@@ -727,14 +732,7 @@ func (c *Config) Process() error {
 	}
 
 	// check if valid load balancing strategy
-	validLb := false
-	for _, lb := range LoadBalancingStrategies {
-		if c.LoadBalance == lb {
-			validLb = true
-			break
-		}
-	}
-	if !validLb {
+	if !IsLoadBalancingAlgorithmValid(c.LoadBalance) {
 		errMsg := fmt.Sprintf("Invalid load balancing algorithm %s. Allowed values are %s", c.LoadBalance, LoadBalancingStrategies)
 		//lint:ignore SA1006 - for consistency sake
 		return fmt.Errorf(errMsg)

--- a/config/config.go
+++ b/config/config.go
@@ -559,6 +559,7 @@ func DefaultConfig() (*Config, error) {
 	return &c, nil
 }
 
+// IsLoadBalancingAlgorithmValid Check validity of the provided load balancing algorithm
 func IsLoadBalancingAlgorithmValid(lbAlgo string) bool {
 	return slices.Contains(LoadBalancingStrategies, lbAlgo)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -559,7 +559,6 @@ func DefaultConfig() (*Config, error) {
 	return &c, nil
 }
 
-// IsLoadBalancingAlgorithmValid Check validity of the provided load balancing algorithm
 func IsLoadBalancingAlgorithmValid(lbAlgo string) bool {
 	return slices.Contains(LoadBalancingStrategies, lbAlgo)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -732,7 +732,6 @@ func (c *Config) Process() error {
 		c.RouteServiceEnabled = true
 	}
 
-	// check if valid load balancing strategy
 	if !IsLoadBalancingAlgorithmValid(c.LoadBalance) {
 		errMsg := fmt.Sprintf("Invalid load balancing algorithm %s. Allowed values are %s", c.LoadBalance, LoadBalancingStrategies)
 		//lint:ignore SA1006 - for consistency sake

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -48,6 +48,16 @@ zone: meow-zone
 			})
 		})
 
+		Context("Load Balancing Algorithm Validator", func() {
+			It("Returns false if the value is not in the list of configured load balancing strategies", func() {
+				Expect(IsLoadBalancingAlgorithmValid("wrong.algo")).To(Equal(false))
+			})
+
+			It("Returns true if the value is in the list of configured load balancing strategies", func() {
+				Expect(IsLoadBalancingAlgorithmValid(LOAD_BALANCE_RR)).To(Equal(true))
+			})
+		})
+
 		Context("load balance config", func() {
 			It("sets default load balance strategy", func() {
 				Expect(config.LoadBalance).To(Equal(LOAD_BALANCE_RR))

--- a/handlers/helpers.go
+++ b/handlers/helpers.go
@@ -63,13 +63,13 @@ func upgradeHeader(request *http.Request) string {
 	return ""
 }
 
-func EndpointIteratorForRequest(logger logger.Logger, request *http.Request, loadBalanceMethod string, stickySessionCookieNames config.StringSet, authNegotiateSticky bool, azPreference string, az string) (route.EndpointIterator, error) {
+func EndpointIteratorForRequest(logger logger.Logger, request *http.Request, stickySessionCookieNames config.StringSet, authNegotiateSticky bool, azPreference string, az string) (route.EndpointIterator, error) {
 	reqInfo, err := ContextRequestInfo(request)
 	if err != nil {
 		return nil, fmt.Errorf("could not find reqInfo in context")
 	}
 	stickyEndpointID, mustBeSticky := GetStickySession(request, stickySessionCookieNames, authNegotiateSticky)
-	return reqInfo.RoutePool.Endpoints(logger, loadBalanceMethod, stickyEndpointID, mustBeSticky, azPreference, az), nil
+	return reqInfo.RoutePool.Endpoints(logger, stickyEndpointID, mustBeSticky, azPreference, az), nil
 }
 
 func GetStickySession(request *http.Request, stickySessionCookieNames config.StringSet, authNegotiateSticky bool) (string, bool) {

--- a/handlers/max_request_size.go
+++ b/handlers/max_request_size.go
@@ -53,7 +53,7 @@ func (m *MaxRequestSize) ServeHTTP(rw http.ResponseWriter, r *http.Request, next
 		if err != nil {
 			logger.Error("request-info-err", zap.Error(err))
 		} else {
-			endpointIterator, err := EndpointIteratorForRequest(logger, r, m.cfg.LoadBalance, m.cfg.StickySessionCookieNames, m.cfg.StickySessionsForAuthNegotiate, m.cfg.LoadBalanceAZPreference, m.cfg.Zone)
+			endpointIterator, err := EndpointIteratorForRequest(logger, r, m.cfg.StickySessionCookieNames, m.cfg.StickySessionsForAuthNegotiate, m.cfg.LoadBalanceAZPreference, m.cfg.Zone)
 			if err != nil {
 				logger.Error("failed-to-find-endpoint-for-req-during-431-short-circuit", zap.Error(err))
 			} else {

--- a/mbus/subscriber.go
+++ b/mbus/subscriber.go
@@ -37,6 +37,7 @@ type RegistryMessage struct {
 	TLSPort                 uint16            `json:"tls_port"`
 	Tags                    map[string]string `json:"tags"`
 	Uris                    []route.Uri       `json:"uris"`
+	LoadBalancingAlgorithm  string            `json:"lb_algo"`
 }
 
 func (rm *RegistryMessage) makeEndpoint(http2Enabled bool) (*route.Endpoint, error) {
@@ -70,6 +71,7 @@ func (rm *RegistryMessage) makeEndpoint(http2Enabled bool) (*route.Endpoint, err
 		IsolationSegment:        rm.IsolationSegment,
 		UseTLS:                  useTLS,
 		UpdatedAt:               updatedAt,
+		LoadBalancingAlgorithm:  rm.LoadBalancingAlgorithm,
 	}), nil
 }
 
@@ -78,7 +80,7 @@ func (rm *RegistryMessage) ValidateMessage() bool {
 	return rm.RouteServiceURL == "" || strings.HasPrefix(rm.RouteServiceURL, "https")
 }
 
-// Prefer TLS Port instead of HTTP Port in Registrty Message
+// Prefer TLS Port instead of HTTP Port in Registry Message
 func (rm *RegistryMessage) port() (uint16, bool, error) {
 	if rm.TLSPort != 0 {
 		return rm.TLSPort, true, nil

--- a/mbus/subscriber.go
+++ b/mbus/subscriber.go
@@ -22,22 +22,26 @@ import (
 )
 
 type RegistryMessage struct {
-	App                     string            `json:"app"`
-	AvailabilityZone        string            `json:"availability_zone"`
-	EndpointUpdatedAtNs     int64             `json:"endpoint_updated_at_ns"`
-	Host                    string            `json:"host"`
-	IsolationSegment        string            `json:"isolation_segment"`
-	Port                    uint16            `json:"port"`
-	PrivateInstanceID       string            `json:"private_instance_id"`
-	PrivateInstanceIndex    string            `json:"private_instance_index"`
-	Protocol                string            `json:"protocol"`
-	RouteServiceURL         string            `json:"route_service_url"`
-	ServerCertDomainSAN     string            `json:"server_cert_domain_san"`
-	StaleThresholdInSeconds int               `json:"stale_threshold_in_seconds"`
-	TLSPort                 uint16            `json:"tls_port"`
-	Tags                    map[string]string `json:"tags"`
-	Uris                    []route.Uri       `json:"uris"`
-	LoadBalancingAlgorithm  string            `json:"lb_algo"`
+	App                     string              `json:"app"`
+	AvailabilityZone        string              `json:"availability_zone"`
+	EndpointUpdatedAtNs     int64               `json:"endpoint_updated_at_ns"`
+	Host                    string              `json:"host"`
+	IsolationSegment        string              `json:"isolation_segment"`
+	Port                    uint16              `json:"port"`
+	PrivateInstanceID       string              `json:"private_instance_id"`
+	PrivateInstanceIndex    string              `json:"private_instance_index"`
+	Protocol                string              `json:"protocol"`
+	RouteServiceURL         string              `json:"route_service_url"`
+	ServerCertDomainSAN     string              `json:"server_cert_domain_san"`
+	StaleThresholdInSeconds int                 `json:"stale_threshold_in_seconds"`
+	TLSPort                 uint16              `json:"tls_port"`
+	Tags                    map[string]string   `json:"tags"`
+	Uris                    []route.Uri         `json:"uris"`
+	Options                 RegistryMessageOpts `json:"options"`
+}
+
+type RegistryMessageOpts struct {
+	LoadBalancingAlgorithm string `json:"lb_algo"`
 }
 
 func (rm *RegistryMessage) makeEndpoint(http2Enabled bool) (*route.Endpoint, error) {
@@ -55,6 +59,8 @@ func (rm *RegistryMessage) makeEndpoint(http2Enabled bool) (*route.Endpoint, err
 		protocol = "http1"
 	}
 
+	//lbAlgorithm := mapOptions(rm)
+
 	return route.NewEndpoint(&route.EndpointOpts{
 		AppId:                   rm.App,
 		AvailabilityZone:        rm.AvailabilityZone,
@@ -71,9 +77,16 @@ func (rm *RegistryMessage) makeEndpoint(http2Enabled bool) (*route.Endpoint, err
 		IsolationSegment:        rm.IsolationSegment,
 		UseTLS:                  useTLS,
 		UpdatedAt:               updatedAt,
-		LoadBalancingAlgorithm:  rm.LoadBalancingAlgorithm,
+		LoadBalancingAlgorithm:  rm.Options.LoadBalancingAlgorithm,
 	}), nil
 }
+
+//const LoadBalancingAlgorithmTag string = "lb_algo"
+
+/*func mapOptions(registryMsg *RegistryMessage) string {
+	if registryMsg.Options != nil {
+	}
+}*/
 
 // ValidateMessage checks to ensure the registry message is valid
 func (rm *RegistryMessage) ValidateMessage() bool {

--- a/mbus/subscriber.go
+++ b/mbus/subscriber.go
@@ -59,8 +59,6 @@ func (rm *RegistryMessage) makeEndpoint(http2Enabled bool) (*route.Endpoint, err
 		protocol = "http1"
 	}
 
-	//lbAlgorithm := mapOptions(rm)
-
 	return route.NewEndpoint(&route.EndpointOpts{
 		AppId:                   rm.App,
 		AvailabilityZone:        rm.AvailabilityZone,
@@ -80,13 +78,6 @@ func (rm *RegistryMessage) makeEndpoint(http2Enabled bool) (*route.Endpoint, err
 		LoadBalancingAlgorithm:  rm.Options.LoadBalancingAlgorithm,
 	}), nil
 }
-
-//const LoadBalancingAlgorithmTag string = "lb_algo"
-
-/*func mapOptions(registryMsg *RegistryMessage) string {
-	if registryMsg.Options != nil {
-	}
-}*/
 
 // ValidateMessage checks to ensure the registry message is valid
 func (rm *RegistryMessage) ValidateMessage() bool {

--- a/mbus/subscriber_test.go
+++ b/mbus/subscriber_test.go
@@ -545,31 +545,6 @@ var _ = Describe("Subscriber", func() {
 				Expect(originalEndpoint).To(Equal(expectedEndpoint))
 			})
 
-			It("endpoint is constructed with an empty options struct", func() {
-				var msg = mbus.RegistryMessage{
-					Host:     "host",
-					App:      "app",
-					Protocol: "http2",
-					Uris:     []route.Uri{"test.example.com"},
-					Options:  mbus.RegistryMessageOpts{},
-				}
-				data, err := json.Marshal(msg)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = natsClient.Publish("router.register", data)
-				Expect(err).ToNot(HaveOccurred())
-
-				Eventually(registry.RegisterCallCount).Should(Equal(2))
-				_, originalEndpoint := registry.RegisterArgsForCall(0)
-				expectedEndpoint := route.NewEndpoint(&route.EndpointOpts{
-					Host:                   "host",
-					AppId:                  "app",
-					Protocol:               "http2",
-					LoadBalancingAlgorithm: "",
-				})
-
-				Expect(originalEndpoint).To(Equal(expectedEndpoint))
-			})
 		})
 
 		Context("when HTTP/2 is disabled and the protocol is http2", func() {

--- a/mbus/subscriber_test.go
+++ b/mbus/subscriber_test.go
@@ -525,7 +525,6 @@ var _ = Describe("Subscriber", func() {
 					App:      "app",
 					Protocol: "http2",
 					Uris:     []route.Uri{"test.example.com"},
-					Options:  mbus.RegistryMessageOpts{LoadBalancingAlgorithm: ""},
 				}
 				data, err := json.Marshal(msg)
 				Expect(err).NotTo(HaveOccurred())
@@ -536,10 +535,9 @@ var _ = Describe("Subscriber", func() {
 				Eventually(registry.RegisterCallCount).Should(Equal(2))
 				_, originalEndpoint := registry.RegisterArgsForCall(0)
 				expectedEndpoint := route.NewEndpoint(&route.EndpointOpts{
-					Host:                   "host",
-					AppId:                  "app",
-					Protocol:               "http2",
-					LoadBalancingAlgorithm: "",
+					Host:     "host",
+					AppId:    "app",
+					Protocol: "http2",
 				})
 
 				Expect(originalEndpoint).To(Equal(expectedEndpoint))

--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -154,7 +154,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 
 	stickyEndpointID, mustBeSticky := handlers.GetStickySession(request, rt.config.StickySessionCookieNames, rt.config.StickySessionsForAuthNegotiate)
 	numberOfEndpoints := reqInfo.RoutePool.NumEndpoints()
-	iter := reqInfo.RoutePool.Endpoints(rt.logger, rt.config.LoadBalance, stickyEndpointID, mustBeSticky, rt.config.LoadBalanceAZPreference, rt.config.Zone)
+	iter := reqInfo.RoutePool.Endpoints(rt.logger, stickyEndpointID, mustBeSticky, rt.config.LoadBalanceAZPreference, rt.config.Zone)
 
 	// The selectEndpointErr needs to be tracked separately. If we get an error
 	// while selecting an endpoint we might just have run out of routes. In

--- a/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/proxy/round_tripper/proxy_round_tripper_test.go
@@ -266,7 +266,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 					res, err := proxyRoundTripper.RoundTrip(req)
 					Expect(err).NotTo(HaveOccurred())
 
-					iter := routePool.Endpoints(logger, "", "", false, AZPreference, AZ)
+					iter := routePool.Endpoints(logger, "", false, AZPreference, AZ)
 					ep1 := iter.Next(0)
 					ep2 := iter.Next(1)
 					Expect(ep1.PrivateInstanceId).To(Equal(ep2.PrivateInstanceId))
@@ -489,7 +489,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 					_, err := proxyRoundTripper.RoundTrip(req)
 					Expect(err).To(MatchError(ContainSubstring("tls: handshake failure")))
 
-					iter := routePool.Endpoints(logger, "", "", false, AZPreference, AZ)
+					iter := routePool.Endpoints(logger, "", false, AZPreference, AZ)
 					ep1 := iter.Next(0)
 					ep2 := iter.Next(1)
 					Expect(ep1).To(Equal(ep2))

--- a/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/proxy/round_tripper/proxy_round_tripper_test.go
@@ -100,12 +100,12 @@ var _ = Describe("ProxyRoundTripper", func() {
 		BeforeEach(func() {
 			logger = test_util.NewTestZapLogger("test")
 			routePool = route.NewPool(&route.PoolOpts{
-				Logger:             logger,
-				RetryAfterFailure:  1 * time.Second,
-				Host:               "myapp.com",
-				ContextPath:        "",
-				MaxConnsPerBackend: 0,
-				//LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
+				Logger:                 logger,
+				RetryAfterFailure:      1 * time.Second,
+				Host:                   "myapp.com",
+				ContextPath:            "",
+				MaxConnsPerBackend:     0,
+				LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
 			})
 			numEndpoints = 1
 			resp = httptest.NewRecorder()

--- a/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/proxy/round_tripper/proxy_round_tripper_test.go
@@ -105,6 +105,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 				Host:               "myapp.com",
 				ContextPath:        "",
 				MaxConnsPerBackend: 0,
+				//LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
 			})
 			numEndpoints = 1
 			resp = httptest.NewRecorder()

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -129,6 +129,7 @@ func (r *RouteRegistry) register(uri route.Uri, endpoint *route.Endpoint) route.
 	if len(endpoint.LoadBalancingAlgorithm) > 0 && endpoint.LoadBalancingAlgorithm != pool.LBAlgorithm {
 		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm) {
 			pool.Lock()
+			//Multiple apps can have the same route, a pool will get the last endpoint's algorithm
 			pool.LBAlgorithm = endpoint.LoadBalancingAlgorithm
 			pool.Unlock()
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -126,7 +126,7 @@ func (r *RouteRegistry) register(uri route.Uri, endpoint *route.Endpoint) route.
 
 	endpointAdded := pool.Put(endpoint)
 	//Check endpoint for a load balancing algorithm. If it does exist & differs from that of the pool, then take the lb algorithm of the endpoint, otherwise keep the pools lb algorithm.
-	if len(endpoint.LoadBalancingAlgorithm()) > 0 && endpoint.LoadBalancingAlgorithm() != pool.LBAlgorithm {
+	if len(endpoint.LoadBalancingAlgorithm()) > 0 && strings.Compare(endpoint.LoadBalancingAlgorithm(), pool.LBAlgorithm) != 0 {
 		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm()) {
 			pool.Lock()
 			//Multiple apps can have the same route, a pool will get the last endpoint's algorithm

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -126,7 +126,7 @@ func (r *RouteRegistry) register(uri route.Uri, endpoint *route.Endpoint) route.
 
 	endpointAdded := pool.Put(endpoint)
 	// Overwrites the load balancing algorithm of a pool by that of a specified endpoint, if that is valid.
-	pool.OverrulePoolLoadBalancingAlgorithm(endpoint)
+	pool.SetPoolLoadBalancingAlgorithm(endpoint)
 	r.SetTimeOfLastUpdate(t)
 
 	return endpointAdded

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -126,19 +126,19 @@ func (r *RouteRegistry) register(uri route.Uri, endpoint *route.Endpoint) route.
 
 	endpointAdded := pool.Put(endpoint)
 	//Check endpoint for a load balancing algorithm. If it does exist & differs from that of the pool, then take the lb algorithm of the endpoint, otherwise keep the pools lb algorithm.
-	if len(endpoint.LoadBalancingAlgorithm()) > 0 && strings.Compare(endpoint.LoadBalancingAlgorithm(), pool.LBAlgorithm) != 0 {
-		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm()) {
+	if len(endpoint.LoadBalancingAlgorithm) > 0 && strings.Compare(endpoint.LoadBalancingAlgorithm, pool.LBAlgorithm) != 0 {
+		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm) {
 			pool.Lock()
 			//Multiple apps can have the same route, a pool will get the last endpoint's algorithm
-			pool.LBAlgorithm = endpoint.LoadBalancingAlgorithm()
-			r.logger.Debug("Setting load balancing algorithm of a pool to that of a last registered endpoint.",
-				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm()),
+			pool.LBAlgorithm = endpoint.LoadBalancingAlgorithm
+			r.logger.Debug("setting-pool-load-balancing-algorithm-to-that-of-an-endpoint",
+				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm),
 				zap.String("poolLBAlgorithm", pool.LBAlgorithm))
 			pool.Unlock()
 
 		} else {
-			r.logger.Error("Invalid load balancing algorithm provided for an endpoint, keeping the pool load balancing algorithm.",
-				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm()),
+			r.logger.Error("invalid-endpoint-load-balancing-algorithm-provided-keeping-pool-lb-algo",
+				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm),
 				zap.String("poolLBAlgorithm", pool.LBAlgorithm))
 		}
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -127,23 +127,6 @@ func (r *RouteRegistry) register(uri route.Uri, endpoint *route.Endpoint) route.
 	endpointAdded := pool.Put(endpoint)
 	// Overwrites the load balancing algorithm of a pool by that of a specified endpoint, if that is valid.
 	pool.OverrulePoolLoadBalancingAlgorithm(endpoint)
-	if len(endpoint.LoadBalancingAlgorithm) > 0 && strings.Compare(endpoint.LoadBalancingAlgorithm, pool.LoadBalancingAlgorithm) != 0 {
-		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm) {
-			pool.Lock()
-			// Multiple apps can have the same route, a pool will get the last endpoint's algorithm
-			pool.LoadBalancingAlgorithm = endpoint.LoadBalancingAlgorithm
-			r.logger.Debug("setting-pool-load-balancing-algorithm-to-that-of-an-endpoint",
-				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm),
-				zap.String("poolLBAlgorithm", pool.LoadBalancingAlgorithm))
-			pool.Unlock()
-
-		} else {
-			r.logger.Error("invalid-endpoint-load-balancing-algorithm-provided-keeping-pool-lb-algo",
-				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm),
-				zap.String("poolLBAlgorithm", pool.LoadBalancingAlgorithm))
-		}
-	}
-
 	r.SetTimeOfLastUpdate(t)
 
 	return endpointAdded

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -131,10 +131,13 @@ func (r *RouteRegistry) register(uri route.Uri, endpoint *route.Endpoint) route.
 			pool.Lock()
 			//Multiple apps can have the same route, a pool will get the last endpoint's algorithm
 			pool.LBAlgorithm = endpoint.LoadBalancingAlgorithm()
+			r.logger.Debug("Setting load balancing algorithm of a pool to that of a last registered endpoint.",
+				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm()),
+				zap.String("poolLBAlgorithm", pool.LBAlgorithm))
 			pool.Unlock()
 
 		} else {
-			r.logger.Error("Invalid load balancing algorithm provided for a route, keeping the pool load balancing algorithm.",
+			r.logger.Error("Invalid load balancing algorithm provided for an endpoint, keeping the pool load balancing algorithm.",
 				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm()),
 				zap.String("poolLBAlgorithm", pool.LBAlgorithm))
 		}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -125,7 +125,8 @@ func (r *RouteRegistry) register(uri route.Uri, endpoint *route.Endpoint) route.
 	}
 
 	endpointAdded := pool.Put(endpoint)
-	//Check endpoint for a load balancing algorithm. If it does exist & differs from that of the pool, then take the lb algorithm of the endpoint, otherwise keep the pools lb algorithm.
+	// Overwrites the load balancing algorithm of a pool by that of a specified endpoint, if that is valid.
+	pool.OverrulePoolLoadBalancingAlgorithm(endpoint)
 	if len(endpoint.LoadBalancingAlgorithm) > 0 && strings.Compare(endpoint.LoadBalancingAlgorithm, pool.LBAlgorithm) != 0 {
 		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm) {
 			pool.Lock()

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -126,16 +126,16 @@ func (r *RouteRegistry) register(uri route.Uri, endpoint *route.Endpoint) route.
 
 	endpointAdded := pool.Put(endpoint)
 	//Check endpoint for a load balancing algorithm. If it does exist & differs from that of the pool, then take the lb algorithm of the endpoint, otherwise keep the pools lb algorithm.
-	if len(endpoint.LoadBalancingAlgorithm) > 0 && endpoint.LoadBalancingAlgorithm != pool.LBAlgorithm {
-		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm) {
+	if len(endpoint.LoadBalancingAlgorithm()) > 0 && endpoint.LoadBalancingAlgorithm() != pool.LBAlgorithm {
+		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm()) {
 			pool.Lock()
 			//Multiple apps can have the same route, a pool will get the last endpoint's algorithm
-			pool.LBAlgorithm = endpoint.LoadBalancingAlgorithm
+			pool.LBAlgorithm = endpoint.LoadBalancingAlgorithm()
 			pool.Unlock()
 
 		} else {
 			r.logger.Error("Invalid load balancing algorithm provided for a route, keeping the pool load balancing algorithm.",
-				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm),
+				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm()),
 				zap.String("poolLBAlgorithm", pool.LBAlgorithm))
 		}
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -127,20 +127,20 @@ func (r *RouteRegistry) register(uri route.Uri, endpoint *route.Endpoint) route.
 	endpointAdded := pool.Put(endpoint)
 	// Overwrites the load balancing algorithm of a pool by that of a specified endpoint, if that is valid.
 	pool.OverrulePoolLoadBalancingAlgorithm(endpoint)
-	if len(endpoint.LoadBalancingAlgorithm) > 0 && strings.Compare(endpoint.LoadBalancingAlgorithm, pool.LBAlgorithm) != 0 {
+	if len(endpoint.LoadBalancingAlgorithm) > 0 && strings.Compare(endpoint.LoadBalancingAlgorithm, pool.LoadBalancingAlgorithm) != 0 {
 		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm) {
 			pool.Lock()
-			//Multiple apps can have the same route, a pool will get the last endpoint's algorithm
-			pool.LBAlgorithm = endpoint.LoadBalancingAlgorithm
+			// Multiple apps can have the same route, a pool will get the last endpoint's algorithm
+			pool.LoadBalancingAlgorithm = endpoint.LoadBalancingAlgorithm
 			r.logger.Debug("setting-pool-load-balancing-algorithm-to-that-of-an-endpoint",
 				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm),
-				zap.String("poolLBAlgorithm", pool.LBAlgorithm))
+				zap.String("poolLBAlgorithm", pool.LoadBalancingAlgorithm))
 			pool.Unlock()
 
 		} else {
 			r.logger.Error("invalid-endpoint-load-balancing-algorithm-provided-keeping-pool-lb-algo",
 				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm),
-				zap.String("poolLBAlgorithm", pool.LBAlgorithm))
+				zap.String("poolLBAlgorithm", pool.LoadBalancingAlgorithm))
 		}
 	}
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -374,7 +374,7 @@ var _ = Describe("RouteRegistry", func() {
 					Expect(r.NumEndpoints()).To(Equal(1))
 
 					p := r.Lookup("foo.com")
-					Expect(p.Endpoints(logger, "", "", false, azPreference, az).Next(0).ModificationTag).To(Equal(modTag))
+					Expect(p.Endpoints(logger, "", false, azPreference, az).Next(0).ModificationTag).To(Equal(modTag))
 				})
 			})
 
@@ -396,7 +396,7 @@ var _ = Describe("RouteRegistry", func() {
 						Expect(r.NumEndpoints()).To(Equal(1))
 
 						p := r.Lookup("foo.com")
-						Expect(p.Endpoints(logger, "", "", false, azPreference, az).Next(0).ModificationTag).To(Equal(modTag))
+						Expect(p.Endpoints(logger, "", false, azPreference, az).Next(0).ModificationTag).To(Equal(modTag))
 					})
 
 					Context("updating an existing route with an older modification tag", func() {
@@ -416,7 +416,7 @@ var _ = Describe("RouteRegistry", func() {
 							Expect(r.NumEndpoints()).To(Equal(1))
 
 							p := r.Lookup("foo.com")
-							ep := p.Endpoints(logger, "", "", false, azPreference, az).Next(0)
+							ep := p.Endpoints(logger, "", false, azPreference, az).Next(0)
 							Expect(ep.ModificationTag).To(Equal(modTag))
 							Expect(ep).To(Equal(endpoint2))
 						})
@@ -435,7 +435,7 @@ var _ = Describe("RouteRegistry", func() {
 						Expect(r.NumEndpoints()).To(Equal(1))
 
 						p := r.Lookup("foo.com")
-						Expect(p.Endpoints(logger, "", "", false, azPreference, az).Next(0).ModificationTag).To(Equal(modTag))
+						Expect(p.Endpoints(logger, "", false, azPreference, az).Next(0).ModificationTag).To(Equal(modTag))
 					})
 				})
 			})
@@ -703,7 +703,7 @@ var _ = Describe("RouteRegistry", func() {
 			Expect(r.NumUris()).To(Equal(1))
 
 			p1 := r.Lookup("foo/bar")
-			iter := p1.Endpoints(logger, "", "", false, azPreference, az)
+			iter := p1.Endpoints(logger, "", false, azPreference, az)
 			Expect(iter.Next(0).CanonicalAddr()).To(Equal("192.168.1.1:1234"))
 
 			p2 := r.Lookup("foo")
@@ -799,7 +799,7 @@ var _ = Describe("RouteRegistry", func() {
 			p2 := r.Lookup("FOO")
 			Expect(p1).To(Equal(p2))
 
-			iter := p1.Endpoints(logger, "", "", false, azPreference, az)
+			iter := p1.Endpoints(logger, "", false, azPreference, az)
 			Expect(iter.Next(0).CanonicalAddr()).To(Equal("192.168.1.1:1234"))
 		})
 
@@ -818,7 +818,7 @@ var _ = Describe("RouteRegistry", func() {
 
 			p := r.Lookup("bar")
 			Expect(p).ToNot(BeNil())
-			e := p.Endpoints(logger, "", "", false, azPreference, az).Next(0)
+			e := p.Endpoints(logger, "", false, azPreference, az).Next(0)
 			Expect(e).ToNot(BeNil())
 			Expect(e.CanonicalAddr()).To(MatchRegexp("192.168.1.1:123[4|5]"))
 
@@ -833,13 +833,13 @@ var _ = Describe("RouteRegistry", func() {
 
 			p := r.Lookup("foo.wild.card")
 			Expect(p).ToNot(BeNil())
-			e := p.Endpoints(logger, "", "", false, azPreference, az).Next(0)
+			e := p.Endpoints(logger, "", false, azPreference, az).Next(0)
 			Expect(e).ToNot(BeNil())
 			Expect(e.CanonicalAddr()).To(Equal("192.168.1.2:1234"))
 
 			p = r.Lookup("foo.space.wild.card")
 			Expect(p).ToNot(BeNil())
-			e = p.Endpoints(logger, "", "", false, azPreference, az).Next(0)
+			e = p.Endpoints(logger, "", false, azPreference, az).Next(0)
 			Expect(e).ToNot(BeNil())
 			Expect(e.CanonicalAddr()).To(Equal("192.168.1.2:1234"))
 		})
@@ -853,7 +853,7 @@ var _ = Describe("RouteRegistry", func() {
 
 			p := r.Lookup("not.wild.card")
 			Expect(p).ToNot(BeNil())
-			e := p.Endpoints(logger, "", "", false, azPreference, az).Next(0)
+			e := p.Endpoints(logger, "", false, azPreference, az).Next(0)
 			Expect(e).ToNot(BeNil())
 			Expect(e.CanonicalAddr()).To(Equal("192.168.1.1:1234"))
 		})
@@ -885,7 +885,7 @@ var _ = Describe("RouteRegistry", func() {
 				p := r.Lookup("dora.app.com/env?foo=bar")
 
 				Expect(p).ToNot(BeNil())
-				iter := p.Endpoints(logger, "", "", false, azPreference, az)
+				iter := p.Endpoints(logger, "", false, azPreference, az)
 				Expect(iter.Next(0).CanonicalAddr()).To(Equal("192.168.1.1:1234"))
 			})
 
@@ -894,7 +894,7 @@ var _ = Describe("RouteRegistry", func() {
 				p := r.Lookup("dora.app.com/env/abc?foo=bar&baz=bing")
 
 				Expect(p).ToNot(BeNil())
-				iter := p.Endpoints(logger, "", "", false, azPreference, az)
+				iter := p.Endpoints(logger, "", false, azPreference, az)
 				Expect(iter.Next(0).CanonicalAddr()).To(Equal("192.168.1.1:1234"))
 			})
 		})
@@ -914,7 +914,7 @@ var _ = Describe("RouteRegistry", func() {
 			p1 := r.Lookup("foo/extra/paths")
 			Expect(p1).ToNot(BeNil())
 
-			iter := p1.Endpoints(logger, "", "", false, azPreference, az)
+			iter := p1.Endpoints(logger, "", false, azPreference, az)
 			Expect(iter.Next(0).CanonicalAddr()).To(Equal("192.168.1.1:1234"))
 		})
 
@@ -926,7 +926,7 @@ var _ = Describe("RouteRegistry", func() {
 			p1 := r.Lookup("foo?fields=foo,bar")
 			Expect(p1).ToNot(BeNil())
 
-			iter := p1.Endpoints(logger, "", "", false, azPreference, az)
+			iter := p1.Endpoints(logger, "", false, azPreference, az)
 			Expect(iter.Next(0).CanonicalAddr()).To(Equal("192.168.1.1:1234"))
 		})
 
@@ -962,7 +962,7 @@ var _ = Describe("RouteRegistry", func() {
 			Expect(r.NumEndpoints()).To(Equal(2))
 
 			p := r.LookupWithInstance("bar.com/foo", appId, appIndex)
-			e := p.Endpoints(logger, "", "", false, azPreference, az).Next(0)
+			e := p.Endpoints(logger, "", false, azPreference, az).Next(0)
 
 			Expect(e).ToNot(BeNil())
 			Expect(e.CanonicalAddr()).To(MatchRegexp("192.168.1.1:1234"))
@@ -976,7 +976,7 @@ var _ = Describe("RouteRegistry", func() {
 			Expect(r.NumEndpoints()).To(Equal(2))
 
 			p := r.LookupWithInstance("bar.com/foo", appId, appIndex)
-			e := p.Endpoints(logger, "", "", false, azPreference, az).Next(0)
+			e := p.Endpoints(logger, "", false, azPreference, az).Next(0)
 
 			Expect(e).ToNot(BeNil())
 			Expect(e.CanonicalAddr()).To(MatchRegexp("192.168.1.1:1234"))
@@ -1169,7 +1169,7 @@ var _ = Describe("RouteRegistry", func() {
 
 			p := r.Lookup("foo")
 			Expect(p).ToNot(BeNil())
-			Expect(p.Endpoints(logger, "", "", false, azPreference, az).Next(0)).To(Equal(endpoint))
+			Expect(p.Endpoints(logger, "", false, azPreference, az).Next(0)).To(Equal(endpoint))
 
 			p = r.Lookup("bar")
 			Expect(p).To(BeNil())

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -472,25 +472,27 @@ var _ = Describe("RouteRegistry", func() {
 					p1, p2, p3, p4 *route.EndpointPool
 				)
 
-				It("overwrites the load balancing algorithm of a pool if provided value is valid", func() {
+				It("overwrites the load balancing algorithm of a pool if provided value is valid and logs correctly", func() {
 					lbSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{
 						LoadBalancingAlgorithm: config.LOAD_BALANCE_LC,
 					})
 					r.Register(app2Uri, lbSpecEndpoint)
 					p1 = r.Lookup(app2Uri)
 					Expect(p1.LBAlgorithm).To(Equal(config.LOAD_BALANCE_LC))
+					Expect(logger).To(gbytes.Say(`endpoint-lb-algorithm-set-to-pool`))
 				})
 
-				It("keeps the load balancing algorithm of a pool if provided value is invalid", func() {
+				It("keeps the load balancing algorithm of a pool if provided value is invalid and logs correctly", func() {
 					lbSpecWrongEndpoint = route.NewEndpoint(&route.EndpointOpts{
 						LoadBalancingAlgorithm: "wrong-load-balancing-algo-value",
 					})
 					r.Register(app2Uri, lbSpecWrongEndpoint)
 					p2 = r.Lookup(app2Uri)
 					Expect(p2.LBAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
+					Expect(logger).To(gbytes.Say(`"Invalid load balancing algorithm provided for a route, keeping the pool load balancing algorithm.`))
 				})
 
-				It("keeps the load balancing algorithm of a pool if provided value is an empty string", func() {
+				It("keeps the load balancing algorithm of a pool if provided value is an empty string and logs correctly", func() {
 					lbSpecEmptyEndpoint = route.NewEndpoint(&route.EndpointOpts{
 						LoadBalancingAlgorithm: "",
 					})

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -442,7 +442,7 @@ var _ = Describe("RouteRegistry", func() {
 
 		})
 
-		Context("Load Balancing Algorithm of a route", func() {
+		Context("Load Balancing Algorithm of an Endpoint", func() {
 
 			var (
 				lbSpecEndpoint, lbSpecWrongEndpoint, lbUnSpecEndpoint, lbSpecEmptyEndpoint *route.Endpoint
@@ -457,7 +457,7 @@ var _ = Describe("RouteRegistry", func() {
 				app4Uri = "test.com/app4"
 			})
 
-			Context("If a load balancing algorithm of a route is not specified", func() {
+			Context("If a load balancing algorithm of an endpoint is not specified", func() {
 
 				It("keeps configured pool default load balancing algorithm", func() {
 					lbUnSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{})
@@ -467,29 +467,29 @@ var _ = Describe("RouteRegistry", func() {
 				})
 			})
 
-			Context("If a load balancing algorithm of a route is specified", func() {
+			Context("If a load balancing algorithm of an endpoint is specified", func() {
 				var (
 					p1, p2, p3, p4 *route.EndpointPool
 				)
 
-				It("overwrites the load balancing algorithm of a pool if provided value is valid and logs correctly", func() {
+				It("overwrites the load balancing algorithm of a pool if provided value for an endpoint is valid and logs correctly", func() {
 					lbSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{
 						LoadBalancingAlgorithm: config.LOAD_BALANCE_LC,
 					})
 					r.Register(app2Uri, lbSpecEndpoint)
 					p1 = r.Lookup(app2Uri)
 					Expect(p1.LBAlgorithm).To(Equal(config.LOAD_BALANCE_LC))
-					Expect(logger).To(gbytes.Say(`endpoint-lb-algorithm-set-to-pool`))
+					Expect(logger).To(gbytes.Say(`Setting load balancing algorithm of a pool to that of a last registered endpoint.`))
 				})
 
-				It("keeps the load balancing algorithm of a pool if provided value is invalid and logs correctly", func() {
+				It("keeps the load balancing algorithm of a pool if provided value for an endpoint is invalid and logs correctly", func() {
 					lbSpecWrongEndpoint = route.NewEndpoint(&route.EndpointOpts{
 						LoadBalancingAlgorithm: "wrong-load-balancing-algo-value",
 					})
 					r.Register(app2Uri, lbSpecWrongEndpoint)
 					p2 = r.Lookup(app2Uri)
 					Expect(p2.LBAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
-					Expect(logger).To(gbytes.Say(`"Invalid load balancing algorithm provided for a route, keeping the pool load balancing algorithm.`))
+					Expect(logger).To(gbytes.Say(`"Invalid load balancing algorithm provided for an endpoint, keeping the pool load balancing algorithm.`))
 				})
 
 				It("keeps the load balancing algorithm of a pool if provided value is an empty string and logs correctly", func() {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -512,17 +512,17 @@ var _ = Describe("RouteRegistry", func() {
 
 				It("overwrites the load balancing algorithm of a pool with the provided value of the last added endpoint", func() {
 					lbSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{
-						LoadBalancingAlgorithm: config.LOAD_BALANCE_LC,
-					})
-					r.Register(app5Uri, lbSpecEndpoint)
-
-					lbSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{
 						LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
 					})
 					r.Register(app5Uri, lbSpecEndpoint)
 
+					lbSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{
+						LoadBalancingAlgorithm: config.LOAD_BALANCE_LC,
+					})
+					r.Register(app5Uri, lbSpecEndpoint)
+
 					p5 = r.Lookup(app5Uri)
-					Expect(p5.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
+					Expect(p5.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_LC))
 				})
 			})
 		})

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -479,7 +479,7 @@ var _ = Describe("RouteRegistry", func() {
 					r.Register(app2Uri, lbSpecEndpoint)
 					p1 = r.Lookup(app2Uri)
 					Expect(p1.LBAlgorithm).To(Equal(config.LOAD_BALANCE_LC))
-					Expect(logger).To(gbytes.Say(`Setting load balancing algorithm of a pool to that of a last registered endpoint.`))
+					Expect(logger).To(gbytes.Say(`setting-pool-load-balancing-algorithm-to-that-of-an-endpoint`))
 				})
 
 				It("keeps the load balancing algorithm of a pool if provided value for an endpoint is invalid and logs correctly", func() {
@@ -489,7 +489,7 @@ var _ = Describe("RouteRegistry", func() {
 					r.Register(app2Uri, lbSpecWrongEndpoint)
 					p2 = r.Lookup(app2Uri)
 					Expect(p2.LBAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
-					Expect(logger).To(gbytes.Say(`"Invalid load balancing algorithm provided for an endpoint, keeping the pool load balancing algorithm.`))
+					Expect(logger).To(gbytes.Say(`"invalid-endpoint-load-balancing-algorithm-provided-keeping-pool-lb-algo`))
 				})
 
 				It("keeps the load balancing algorithm of a pool if provided value is an empty string and logs correctly", func() {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -445,9 +445,9 @@ var _ = Describe("RouteRegistry", func() {
 		Context("Load Balancing Algorithm of an Endpoint", func() {
 
 			var (
-				lbSpecEndpoint, lbSpecWrongEndpoint, lbUnSpecEndpoint, lbSpecEmptyEndpoint, lbNoSpecEndpoint *route.Endpoint
-				appUri, app1Uri, app2Uri, app3Uri, app4Uri, app5Uri                                          route.Uri
-				pool                                                                                         *route.EndpointPool
+				lbSpecEndpoint, lbSpecWrongEndpoint, lbUnSpecEndpoint, lbNoSpecEndpoint *route.Endpoint
+				appUri, app1Uri, app2Uri, app3Uri, app4Uri                              route.Uri
+				pool                                                                    *route.EndpointPool
 			)
 
 			BeforeEach(func() {
@@ -456,7 +456,6 @@ var _ = Describe("RouteRegistry", func() {
 				app2Uri = "test.com/app2"
 				app3Uri = "test.com/app3"
 				app4Uri = "test.com/app4"
-				app5Uri = "test.com/app5"
 			})
 
 			Context("If a load balancing algorithm of an endpoint is not specified", func() {
@@ -471,7 +470,7 @@ var _ = Describe("RouteRegistry", func() {
 
 			Context("If a load balancing algorithm of an endpoint is specified", func() {
 				var (
-					p1, p2, p3, p4, p5 *route.EndpointPool
+					p1, p2, p3, p4 *route.EndpointPool
 				)
 
 				It("overwrites the load balancing algorithm of a pool if provided value for an endpoint is valid and logs correctly", func() {
@@ -494,35 +493,26 @@ var _ = Describe("RouteRegistry", func() {
 					Expect(logger).To(gbytes.Say(`"invalid-endpoint-load-balancing-algorithm-provided-keeping-pool-lb-algo`))
 				})
 
-				It("keeps the load balancing algorithm of a pool if provided value is an empty string", func() {
-					lbSpecEmptyEndpoint = route.NewEndpoint(&route.EndpointOpts{
-						LoadBalancingAlgorithm: "",
-					})
-					r.Register(app3Uri, lbSpecEmptyEndpoint)
-					p3 = r.Lookup(app3Uri)
-					Expect(p3.LoadBalancingAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
-				})
-
 				It("keeps the load balancing algorithm of a pool if the value is not provided", func() {
 					lbNoSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{})
-					r.Register(app4Uri, lbNoSpecEndpoint)
-					p4 = r.Lookup(app4Uri)
-					Expect(p4.LoadBalancingAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
+					r.Register(app3Uri, lbNoSpecEndpoint)
+					p3 = r.Lookup(app3Uri)
+					Expect(p3.LoadBalancingAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
 				})
 
 				It("overwrites the load balancing algorithm of a pool with the provided value of the last added endpoint", func() {
 					lbSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{
 						LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
 					})
-					r.Register(app5Uri, lbSpecEndpoint)
+					r.Register(app4Uri, lbSpecEndpoint)
 
 					lbSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{
 						LoadBalancingAlgorithm: config.LOAD_BALANCE_LC,
 					})
-					r.Register(app5Uri, lbSpecEndpoint)
+					r.Register(app4Uri, lbSpecEndpoint)
 
-					p5 = r.Lookup(app5Uri)
-					Expect(p5.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_LC))
+					p4 = r.Lookup(app4Uri)
+					Expect(p4.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_LC))
 				})
 			})
 		})

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -446,7 +446,7 @@ var _ = Describe("RouteRegistry", func() {
 
 			var (
 				lbSpecEndpoint, lbSpecWrongEndpoint, lbUnSpecEndpoint, lbSpecEmptyEndpoint, lbNoSpecEndpoint *route.Endpoint
-				appUri, app1Uri, app2Uri, app3Uri, app4Uri                                                   route.Uri
+				appUri, app1Uri, app2Uri, app3Uri, app4Uri, app5Uri                                          route.Uri
 				pool                                                                                         *route.EndpointPool
 			)
 
@@ -456,6 +456,7 @@ var _ = Describe("RouteRegistry", func() {
 				app2Uri = "test.com/app2"
 				app3Uri = "test.com/app3"
 				app4Uri = "test.com/app4"
+				app5Uri = "test.com/app5"
 			})
 
 			Context("If a load balancing algorithm of an endpoint is not specified", func() {
@@ -505,23 +506,23 @@ var _ = Describe("RouteRegistry", func() {
 				It("keeps the load balancing algorithm of a pool if the value is not provided", func() {
 					lbNoSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{})
 					r.Register(app4Uri, lbNoSpecEndpoint)
-					p5 = r.Lookup(app4Uri)
-					Expect(p5.LBAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
+					p4 = r.Lookup(app4Uri)
+					Expect(p4.LBAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
 				})
 
 				It("overwrites the load balancing algorithm of a pool with the provided value of the last added endpoint", func() {
 					lbSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{
 						LoadBalancingAlgorithm: config.LOAD_BALANCE_LC,
 					})
-					r.Register(app4Uri, lbSpecEndpoint)
+					r.Register(app5Uri, lbSpecEndpoint)
 
 					lbSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{
 						LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
 					})
-					r.Register(app4Uri, lbSpecEndpoint)
+					r.Register(app5Uri, lbSpecEndpoint)
 
-					p4 = r.Lookup(app4Uri)
-					Expect(p4.LBAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
+					p5 = r.Lookup(app5Uri)
+					Expect(p5.LBAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
 				})
 			})
 		})

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -463,7 +463,7 @@ var _ = Describe("RouteRegistry", func() {
 					lbUnSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{})
 					r.Register(app1Uri, lbUnSpecEndpoint)
 					pool = r.Lookup(app1Uri)
-					Expect(pool.LBAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
+					Expect(pool.LBAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
 				})
 			})
 
@@ -487,7 +487,7 @@ var _ = Describe("RouteRegistry", func() {
 					})
 					r.Register(app2Uri, lbSpecWrongEndpoint)
 					p2 = r.Lookup(app2Uri)
-					Expect(p2.LBAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
+					Expect(p2.LBAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
 				})
 
 				It("keeps the load balancing algorithm of a pool if provided value is an empty string", func() {
@@ -496,7 +496,7 @@ var _ = Describe("RouteRegistry", func() {
 					})
 					r.Register(app3Uri, lbSpecEmptyEndpoint)
 					p3 = r.Lookup(app3Uri)
-					Expect(p3.LBAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
+					Expect(p3.LBAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
 				})
 
 				It("overwrites the load balancing algorithm of a pool with the provided value of the last added endpoint", func() {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -465,7 +465,7 @@ var _ = Describe("RouteRegistry", func() {
 					lbUnSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{})
 					r.Register(appUri, lbUnSpecEndpoint)
 					pool = r.Lookup(appUri)
-					Expect(pool.LBAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
+					Expect(pool.LoadBalancingAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
 				})
 			})
 
@@ -480,7 +480,7 @@ var _ = Describe("RouteRegistry", func() {
 					})
 					r.Register(app1Uri, lbSpecEndpoint)
 					p1 = r.Lookup(app1Uri)
-					Expect(p1.LBAlgorithm).To(Equal(config.LOAD_BALANCE_LC))
+					Expect(p1.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_LC))
 					Expect(logger).To(gbytes.Say(`setting-pool-load-balancing-algorithm-to-that-of-an-endpoint`))
 				})
 
@@ -490,7 +490,7 @@ var _ = Describe("RouteRegistry", func() {
 					})
 					r.Register(app2Uri, lbSpecWrongEndpoint)
 					p2 = r.Lookup(app2Uri)
-					Expect(p2.LBAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
+					Expect(p2.LoadBalancingAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
 					Expect(logger).To(gbytes.Say(`"invalid-endpoint-load-balancing-algorithm-provided-keeping-pool-lb-algo`))
 				})
 
@@ -500,14 +500,14 @@ var _ = Describe("RouteRegistry", func() {
 					})
 					r.Register(app3Uri, lbSpecEmptyEndpoint)
 					p3 = r.Lookup(app3Uri)
-					Expect(p3.LBAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
+					Expect(p3.LoadBalancingAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
 				})
 
 				It("keeps the load balancing algorithm of a pool if the value is not provided", func() {
 					lbNoSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{})
 					r.Register(app4Uri, lbNoSpecEndpoint)
 					p4 = r.Lookup(app4Uri)
-					Expect(p4.LBAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
+					Expect(p4.LoadBalancingAlgorithm).To(Equal(r.DefaultLoadBalancingAlgorithm))
 				})
 
 				It("overwrites the load balancing algorithm of a pool with the provided value of the last added endpoint", func() {
@@ -522,7 +522,7 @@ var _ = Describe("RouteRegistry", func() {
 					r.Register(app5Uri, lbSpecEndpoint)
 
 					p5 = r.Lookup(app5Uri)
-					Expect(p5.LBAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
+					Expect(p5.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
 				})
 			})
 		})

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -441,6 +441,43 @@ var _ = Describe("RouteRegistry", func() {
 			})
 
 		})
+
+		Context("Load Balancing Algorithm of a route", func() {
+
+			var (
+				lbSpecEndpoint   *route.Endpoint
+				lbUnSpecEndpoint *route.Endpoint
+				app1Uri          route.Uri
+				app2Uri          route.Uri
+			)
+
+			BeforeEach(func() {
+				app1Uri = "test.com/app1"
+				app2Uri = "test.com/app2"
+				lbUnSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{})
+				r.Register(app1Uri, lbUnSpecEndpoint)
+			})
+
+			Context("If a load balancing algorithm of a route is not specified", func() {
+
+				It("keeps configured pool default load balancing algorithm", func() {
+					p := r.Lookup(app1Uri)
+					Expect(p.LBAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
+				})
+			})
+
+			Context("If a load balancing algorithm of a route is specified", func() {
+
+				It("overwrites the load balancing algorithm of a pool", func() {
+					lbSpecEndpoint = route.NewEndpoint(&route.EndpointOpts{
+						LoadBalancingAlgorithm: config.LOAD_BALANCE_LC,
+					})
+					r.Register(app2Uri, lbSpecEndpoint)
+					p := r.Lookup(app2Uri)
+					Expect(p.LBAlgorithm).To(Equal(config.LOAD_BALANCE_LC))
+				})
+			})
+		})
 	})
 
 	Context("Unregister", func() {

--- a/route/pool.go
+++ b/route/pool.go
@@ -490,7 +490,7 @@ func (p *EndpointPool) OverrulePoolLoadBalancingAlgorithm(endpoint *Endpoint) {
 	defer p.Unlock()
 	if len(endpoint.LoadBalancingAlgorithm) > 0 && endpoint.LoadBalancingAlgorithm != p.LoadBalancingAlgorithm {
 		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm) {
-			//Multiple apps can have the same route, a pool will get the last endpoint's algorithm
+			// Multiple apps can have the same route, a pool will get the last endpoint's algorithm
 			p.LoadBalancingAlgorithm = endpoint.LoadBalancingAlgorithm
 			p.logger.Debug("setting-pool-load-balancing-algorithm-to-that-of-an-endpoint",
 				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm),

--- a/route/pool.go
+++ b/route/pool.go
@@ -484,8 +484,8 @@ func (p *EndpointPool) MarshalJSON() ([]byte, error) {
 	return json.Marshal(endpoints)
 }
 
-// OverrulePoolLoadBalancingAlgorithm overwrites the load balancing algorithm of a pool by that of a specified endpoint, if that is valid.
-func (p *EndpointPool) OverrulePoolLoadBalancingAlgorithm(endpoint *Endpoint) {
+// SetPoolLoadBalancingAlgorithm overwrites the load balancing algorithm of a pool by that of a specified endpoint, if that is valid.
+func (p *EndpointPool) SetPoolLoadBalancingAlgorithm(endpoint *Endpoint) {
 	p.Lock()
 	defer p.Unlock()
 	if len(endpoint.LoadBalancingAlgorithm) > 0 && endpoint.LoadBalancingAlgorithm != p.LoadBalancingAlgorithm {

--- a/route/pool.go
+++ b/route/pool.go
@@ -380,10 +380,10 @@ func (p *EndpointPool) removeEndpoint(e *endpointElem) {
 func (p *EndpointPool) Endpoints(logger logger.Logger, initial string, mustBeSticky bool, azPreference string, az string) EndpointIterator {
 	switch p.LoadBalancingAlgorithm {
 	case config.LOAD_BALANCE_LC:
-		logger.Debug("endpoint-with-least-connection-lb-algo-added-to-pool")
+		logger.Debug("endpoint-iterator-with-least-connection-lb-algo")
 		return NewLeastConnection(logger, p, initial, mustBeSticky, azPreference == config.AZ_PREF_LOCAL, az)
 	case config.LOAD_BALANCE_RR:
-		logger.Debug("endpoint-with-round-robin-lb-algo-added-to-pool")
+		logger.Debug("endpoint-iterator-with-round-robin-lb-algo")
 		return NewRoundRobin(logger, p, initial, mustBeSticky, azPreference == config.AZ_PREF_LOCAL, az)
 	default:
 		logger.Error("invalid-pool-load-balancing-algorithm", zap.String("poolLBAlgorithm", p.LoadBalancingAlgorithm))
@@ -490,7 +490,6 @@ func (p *EndpointPool) OverrulePoolLoadBalancingAlgorithm(endpoint *Endpoint) {
 	defer p.Unlock()
 	if len(endpoint.LoadBalancingAlgorithm) > 0 && endpoint.LoadBalancingAlgorithm != p.LoadBalancingAlgorithm {
 		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm) {
-			// Multiple apps can have the same route, a pool will get the last endpoint's algorithm
 			p.LoadBalancingAlgorithm = endpoint.LoadBalancingAlgorithm
 			p.logger.Debug("setting-pool-load-balancing-algorithm-to-that-of-an-endpoint",
 				zap.String("endpointLBAlgorithm", endpoint.LoadBalancingAlgorithm),

--- a/route/pool.go
+++ b/route/pool.go
@@ -78,11 +78,7 @@ type Endpoint struct {
 	roundTripperMutex      sync.RWMutex
 	UpdatedAt              time.Time
 	RoundTripperInit       sync.Once
-	loadBalancingAlgorithm string
-}
-
-func (e *Endpoint) LoadBalancingAlgorithm() string {
-	return e.loadBalancingAlgorithm
+	LoadBalancingAlgorithm string
 }
 
 func (e *Endpoint) RoundTripper() ProxyRoundTripper {
@@ -203,7 +199,7 @@ func NewEndpoint(opts *EndpointOpts) *Endpoint {
 		Stats:                  NewStats(),
 		IsolationSegment:       opts.IsolationSegment,
 		UpdatedAt:              opts.UpdatedAt,
-		loadBalancingAlgorithm: opts.LoadBalancingAlgorithm,
+		LoadBalancingAlgorithm: opts.LoadBalancingAlgorithm,
 	}
 }
 
@@ -384,16 +380,13 @@ func (p *EndpointPool) removeEndpoint(e *endpointElem) {
 func (p *EndpointPool) Endpoints(logger logger.Logger, initial string, mustBeSticky bool, azPreference string, az string) EndpointIterator {
 	switch p.LBAlgorithm {
 	case config.LOAD_BALANCE_LC:
-		logger.Debug("A new endpoint with a least connection load balancing algorithm added to the pool.")
+		logger.Debug("endpoint-with-least-connection-lb-algo-added-to-pool")
 		return NewLeastConnection(logger, p, initial, mustBeSticky, azPreference == config.AZ_PREF_LOCAL, az)
 	case config.LOAD_BALANCE_RR:
-		logger.Debug("A new endpoint with a round-robin load balancing algorithm added to the pool.")
+		logger.Debug("endpoint-with-round-robin-lb-algo-added-to-pool")
 		return NewRoundRobin(logger, p, initial, mustBeSticky, azPreference == config.AZ_PREF_LOCAL, az)
 	default:
-		logger.Error(
-			"Invalid pool load balancing algorithm.",
-			zap.String("poolLBAlgorithm", p.LBAlgorithm),
-		)
+		logger.Error("invalid-pool-load-balancing-algorithm", zap.String("poolLBAlgorithm", p.LBAlgorithm))
 		return NewRoundRobin(logger, p, initial, mustBeSticky, azPreference == config.AZ_PREF_LOCAL, az)
 	}
 }

--- a/route/pool.go
+++ b/route/pool.go
@@ -384,8 +384,10 @@ func (p *EndpointPool) removeEndpoint(e *endpointElem) {
 func (p *EndpointPool) Endpoints(logger logger.Logger, initial string, mustBeSticky bool, azPreference string, az string) EndpointIterator {
 	switch p.LBAlgorithm {
 	case config.LOAD_BALANCE_LC:
+		logger.Debug("A new endpoint with a least connection load balancing algorithm added to the pool.")
 		return NewLeastConnection(logger, p, initial, mustBeSticky, azPreference == config.AZ_PREF_LOCAL, az)
 	case config.LOAD_BALANCE_RR:
+		logger.Debug("A new endpoint with a round-robin load balancing algorithm added to the pool.")
 		return NewRoundRobin(logger, p, initial, mustBeSticky, azPreference == config.AZ_PREF_LOCAL, az)
 	default:
 		logger.Error(

--- a/route/pool.go
+++ b/route/pool.go
@@ -488,7 +488,7 @@ func (p *EndpointPool) MarshalJSON() ([]byte, error) {
 func (p *EndpointPool) OverrulePoolLoadBalancingAlgorithm(endpoint *Endpoint) {
 	p.Lock()
 	defer p.Unlock()
-	if len(endpoint.LoadBalancingAlgorithm) > 0 && endpoint.LoadBalancingAlgorithm == p.LoadBalancingAlgorithm {
+	if len(endpoint.LoadBalancingAlgorithm) > 0 && endpoint.LoadBalancingAlgorithm != p.LoadBalancingAlgorithm {
 		if config.IsLoadBalancingAlgorithmValid(endpoint.LoadBalancingAlgorithm) {
 			//Multiple apps can have the same route, a pool will get the last endpoint's algorithm
 			p.LoadBalancingAlgorithm = endpoint.LoadBalancingAlgorithm

--- a/route/pool.go
+++ b/route/pool.go
@@ -484,7 +484,7 @@ func (p *EndpointPool) MarshalJSON() ([]byte, error) {
 	return json.Marshal(endpoints)
 }
 
-// OverrulePoolLoadBalancingAlgorithm Overwrites the load balancing algorithm of a pool by that of a specified endpoint, if that is valid.
+// OverrulePoolLoadBalancingAlgorithm overwrites the load balancing algorithm of a pool by that of a specified endpoint, if that is valid.
 func (p *EndpointPool) OverrulePoolLoadBalancingAlgorithm(endpoint *Endpoint) {
 	p.Lock()
 	defer p.Unlock()

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -181,7 +181,7 @@ var _ = Describe("EndpointPool", func() {
 				endpoint := route.NewEndpoint(&route.EndpointOpts{Host: "1.2.3.4", Port: 5678, ModificationTag: modTag2})
 
 				Expect(pool.Put(endpoint)).To(Equal(route.UPDATED))
-				Expect(pool.Endpoints(logger, "", "", false, azPreference, az).Next(0).ModificationTag).To(Equal(modTag2))
+				Expect(pool.Endpoints(logger, "", false, azPreference, az).Next(0).ModificationTag).To(Equal(modTag2))
 			})
 
 			Context("when modification_tag is older", func() {
@@ -196,7 +196,7 @@ var _ = Describe("EndpointPool", func() {
 					endpoint := route.NewEndpoint(&route.EndpointOpts{Host: "1.2.3.4", Port: 5678, ModificationTag: olderModTag})
 
 					Expect(pool.Put(endpoint)).To(Equal(route.UNMODIFIED))
-					Expect(pool.Endpoints(logger, "", "", false, azPreference, az).Next(0).ModificationTag).To(Equal(modTag2))
+					Expect(pool.Endpoints(logger, "", false, azPreference, az).Next(0).ModificationTag).To(Equal(modTag2))
 				})
 			})
 		})
@@ -302,7 +302,7 @@ var _ = Describe("EndpointPool", func() {
 					azPreference := "none"
 					connectionResetError := &net.OpError{Op: "read", Err: errors.New("read: connection reset by peer")}
 					pool.EndpointFailed(failedEndpoint, connectionResetError)
-					i := pool.Endpoints(logger, "", "", false, azPreference, az)
+					i := pool.Endpoints(logger, "", false, azPreference, az)
 					epOne := i.Next(0)
 					epTwo := i.Next(1)
 					Expect(epOne).To(Equal(epTwo))

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -256,7 +256,8 @@ var _ = Describe("EndpointPool", func() {
 				Logger:                 logger,
 				LoadBalancingAlgorithm: config.LOAD_BALANCE_LC,
 			})
-			poolWithLBAlgoLC.Endpoints(logger, "", false, "none", "az")
+			iterator := poolWithLBAlgoLC.Endpoints(logger, "", false, "none", "az")
+			Expect(iterator).To(BeAssignableToTypeOf(&route.LeastConnection{}))
 			Expect(logger.Buffer()).To(gbytes.Say(`A new endpoint with a least connection load balancing algorithm added to the pool.`))
 		})
 
@@ -265,7 +266,8 @@ var _ = Describe("EndpointPool", func() {
 				Logger:                 logger,
 				LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
 			})
-			poolWithLBAlgoLC.Endpoints(logger, "", false, "none", "az")
+			iterator := poolWithLBAlgoLC.Endpoints(logger, "", false, "none", "az")
+			Expect(iterator).To(BeAssignableToTypeOf(&route.RoundRobin{}))
 			Expect(logger.Buffer()).To(gbytes.Say(`A new endpoint with a round-robin load balancing algorithm added to the pool.`))
 		})
 	})

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -242,7 +242,7 @@ var _ = Describe("EndpointPool", func() {
 			Expect(poolWithLBAlgo.LBAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
 		})
 
-		It("has an invalid specified in the pool options", func() {
+		It("has an invalid value specified in the pool options", func() {
 			poolWithLBAlgo2 := route.NewPool(&route.PoolOpts{
 				Logger:                 logger,
 				LoadBalancingAlgorithm: "wrong-lb-algo",

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -259,7 +259,7 @@ var _ = Describe("EndpointPool", func() {
 			})
 			iterator := poolWithLBAlgoLC.Endpoints(logger, "", false, "none", "az")
 			Expect(iterator).To(BeAssignableToTypeOf(&route.LeastConnection{}))
-			Expect(logger.Buffer()).To(gbytes.Say(`endpoint-with-least-connection-lb-algo-added-to-pool`))
+			Expect(logger.Buffer()).To(gbytes.Say(`endpoint-iterator-with-least-connection-lb-algo`))
 		})
 
 		It("is correctly propagated to the newly created endpoints LOAD_BALANCE_RR ", func() {
@@ -269,7 +269,7 @@ var _ = Describe("EndpointPool", func() {
 			})
 			iterator := poolWithLBAlgoLC.Endpoints(logger, "", false, "none", "az")
 			Expect(iterator).To(BeAssignableToTypeOf(&route.RoundRobin{}))
-			Expect(logger.Buffer()).To(gbytes.Say(`endpoint-with-round-robin-lb-algo-added-to-pool`))
+			Expect(logger.Buffer()).To(gbytes.Say(`endpoint-iterator-with-round-robin-lb-algo`))
 		})
 	})
 

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -249,7 +249,7 @@ var _ = Describe("EndpointPool", func() {
 			})
 			iterator := poolWithLBAlgo2.Endpoints(logger, "", false, "none", "zone")
 			Expect(iterator).To(BeAssignableToTypeOf(&route.RoundRobin{}))
-			Expect(logger.Buffer()).To(gbytes.Say(`Invalid pool load balancing algorithm.`))
+			Expect(logger.Buffer()).To(gbytes.Say(`invalid-pool-load-balancing-algorithm`))
 		})
 
 		It("is correctly propagated to the newly created endpoints LOAD_BALANCE_LC ", func() {
@@ -259,7 +259,7 @@ var _ = Describe("EndpointPool", func() {
 			})
 			iterator := poolWithLBAlgoLC.Endpoints(logger, "", false, "none", "az")
 			Expect(iterator).To(BeAssignableToTypeOf(&route.LeastConnection{}))
-			Expect(logger.Buffer()).To(gbytes.Say(`A new endpoint with a least connection load balancing algorithm added to the pool.`))
+			Expect(logger.Buffer()).To(gbytes.Say(`endpoint-with-least-connection-lb-algo-added-to-pool`))
 		})
 
 		It("is correctly propagated to the newly created endpoints LOAD_BALANCE_RR ", func() {
@@ -269,7 +269,7 @@ var _ = Describe("EndpointPool", func() {
 			})
 			iterator := poolWithLBAlgoLC.Endpoints(logger, "", false, "none", "az")
 			Expect(iterator).To(BeAssignableToTypeOf(&route.RoundRobin{}))
-			Expect(logger.Buffer()).To(gbytes.Say(`A new endpoint with a round-robin load balancing algorithm added to the pool.`))
+			Expect(logger.Buffer()).To(gbytes.Say(`endpoint-with-round-robin-lb-algo-added-to-pool`))
 		})
 	})
 

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -239,7 +239,7 @@ var _ = Describe("EndpointPool", func() {
 				Logger:                 logger,
 				LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
 			})
-			Expect(poolWithLBAlgo.LBAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
+			Expect(poolWithLBAlgo.LoadBalancingAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
 		})
 
 		It("has an invalid value specified in the pool options", func() {

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -11,6 +11,7 @@ import (
 
 	"net"
 
+	"code.cloudfoundry.org/gorouter/config"
 	"code.cloudfoundry.org/gorouter/route"
 	"code.cloudfoundry.org/gorouter/test_util"
 	"code.cloudfoundry.org/routing-api/models"
@@ -229,6 +230,20 @@ var _ = Describe("EndpointPool", func() {
 				})
 			})
 
+		})
+	})
+	Context("Load Balancing Algorithm of a pool", func() {
+
+		It("has a value specified in the pool options", func() {
+			poolWithLBAlgo := route.NewPool(&route.PoolOpts{
+				Logger:                 logger,
+				RetryAfterFailure:      2 * time.Minute,
+				Host:                   "",
+				ContextPath:            "",
+				MaxConnsPerBackend:     0,
+				LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
+			})
+			Expect(poolWithLBAlgo.LBAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
 		})
 	})
 

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -286,7 +286,7 @@ var _ = Describe("EndpointPool", func() {
 				RouteServiceUrl:        "url",
 				LoadBalancingAlgorithm: expectedLBAlgo,
 			})
-			pool.OverrulePoolLoadBalancingAlgorithm(endpoint)
+			pool.SetPoolLoadBalancingAlgorithm(endpoint)
 			Expect(pool.LoadBalancingAlgorithm).To(Equal(expectedLBAlgo))
 			Expect(logger.Buffer()).To(gbytes.Say(`setting-pool-load-balancing-algorithm-to-that-of-an-endpoint`))
 		})
@@ -299,10 +299,9 @@ var _ = Describe("EndpointPool", func() {
 			})
 			endpoint := route.NewEndpoint(&route.EndpointOpts{
 				Host: "host-1", Port: 1234,
-				RouteServiceUrl:        "url",
-				LoadBalancingAlgorithm: "",
+				RouteServiceUrl: "url",
 			})
-			pool.OverrulePoolLoadBalancingAlgorithm(endpoint)
+			pool.SetPoolLoadBalancingAlgorithm(endpoint)
 			Expect(pool.LoadBalancingAlgorithm).To(Equal(expectedLBAlgo))
 		})
 
@@ -316,7 +315,7 @@ var _ = Describe("EndpointPool", func() {
 				Host: "host-1", Port: 1234,
 				RouteServiceUrl: "url",
 			})
-			pool.OverrulePoolLoadBalancingAlgorithm(endpoint)
+			pool.SetPoolLoadBalancingAlgorithm(endpoint)
 			Expect(pool.LoadBalancingAlgorithm).To(Equal(expectedLBAlgo))
 		})
 
@@ -331,7 +330,7 @@ var _ = Describe("EndpointPool", func() {
 				RouteServiceUrl:        "url",
 				LoadBalancingAlgorithm: "invalid-lb-algo",
 			})
-			pool.OverrulePoolLoadBalancingAlgorithm(endpoint)
+			pool.SetPoolLoadBalancingAlgorithm(endpoint)
 			Expect(pool.LoadBalancingAlgorithm).To(Equal(expectedLBAlgo))
 			Expect(logger.Buffer()).To(gbytes.Say(`invalid-endpoint-load-balancing-algorithm-provided-keeping-pool-lb-algo`))
 		})

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -237,26 +237,36 @@ var _ = Describe("EndpointPool", func() {
 		It("has a value specified in the pool options", func() {
 			poolWithLBAlgo := route.NewPool(&route.PoolOpts{
 				Logger:                 logger,
-				RetryAfterFailure:      2 * time.Minute,
-				Host:                   "",
-				ContextPath:            "",
-				MaxConnsPerBackend:     0,
 				LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
 			})
 			Expect(poolWithLBAlgo.LBAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
 		})
 
-		It("has an invalid specified in the pool options and will log an error.", func() {
+		It("has an invalid specified in the pool options", func() {
 			poolWithLBAlgo2 := route.NewPool(&route.PoolOpts{
 				Logger:                 logger,
-				RetryAfterFailure:      2 * time.Minute,
-				Host:                   "",
-				ContextPath:            "",
-				MaxConnsPerBackend:     0,
 				LoadBalancingAlgorithm: "wrong-lb-algo",
 			})
 			poolWithLBAlgo2.Endpoints(logger, "", false, "none", "zone")
 			Expect(logger.Buffer()).To(gbytes.Say(`Invalid pool load balancing algorithm.`))
+		})
+
+		It("is correctly propagated to the newly created endpoints LOAD_BALANCE_LC ", func() {
+			poolWithLBAlgoLC := route.NewPool(&route.PoolOpts{
+				Logger:                 logger,
+				LoadBalancingAlgorithm: config.LOAD_BALANCE_LC,
+			})
+			poolWithLBAlgoLC.Endpoints(logger, "", false, "none", "az")
+			Expect(logger.Buffer()).To(gbytes.Say(`A new endpoint with a least connection load balancing algorithm added to the pool.`))
+		})
+
+		It("is correctly propagated to the newly created endpoints LOAD_BALANCE_RR ", func() {
+			poolWithLBAlgoLC := route.NewPool(&route.PoolOpts{
+				Logger:                 logger,
+				LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
+			})
+			poolWithLBAlgoLC.Endpoints(logger, "", false, "none", "az")
+			Expect(logger.Buffer()).To(gbytes.Say(`A new endpoint with a round-robin load balancing algorithm added to the pool.`))
 		})
 	})
 

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -273,6 +273,70 @@ var _ = Describe("EndpointPool", func() {
 		})
 	})
 
+	Context("Load balancing algorithm of a newly added endpoint", func() {
+
+		It("is valid and will overwrite the load balancing algorithm of a pool", func() {
+			pool := route.NewPool(&route.PoolOpts{
+				Logger:                 logger,
+				LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
+			})
+			expectedLBAlgo := config.LOAD_BALANCE_LC
+			endpoint := route.NewEndpoint(&route.EndpointOpts{
+				Host: "host-1", Port: 1234,
+				RouteServiceUrl:        "url",
+				LoadBalancingAlgorithm: expectedLBAlgo,
+			})
+			pool.OverrulePoolLoadBalancingAlgorithm(endpoint)
+			Expect(pool.LoadBalancingAlgorithm).To(Equal(expectedLBAlgo))
+			Expect(logger.Buffer()).To(gbytes.Say(`setting-pool-load-balancing-algorithm-to-that-of-an-endpoint`))
+		})
+
+		It("is an empty string and the load balancing algorithm of a pool is kept", func() {
+			expectedLBAlgo := config.LOAD_BALANCE_RR
+			pool := route.NewPool(&route.PoolOpts{
+				Logger:                 logger,
+				LoadBalancingAlgorithm: expectedLBAlgo,
+			})
+			endpoint := route.NewEndpoint(&route.EndpointOpts{
+				Host: "host-1", Port: 1234,
+				RouteServiceUrl:        "url",
+				LoadBalancingAlgorithm: "",
+			})
+			pool.OverrulePoolLoadBalancingAlgorithm(endpoint)
+			Expect(pool.LoadBalancingAlgorithm).To(Equal(expectedLBAlgo))
+		})
+
+		It("is not specified in the endpoint options and the load balancing algorithm of a pool is kept", func() {
+			expectedLBAlgo := config.LOAD_BALANCE_RR
+			pool := route.NewPool(&route.PoolOpts{
+				Logger:                 logger,
+				LoadBalancingAlgorithm: expectedLBAlgo,
+			})
+			endpoint := route.NewEndpoint(&route.EndpointOpts{
+				Host: "host-1", Port: 1234,
+				RouteServiceUrl: "url",
+			})
+			pool.OverrulePoolLoadBalancingAlgorithm(endpoint)
+			Expect(pool.LoadBalancingAlgorithm).To(Equal(expectedLBAlgo))
+		})
+
+		It("is an invalid value and the load balancing algorithm of a pool is kept", func() {
+			expectedLBAlgo := config.LOAD_BALANCE_RR
+			pool := route.NewPool(&route.PoolOpts{
+				Logger:                 logger,
+				LoadBalancingAlgorithm: expectedLBAlgo,
+			})
+			endpoint := route.NewEndpoint(&route.EndpointOpts{
+				Host: "host-1", Port: 1234,
+				RouteServiceUrl:        "url",
+				LoadBalancingAlgorithm: "invalid-lb-algo",
+			})
+			pool.OverrulePoolLoadBalancingAlgorithm(endpoint)
+			Expect(pool.LoadBalancingAlgorithm).To(Equal(expectedLBAlgo))
+			Expect(logger.Buffer()).To(gbytes.Say(`invalid-endpoint-load-balancing-algorithm-provided-keeping-pool-lb-algo`))
+		})
+	})
+
 	Context("RouteServiceUrl", func() {
 		It("returns the route_service_url associated with the pool", func() {
 			endpoint := &route.Endpoint{}

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -247,7 +247,8 @@ var _ = Describe("EndpointPool", func() {
 				Logger:                 logger,
 				LoadBalancingAlgorithm: "wrong-lb-algo",
 			})
-			poolWithLBAlgo2.Endpoints(logger, "", false, "none", "zone")
+			iterator := poolWithLBAlgo2.Endpoints(logger, "", false, "none", "zone")
+			Expect(iterator).To(BeAssignableToTypeOf(&route.RoundRobin{}))
 			Expect(logger.Buffer()).To(gbytes.Say(`Invalid pool load balancing algorithm.`))
 		})
 

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -1,6 +1,7 @@
 package route_test
 
 import (
+	"code.cloudfoundry.org/gorouter/config"
 	"errors"
 	"net/http"
 	"time"
@@ -11,7 +12,6 @@ import (
 
 	"net"
 
-	"code.cloudfoundry.org/gorouter/config"
 	"code.cloudfoundry.org/gorouter/route"
 	"code.cloudfoundry.org/gorouter/test_util"
 	"code.cloudfoundry.org/routing-api/models"
@@ -244,6 +244,19 @@ var _ = Describe("EndpointPool", func() {
 				LoadBalancingAlgorithm: config.LOAD_BALANCE_RR,
 			})
 			Expect(poolWithLBAlgo.LBAlgorithm).To(Equal(config.LOAD_BALANCE_RR))
+		})
+
+		It("has an invalid specified in the pool options and will log an error.", func() {
+			poolWithLBAlgo2 := route.NewPool(&route.PoolOpts{
+				Logger:                 logger,
+				RetryAfterFailure:      2 * time.Minute,
+				Host:                   "",
+				ContextPath:            "",
+				MaxConnsPerBackend:     0,
+				LoadBalancingAlgorithm: "wrong-lb-algo",
+			})
+			poolWithLBAlgo2.Endpoints(logger, "", false, "none", "zone")
+			Expect(logger.Buffer()).To(gbytes.Say(`Invalid pool load balancing algorithm.`))
 		})
 	})
 


### PR DESCRIPTION
Summary
---------------
Detailed specification including that of for all the involved components is provided in the [**RFC**](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0027-generic-per-route-features.md)

Route definition is extended by generic options map with a load balancing algorithm. Options can be optionally specified in the following way with a json key **lb_algo** for the load balancing algorithm, e.g.
```
{
  "host": "127.0.0.1",
  "port": 4567,
  "protocol": "http1",
  "uris": ["url.localhost.routing.cf-app.com"],
  "options": {
    "lb_algo": "least-connection"
  },
  "app": "some_app_guid",
  "stale_threshold_in_seconds": 120,
  "server_cert_domain_san": "some_subject_alternative_name"
}
```

Supported load-balancing algorithms are specified in the Gorouter configuration in the **LoadBalancingStrategies** list. If a load balancing algorithm, provided for a route, is not in this configured list, the pool load balancing algorithm is kept and the error *invalid-endpoint-load-balancing-algorithm-provided-keeping-pool-lb-algo* is logged.

*RegistryMessage* structure is extended by an **Options** field of type *RegistryMessageOpts* structure, currently only containing the LoadBalancingAlgorithm field. *Endpoint* structure is extended by **LoadBalancingAlgorithm** field. 

When initialising new endpoints, the load balancing algorithm is initialised to the value from the corresponding registry message option. When endpoints are registered and added to the pool, the load balancing algorithm of a pool is set to that one of a new endpoint.

*RouteRegistry* structure is extended by a new field **DefaultLoadBalancingAlgorithm**, which is initialised by the Gorouter default load balancing configuration property **LoadBalance**. This default value is a default load balancing algorithm for a new pool.

Since the route options are optional, not providing them has no effect on the existing default load balancing algorithm logic.

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->

Check list
---------------
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md)
- [x] I have viewed signed and have submitted the Contributor License Agreement
- [x] I have made this pull request to the main branch
- [x] I have [run all the unit tests](https://github.com/cloudfoundry/routing-release#running-unit-and-integration-tests).

Resolves: cloudfoundry/routing-release#421



