### PR TITLE
Go 1.22 test fixes

### DIFF
--- a/integration/common_integration_test.go
+++ b/integration/common_integration_test.go
@@ -103,6 +103,7 @@ func NewTestState() *testState {
 	gorouterToBackendsClientCertChain := test_util.CreateSignedCertWithRootCA(test_util.CertNames{CommonName: "gorouter", SANs: test_util.SubjectAltNames{DNS: "gorouter"}})
 	trustedBackendTLSConfig := backendCertChain.AsTLSConfig()
 	trustedBackendTLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	trustedBackendTLSConfig.CipherSuites = []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256}
 
 	untrustedBackendServerCertSAN := "some-trusted-backend.example.net"
 	untrustedBackendCLientCertChain := test_util.CreateSignedCertWithRootCA(test_util.CertNames{CommonName: untrustedBackendServerCertSAN, SANs: test_util.SubjectAltNames{DNS: untrustedBackendServerCertSAN}})

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -80,7 +80,7 @@ func setupTLSServer() *ghttp.Server {
 	caCertsPath = certChain.WriteCACertToDir(testAssets)
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{certChain.TLSCert()},
-		CipherSuites: []uint16{tls.TLS_RSA_WITH_AES_256_CBC_SHA},
+		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA},
 	}
 
 	server := ghttp.NewUnstartedServer()

