### PR TITLE
fix: remove partitioned cookie workaround

### DIFF
--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptrace"
 	"net/textproto"
 	"net/url"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -61,20 +60,6 @@ func GetRoundTripper(endpoint *route.Endpoint, roundTripperFactory RoundTripperF
 	})
 
 	return endpoint.RoundTripper()
-}
-
-type Cookie struct {
-	http.Cookie
-	// indicates, whether this cookie is partitioned. Relevant for embedding in iframes.
-	Partitioned bool
-}
-
-func (c *Cookie) String() string {
-	cookieString := c.Cookie.String()
-	if c.Partitioned {
-		return cookieString + "; Partitioned"
-	}
-	return cookieString
 }
 
 //go:generate counterfeiter -o fakes/fake_error_handler.go --fake-name ErrorHandler . errorHandler
@@ -451,11 +436,8 @@ func setupStickySession(
 				secure = v.Secure
 				sameSite = v.SameSite
 				expiry = v.Expires
+				partitioned = v.Partitioned
 
-				// temporary workaround for "Partitioned" cookies, used in embedded websites (iframe),
-				// until Golang natively supports parsing the Partitioned flag.
-				// See also https://github.com/golang/go/issues/62490
-				partitioned = slices.Contains(v.Unparsed, "Partitioned")
 				break
 			}
 		}
@@ -475,17 +457,15 @@ func setupStickySession(
 			secure = true
 		}
 
-		vcapIDCookie := &Cookie{
-			Cookie: http.Cookie{
-				Name:     VcapCookieId,
-				Value:    endpoint.PrivateInstanceId,
-				Path:     path,
-				MaxAge:   maxAge,
-				HttpOnly: true,
-				Secure:   secure,
-				SameSite: sameSite,
-				Expires:  expiry,
-			},
+		vcapIDCookie := http.Cookie{
+			Name:        VcapCookieId,
+			Value:       endpoint.PrivateInstanceId,
+			Path:        path,
+			MaxAge:      maxAge,
+			HttpOnly:    true,
+			Secure:      secure,
+			SameSite:    sameSite,
+			Expires:     expiry,
 			Partitioned: partitioned,
 		}
 

--- a/proxy/round_tripper/proxy_round_tripper_test.go
+++ b/proxy/round_tripper/proxy_round_tripper_test.go
@@ -1056,7 +1056,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 
 			Context("when using sticky sessions", func() {
 				var (
-					sessionCookie *round_tripper.Cookie
+					sessionCookie *http.Cookie
 					endpoint1     *route.Endpoint
 					endpoint2     *route.Endpoint
 
@@ -1090,11 +1090,9 @@ var _ = Describe("ProxyRoundTripper", func() {
 				}
 
 				setVCAPID := func(resp *http.Response) (response *http.Response) {
-					vcapCookie := round_tripper.Cookie{
-						Cookie: http.Cookie{
-							Name:  round_tripper.VcapCookieId,
-							Value: "vcap-id-property-already-on-the-response",
-						},
+					vcapCookie := http.Cookie{
+						Name:  round_tripper.VcapCookieId,
+						Value: "vcap-id-property-already-on-the-response",
 					}
 
 					if c := vcapCookie.String(); c != "" {
@@ -1138,10 +1136,8 @@ var _ = Describe("ProxyRoundTripper", func() {
 				}
 
 				JustBeforeEach(func() {
-					sessionCookie = &round_tripper.Cookie{
-						Cookie: http.Cookie{
-							Name: StickyCookieKey, //JSESSIONID
-						},
+					sessionCookie = &http.Cookie{
+						Name: StickyCookieKey, //JSESSIONID
 					}
 
 					endpoint1 = route.NewEndpoint(&route.EndpointOpts{
@@ -1433,10 +1429,7 @@ var _ = Describe("ProxyRoundTripper", func() {
 								newCookies := resp.Cookies()
 								Expect(newCookies).To(HaveLen(2))
 								Expect(newCookies[0].Raw).To(Equal(sessionCookie.String()))
-
-								// This should fail when Golang introduces parsing for the Partitioned flag on cookies.
-								// see https://github.com/golang/go/issues/62490
-								Expect(newCookies[0].Unparsed).To(Equal([]string{"Partitioned"}))
+								Expect(newCookies[0].Partitioned).To(BeTrue())
 
 								Expect(newCookies[1].Name).To(Equal(round_tripper.VcapCookieId))
 								Expect(newCookies[1].Value).To(Equal(cookies[1].Value)) // still pointing to the same app


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->

Remove workaround for partitioned cookies since go1.23 supports partitioned cookies.

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
