### PR TITLE
Replace nats deprecated DefaultOptions with GetDefaultOptions()

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -1444,7 +1444,7 @@ func hostnameAndPort(url string) (string, int) {
 
 func newMessageBus(c *config.Config) (*nats.Conn, error) {
 	natsMembers := make([]string, len(c.Nats.Hosts))
-	options := nats.DefaultOptions
+	options := nats.GetDefaultOptions()
 	options.PingInterval = 200 * time.Millisecond
 	for _, host := range c.Nats.Hosts {
 		uri := url.URL{

--- a/mbus/client.go
+++ b/mbus/client.go
@@ -58,7 +58,7 @@ func Connect(c *config.Config, reconnected chan<- Signal, l logger.Logger) *nats
 }
 
 func natsOptions(l logger.Logger, c *config.Config, natsHost *atomic.Value, natsAddr *atomic.Value, reconnected chan<- Signal) nats.Options {
-	options := nats.DefaultOptions
+	options := nats.GetDefaultOptions()
 	options.Servers = c.NatsServers()
 	if c.Nats.TLSEnabled {
 		var err error


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Replace deprecated DefaultOptions field with GetDefaultOptions function.


Backward Compatibility
---------------
Breaking Change? **No**