### PR TITLE
Set ReadHeaderTimeout on gorouter and route-services servers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -420,6 +420,7 @@ type Config struct {
 	EndpointKeepAliveProbeInterval  time.Duration `yaml:"endpoint_keep_alive_probe_interval,omitempty"`
 	RouteServiceTimeout             time.Duration `yaml:"route_services_timeout,omitempty"`
 	FrontendIdleTimeout             time.Duration `yaml:"frontend_idle_timeout,omitempty"`
+	ReadHeaderTimeout               time.Duration `yaml:"read_header_timeout,omitempty"`
 
 	RouteLatencyMetricMuzzleDuration time.Duration `yaml:"route_latency_metric_muzzle_duration,omitempty"`
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -255,6 +255,16 @@ frontend_idle_timeout: 5s
 			Expect(config.FrontendIdleTimeout).To(Equal(5 * time.Second))
 		})
 
+		It("sets read header timeout", func() {
+			var b = []byte(`
+read_header_timeout: 30s
+`)
+
+			err := config.Initialize(b)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.ReadHeaderTimeout).To(Equal(30 * time.Second))
+		})
+
 		It("sets endpoint timeout", func() {
 			var b = []byte(`
 endpoint_timeout: 10s

--- a/router/route_service_server.go
+++ b/router/route_service_server.go
@@ -73,7 +73,6 @@ func NewRouteServicesServer(cfg *config.Config) (*RouteServicesServer, error) {
 }
 
 func (rs *RouteServicesServer) Serve(handler http.Handler, errChan chan error) error {
-	fmt.Printf("starting server with timeout: %#v\n", rs.readHeaderTimeout)
 	localServer := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			handler.ServeHTTP(w, r)

--- a/router/route_service_server_test.go
+++ b/router/route_service_server_test.go
@@ -1,7 +1,11 @@
 package router_test
 
 import (
+	"bufio"
+	"crypto/tls"
+	"fmt"
 	"net/http"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -27,15 +31,19 @@ var _ = Describe("RouteServicesServer", func() {
 		var err error
 		cfg, err = config.DefaultConfig()
 		Expect(err).NotTo(HaveOccurred())
+
+		req, err = http.NewRequest("GET", "/foo", nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	JustBeforeEach(func() {
+		var err error
 		rss, err = router.NewRouteServicesServer(cfg)
 		Expect(err).NotTo(HaveOccurred())
 
 		errChan = make(chan error)
 
 		Expect(rss.Serve(handler, errChan)).To(Succeed())
-
-		req, err = http.NewRequest("GET", "/foo", nil)
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -50,6 +58,40 @@ var _ = Describe("RouteServicesServer", func() {
 			resp.Body.Close()
 
 			Expect(resp.StatusCode).To(Equal(http.StatusTeapot))
+		})
+	})
+
+	Describe("ReadHeaderTimeout", func() {
+		BeforeEach(func() {
+			cfg.ReadHeaderTimeout = 100 * time.Millisecond
+		})
+
+		It("closes requests when their header write exceeds ReadHeaderTimeout", func() {
+			roundTripper := rss.GetRoundTripper()
+			conn, err := tls.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", cfg.RouteServicesServerPort), roundTripper.TLSClientConfig())
+			Expect(err).NotTo(HaveOccurred())
+			defer conn.Close()
+
+			writer := bufio.NewWriter(conn)
+
+			fmt.Fprintf(writer, "GET /some-request HTTP/1.1\r\n")
+
+			// started writing headers
+			fmt.Fprintf(writer, "Host: localhost\r\n")
+			writer.Flush()
+
+			time.Sleep(300 * time.Millisecond)
+
+			fmt.Fprintf(writer, "User-Agent: CustomClient/1.0\r\n")
+			writer.Flush()
+
+			// done
+			fmt.Fprintf(writer, "\r\n")
+			writer.Flush()
+
+			resp := bufio.NewReader(conn)
+			_, err = resp.ReadString('\n')
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/router/router.go
+++ b/router/router.go
@@ -210,10 +210,11 @@ func (r *Router) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
 	time.Sleep(r.config.StartResponseDelayInterval)
 
 	server := &http.Server{
-		Handler:        r.handler,
-		ConnState:      r.HandleConnState,
-		IdleTimeout:    r.config.FrontendIdleTimeout,
-		MaxHeaderBytes: MAX_HEADER_BYTES,
+		Handler:           r.handler,
+		ConnState:         r.HandleConnState,
+		IdleTimeout:       r.config.FrontendIdleTimeout,
+		ReadHeaderTimeout: r.config.ReadHeaderTimeout,
+		MaxHeaderBytes:    MAX_HEADER_BYTES,
 	}
 
 	err = r.serveHTTP(server, r.errChan)

--- a/test/common/app.go
+++ b/test/common/app.go
@@ -69,9 +69,10 @@ func (a *TestApp) Endpoint() string {
 
 func (a *TestApp) TlsListen(tlsConfig *tls.Config) chan error {
 	a.server = &http.Server{
-		Addr:      fmt.Sprintf(":%d", a.port),
-		Handler:   a.mux,
-		TLSConfig: tlsConfig,
+		Addr:              fmt.Sprintf(":%d", a.port),
+		Handler:           a.mux,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 	errChan := make(chan error, 1)
 
@@ -89,8 +90,9 @@ func (a *TestApp) RegisterAndListen() {
 
 func (a *TestApp) Listen() {
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", a.port),
-		Handler: a.mux,
+		Addr:              fmt.Sprintf(":%d", a.port),
+		Handler:           a.mux,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 	go server.ListenAndServe()
 }

--- a/test_util/helpers.go
+++ b/test_util/helpers.go
@@ -78,7 +78,7 @@ func RegisterHTTPHandler(reg *registry.RouteRegistry, path string, handler http.
 	ln, err := startBackendListener(rcfg)
 	Expect(err).NotTo(HaveOccurred())
 
-	server := http.Server{Handler: handler}
+	server := http.Server{Handler: handler, ReadHeaderTimeout: 5 * time.Second}
 	go server.Serve(ln)
 
 	RegisterAddr(reg, path, ln.Addr().String(), prepareConfig(rcfg))
@@ -98,7 +98,7 @@ func RegisterWSHandler(reg *registry.RouteRegistry, path string, handler websock
 	nilHandshake := func(c *websocket.Config, request *http.Request) error { return nil }
 	wsServer := websocket.Server{Handler: handler, Handshake: nilHandshake}
 
-	server := http.Server{Handler: wsServer}
+	server := http.Server{Handler: wsServer, ReadHeaderTimeout: 5 * time.Second}
 	go server.Serve(ln)
 
 	RegisterAddr(reg, path, ln.Addr().String(), prepareConfig(rcfg))


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Add option to configure ReadHeaderTimeout on gorouter and route-services server.


Backward Compatibility
---------------
Breaking Change? **No**
Default value is 0, this change is not breaking. Change in the release will be breaking.