--- a/integration/large_upload_test.go
+++ b/integration/large_upload_test.go
@@ -41,7 +41,8 @@ var _ = Describe("Large upload", func() {
 
 			echoApp = newEchoApp([]route.Uri{route.Uri(appURL)}, testState.cfg.Port, testState.mbusClient, time.Millisecond, "")
 			echoApp.TlsRegister(testState.trustedBackendServerCertSAN)
-			echoApp.TlsListen(testState.trustedBackendTLSConfig)
+			errChan := echoApp.TlsListen(testState.trustedBackendTLSConfig)
+			Consistently(errChan).ShouldNot(Receive())
 		})
 
 		It("the connection remains open for the entire upload", func() {

--- a/integration/retry_test.go
+++ b/integration/retry_test.go
@@ -44,8 +44,8 @@ var _ = Describe("Retries", func() {
 				w.WriteHeader(http.StatusTeapot)
 			})
 
-			err := app.TlsListen(testState.trustedBackendTLSConfig)
-			Expect(err).ToNot(HaveOccurred())
+			errChan := app.TlsListen(testState.trustedBackendTLSConfig)
+			Consistently(errChan).ShouldNot(Receive())
 		})
 
 		AfterEach(func() {

--- a/integration/route_services_test.go
+++ b/integration/route_services_test.go
@@ -150,8 +150,8 @@ var _ = Describe("Route services", func() {
 
 			app.GUID = tlsTestAppID
 			app.TlsRegisterWithIndex(testState.trustedBackendServerCertSAN, index)
-			err := app.TlsListen(testState.trustedBackendTLSConfig.Clone())
-			Expect(err).NotTo(HaveOccurred())
+			errChan := app.TlsListen(testState.trustedBackendTLSConfig.Clone())
+			Consistently(errChan).ShouldNot(Receive())
 
 			return app
 		}
@@ -312,7 +312,7 @@ var _ = Describe("Route services", func() {
 	Context("when the route service has a MaxVersion of TLS 1.1", func() {
 		BeforeEach(func() {
 			routeService.TLS = testState.trustedExternalServiceTLS
-			routeService.TLS.CipherSuites = []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA}
+			routeService.TLS.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA}
 			routeService.TLS.MaxVersion = tls.VersionTLS11
 			routeService.TLS.MinVersion = tls.VersionTLS11
 			routeService.StartTLS()
@@ -349,7 +349,7 @@ var _ = Describe("Route services", func() {
 		Context("when the client has MinVersion of TLS 1.1", func() {
 			BeforeEach(func() {
 				testState.cfg.MinTLSVersionString = "TLSv1.1"
-				testState.cfg.CipherString = "TLS_RSA_WITH_AES_128_CBC_SHA"
+				testState.cfg.CipherString = "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
 				testState.StartGorouterOrFail()
 			})
 

--- a/integration/tls_to_backends_test.go
+++ b/integration/tls_to_backends_test.go
@@ -68,7 +68,8 @@ var _ = Describe("TLS to backends", func() {
 		It("successfully connects with both websockets and TLS to backends", func() {
 			wsApp := test.NewWebSocketApp([]route.Uri{"ws-app." + test_util.LocalhostDNS}, testState.cfg.Port, testState.mbusClient, time.Millisecond, "")
 			wsApp.TlsRegister(testState.trustedBackendServerCertSAN)
-			wsApp.TlsListen(testState.trustedBackendTLSConfig)
+			errChan := wsApp.TlsListen(testState.trustedBackendTLSConfig)
+			Consistently(errChan).ShouldNot(Receive())
 
 			assertWebsocketSuccess(wsApp)
 		})
@@ -124,7 +125,8 @@ var _ = Describe("TLS to backends", func() {
 	It("successfully establishes a mutual TLS connection with backend", func() {
 		runningApp1 := test.NewGreetApp([]route.Uri{"some-app-expecting-client-certs." + test_util.LocalhostDNS}, testState.cfg.Port, testState.mbusClient, nil)
 		runningApp1.TlsRegister(testState.trustedBackendServerCertSAN)
-		runningApp1.TlsListen(testState.trustedBackendTLSConfig)
+		errChan := runningApp1.TlsListen(testState.trustedBackendTLSConfig)
+		Consistently(errChan).ShouldNot(Receive())
 
 		routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Routes.Port)
 
@@ -136,7 +138,9 @@ var _ = Describe("TLS to backends", func() {
 		// registering a route setup
 		runningApp1 := test.NewGreetApp([]route.Uri{"some-app-expecting-client-certs." + test_util.LocalhostDNS}, testState.cfg.Port, testState.mbusClient, nil)
 		runningApp1.TlsRegister(testState.trustedBackendServerCertSAN)
-		runningApp1.TlsListen(testState.trustedBackendTLSConfig)
+		errChan := runningApp1.TlsListen(testState.trustedBackendTLSConfig)
+		Consistently(errChan).ShouldNot(Receive())
+
 		routesURI := fmt.Sprintf("http://%s:%s@%s:%d/routes", testState.cfg.Status.User, testState.cfg.Status.Pass, "localhost", testState.cfg.Status.Routes.Port)
 		Eventually(func() bool { return appRegistered(routesURI, runningApp1) }, "2s").Should(BeTrue())
 		runningApp1.VerifyAppStatus(200)

--- a/proxy/proxy_suite_test.go
+++ b/proxy/proxy_suite_test.go
@@ -107,7 +107,7 @@ var _ = JustBeforeEach(func() {
 
 	conf.EnableSSL = true
 	if len(conf.CipherSuites) == 0 {
-		conf.CipherSuites = []uint16{tls.TLS_RSA_WITH_AES_256_CBC_SHA}
+		conf.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA}
 	}
 
 	tlsConfig := &tls.Config{

--- a/router/router_drain_test.go
+++ b/router/router_drain_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Router", func() {
 		config.EnableSSL = true
 		config.SSLPort = sslPort
 		config.SSLCertificates = []tls.Certificate{defaultCert, cert2}
-		config.CipherSuites = []uint16{tls.TLS_RSA_WITH_AES_256_CBC_SHA}
+		config.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA}
 		config.EndpointTimeout = 1 * time.Second
 
 		mbusClient = natsRunner.MessageBus

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Router", func() {
 		config.DisableHTTP = false
 		cert := test_util.CreateCert("default")
 		config.SSLCertificates = []tls.Certificate{cert}
-		config.CipherSuites = []uint16{tls.TLS_RSA_WITH_AES_256_CBC_SHA}
+		config.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA}
 		config.ClientCertificateValidation = tls.NoClientCert
 		config.StickySessionCookieNames = map[string]struct{}{
 			StickyCookieKey: struct{}{},

--- a/test/common/app.go
+++ b/test/common/app.go
@@ -65,15 +65,19 @@ func (a *TestApp) Endpoint() string {
 	return fmt.Sprintf("http://%s:%d/", a.urls[0], a.rPort)
 }
 
-func (a *TestApp) TlsListen(tlsConfig *tls.Config) error {
+func (a *TestApp) TlsListen(tlsConfig *tls.Config) chan error {
 	a.server = &http.Server{
 		Addr:      fmt.Sprintf(":%d", a.port),
 		Handler:   a.mux,
 		TLSConfig: tlsConfig,
 	}
+	errChan := make(chan error, 1)
 
-	go a.server.ListenAndServeTLS("", "")
-	return nil
+	go func() {
+		err := a.server.ListenAndServeTLS("", "")
+		errChan <- err
+	}()
+	return errChan
 }
 
 func (a *TestApp) RegisterAndListen() {

--- a/test_util/helpers.go
+++ b/test_util/helpers.go
@@ -237,6 +237,7 @@ func CustomSpecSSLConfig(onlyTrustClientCACerts bool, TLSClientConfigOption int,
 		unknownCertChain := CreateSignedCertWithRootCA(CertNames{CommonName: "neopets-is-gr8.com"})
 		clientTLSConfig = unknownCertChain.AsTLSConfig()
 	}
+	clientTLSConfig.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256}
 
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(rootCertChain.CACertPEM)
@@ -329,6 +330,7 @@ func (cc *CertChain) AsTLSConfig() *tls.Config {
 	Expect(err).ToNot(HaveOccurred())
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
+		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA},
 	}
 }
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fixes test failures after go.mod was updated to 1.22.


Backward Compatibility
---------------
Breaking Change? **No**