### PR TITLE
Properly calculate length of HTTP headers when evaluating max request header size

### DIFF
--- a/handlers/max_request_size_test.go
+++ b/handlers/max_request_size_test.go
@@ -63,7 +63,7 @@ var _ = Describe("MaxRequestSize", func() {
 
 	BeforeEach(func() {
 		cfg = &config.Config{
-			MaxHeaderBytes:           40,
+			MaxHeaderBytes:           89,
 			LoadBalance:              config.LOAD_BALANCE_RR,
 			StickySessionCookieNames: config.StringSet{"blarg": struct{}{}},
 		}
@@ -155,6 +155,17 @@ var _ = Describe("MaxRequestSize", func() {
 			Expect(result.StatusCode).To(Equal(http.StatusRequestHeaderFieldsTooLarge))
 		})
 	})
+	Context("when a single header has multiple small values taking it over the limit", func() {
+		BeforeEach(func() {
+			for i := 0; i < 10; i++ {
+				header.Add("k", "meow")
+			}
+		})
+		It("throws an http 431", func() {
+			handleRequest()
+			Expect(result.StatusCode).To(Equal(http.StatusRequestHeaderFieldsTooLarge))
+		})
+	})
 	Context("when enough normally-sized headers put the request over the limit", func() {
 		BeforeEach(func() {
 			header.Add("header1", "smallRequest")
@@ -168,7 +179,7 @@ var _ = Describe("MaxRequestSize", func() {
 	})
 	Context("when any combination of things makes the request over the limit", func() {
 		BeforeEach(func() {
-			rawPath = "/?q=v"
+			rawPath = "/?q=meowmeow"
 			header.Add("header1", "smallRequest")
 			header.Add("header2", "smallRequest")
 		})

--- a/integration/common_integration_test.go
+++ b/integration/common_integration_test.go
@@ -137,7 +137,7 @@ func NewTestState() *testState {
 	}
 	cfg.OAuth.TokenEndpoint, cfg.OAuth.Port = hostnameAndPort(oauthServer.Addr())
 
-	cfg.MaxHeaderBytes = 1024 //1kb
+	cfg.MaxHeaderBytes = 48 * 1024 //1kb
 
 	return &testState{
 		cfg: cfg,


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Previously, we had been calculating the HTTP header length using the number of values in a given http header, rather than the sum of each of those values.

Updated tests to properly catch the bad state, then fixed + added more tests.

Backward Compatibility
---------------
Breaking Change? No.