### PR TITLE
fix: Enhance gorouter retry logic (#437)

### DIFF
--- a/route/pool.go
+++ b/route/pool.go
@@ -412,15 +412,16 @@ func (p *EndpointPool) IsEmpty() bool {
 func (p *EndpointPool) NextIndex() int {
 	if p.NextIdx == -1 {
 		p.NextIdx = p.random.Intn(len(p.endpoints))
-	} else {
-		p.NextIdx++
 	}
+
+	next := p.NextIdx
+	p.NextIdx++
 
 	if p.NextIdx >= len(p.endpoints) {
 		p.NextIdx = 0
 	}
 
-	return p.NextIdx
+	return next
 }
 
 func (p *EndpointPool) IsOverloaded() bool {

--- a/route/pool.go
+++ b/route/pool.go
@@ -409,6 +409,20 @@ func (p *EndpointPool) IsEmpty() bool {
 	return l == 0
 }
 
+func (p *EndpointPool) NextIndex() int {
+	if p.NextIdx == -1 {
+		p.NextIdx = p.random.Intn(len(p.endpoints))
+	} else {
+		p.NextIdx++
+	}
+
+	if p.NextIdx >= len(p.endpoints) {
+		p.NextIdx = 0
+	}
+
+	return p.NextIdx
+}
+
 func (p *EndpointPool) IsOverloaded() bool {
 	if p.IsEmpty() {
 		return false

--- a/route/roundrobin.go
+++ b/route/roundrobin.go
@@ -3,7 +3,6 @@ package route
 import (
 	"context"
 	"log/slog"
-	"math/rand"
 	"sync"
 	"time"
 )
@@ -12,7 +11,6 @@ type RoundRobin struct {
 	logger *slog.Logger
 	pool   *EndpointPool
 	lock   *sync.Mutex
-	random *rand.Rand
 
 	initialEndpoint       string
 	mustBeSticky          bool
@@ -28,7 +26,6 @@ func NewRoundRobin(logger *slog.Logger, p *EndpointPool, initial string, mustBeS
 		logger:                logger,
 		pool:                  p,
 		lock:                  &sync.Mutex{},
-		random:                rand.New(rand.NewSource(time.Now().UnixNano())),
 		initialEndpoint:       initial,
 		mustBeSticky:          mustBeSticky,
 		locallyOptimistic:     locallyOptimistic,

--- a/route/roundrobin.go
+++ b/route/roundrobin.go
@@ -96,6 +96,10 @@ func (r *RoundRobin) next(attempt int) *endpointElem {
 	if r.nextIdx == -1 {
 		r.nextIdx = r.pool.NextIndex()
 	}
+	// Check the next index of iterator in case the pool size decreased
+	if r.nextIdx >= poolSize {
+		r.nextIdx = 0
+	}
 
 	startingIndex := r.nextIdx
 	currentIndex := startingIndex
@@ -107,7 +111,7 @@ func (r *RoundRobin) next(attempt int) *endpointElem {
 
 		// We tried using the actual modulo operator, but it has a 10x performance penalty
 		nextIndex = currentIndex + 1
-		if nextIndex == poolSize {
+		if nextIndex >= poolSize {
 			nextIndex = 0
 		}
 


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
The fix for the issue described in https://github.com/cloudfoundry/gorouter/issues/437. 
- We propose to use the pool index to "seed" each iterator and next calls on that iterator will then loop over the entire pool exactly once (without to affect the global pool iterator).
- Implement additional tests for two parallel iterator 
- Adapt the test cases in round_robin_test.go which were bound to pool nextIndex strongly (e.g. "RoundRobin Next when locally-optimistic mode on the first attempt when the pool has multiple in the same AZ as the router when all AZ-local endpoints have errors it resets the errors and returns one of the endpoints regardless of AZ"  to check not a specific CanonicalAddr but to validate that one endpoint from other AZ has been returned)


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
