### PR TITLE
Show LB Algorithm in RoutingTable (`/routes` page)

### DIFF
--- a/route/pool.go
+++ b/route/pool.go
@@ -517,16 +517,17 @@ func (e *endpointElem) isOverloaded() bool {
 
 func (e *Endpoint) MarshalJSON() ([]byte, error) {
 	var jsonObj struct {
-		Address             string            `json:"address"`
-		AvailabilityZone    string            `json:"availability_zone"`
-		Protocol            string            `json:"protocol"`
-		TLS                 bool              `json:"tls"`
-		TTL                 int               `json:"ttl"`
-		RouteServiceUrl     string            `json:"route_service_url,omitempty"`
-		Tags                map[string]string `json:"tags"`
-		IsolationSegment    string            `json:"isolation_segment,omitempty"`
-		PrivateInstanceId   string            `json:"private_instance_id,omitempty"`
-		ServerCertDomainSAN string            `json:"server_cert_domain_san,omitempty"`
+		Address                string            `json:"address"`
+		AvailabilityZone       string            `json:"availability_zone"`
+		Protocol               string            `json:"protocol"`
+		TLS                    bool              `json:"tls"`
+		TTL                    int               `json:"ttl"`
+		RouteServiceUrl        string            `json:"route_service_url,omitempty"`
+		Tags                   map[string]string `json:"tags"`
+		IsolationSegment       string            `json:"isolation_segment,omitempty"`
+		PrivateInstanceId      string            `json:"private_instance_id,omitempty"`
+		ServerCertDomainSAN    string            `json:"server_cert_domain_san,omitempty"`
+		LoadBalancingAlgorithm string            `json:"load_balancing_algorithm,omitempty"`
 	}
 
 	jsonObj.Address = e.addr
@@ -539,6 +540,7 @@ func (e *Endpoint) MarshalJSON() ([]byte, error) {
 	jsonObj.IsolationSegment = e.IsolationSegment
 	jsonObj.PrivateInstanceId = e.PrivateInstanceId
 	jsonObj.ServerCertDomainSAN = e.ServerCertDomainSAN
+	jsonObj.LoadBalancingAlgorithm = e.LoadBalancingAlgorithm
 	return json.Marshal(jsonObj)
 }
 

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -822,6 +822,7 @@ var _ = Describe("EndpointPool", func() {
 			ServerCertDomainSAN:     "pvt_test_san",
 			PrivateInstanceId:       "pvt_test_instance_id",
 			UseTLS:                  true,
+			LoadBalancingAlgorithm:  "lb-meow",
 		})
 
 		pool.Put(e)
@@ -830,7 +831,7 @@ var _ = Describe("EndpointPool", func() {
 		json, err := pool.MarshalJSON()
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(string(json)).To(Equal(`[{"address":"1.2.3.4:5678","availability_zone":"az-meow","protocol":"http1","tls":false,"ttl":-1,"route_service_url":"https://my-rs.com","tags":null},{"address":"5.6.7.8:5678","availability_zone":"","protocol":"http2","tls":true,"ttl":-1,"tags":null,"private_instance_id":"pvt_test_instance_id","server_cert_domain_san":"pvt_test_san"}]`))
+		Expect(string(json)).To(Equal(`[{"address":"1.2.3.4:5678","availability_zone":"az-meow","protocol":"http1","tls":false,"ttl":-1,"route_service_url":"https://my-rs.com","tags":null},{"address":"5.6.7.8:5678","availability_zone":"","protocol":"http2","tls":true,"ttl":-1,"tags":null,"private_instance_id":"pvt_test_instance_id","server_cert_domain_san":"pvt_test_san","load_balancing_algorithm":"lb-meow"}]`))
 	})
 
 	Context("when endpoints do not have empty tags", func() {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Adds `load_balancing_algorithm` to `Endpoint` JSON representation to display the LB algorithm in the `/routes` page. This simplifies debugging of related issues.
The option to set route-specific load balancing algorithms was introduced in https://github.com/cloudfoundry/gorouter/pull/428.


Backward Compatibility
---------------
Breaking Change? **No**

(According to the [Gorouter docs](https://github.com/cloudfoundry/gorouter/pull/446/files#diff-6b5dcfee48e174b2716e3ac3adcbc21860aab85bdf03789929f4eb64d2e32f9eR46-R48), the /routes endpoint is an internal feature, so it shouldn't be a breaking change even though we're adding a JSON property.)