### PR TITLE
Fix test for logging tls-listener-started event

### DIFF
--- a/router/router_test.go
+++ b/router/router_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Router", func() {
 		})
 
 		It("logs tls-listener-started event with proper address structure", func() {
-			Eventually(logger, "60s").Should(gbytes.Say("\"message\":\"tls-listener-started\",\"source\":\"router.test\",\"data\":{\"address\":{\"IP\":\"[::]:\""))
+			Eventually(logger, "60s").Should(gbytes.Say("\"message\":\"tls-listener-started\",\"source\":\"router.test\",\"data\":{\"address\":{\"IP\":\".+?\",\"Port\":[0-9]+,\"Zone\":\".*\""))
 		})
 
 		It("shuts down the server properly", func() {


### PR DESCRIPTION
Do not fail `router` logging test when running on a system not supporting IPv6. With this change, only the log structure is tested.

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This fixes a bug in `router` tests introduced with #435.

Backward Compatibility
---------------
Breaking Change? **No**