### PR TITLE
Resolve G115 integer overflow warnings

### DIFF
--- a/common/secure/crypto.go
+++ b/common/secure/crypto.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"errors"
+	"fmt"
 
 	"golang.org/x/crypto/pbkdf2"
 )
@@ -64,10 +65,13 @@ func NewPbkdf2(input []byte, keyLen int) []byte {
 }
 
 func (gcm *AesGCM) generateNonce() ([]byte, error) {
-	return RandomBytes(uint(gcm.NonceSize()))
+	return RandomBytes(gcm.NonceSize())
 }
 
-func RandomBytes(size uint) ([]byte, error) {
+func RandomBytes(size int) ([]byte, error) {
+	if size < 0 {
+		return nil, fmt.Errorf("cannot generate a negative number of random bytes")
+	}
 	b := make([]byte, size)
 	_, err := rand.Read(b)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -152,7 +152,7 @@ type RoutingApiConfig struct {
 
 type OAuthConfig struct {
 	TokenEndpoint     string `yaml:"token_endpoint"`
-	Port              int    `yaml:"port"`
+	Port              uint16 `yaml:"port"`
 	SkipSSLValidation bool   `yaml:"skip_ssl_validation"`
 	ClientName        string `yaml:"client_name"`
 	ClientSecret      string `yaml:"client_secret"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -654,7 +654,7 @@ oauth:
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(config.OAuth.TokenEndpoint).To(Equal("uaa.internal"))
-			Expect(config.OAuth.Port).To(Equal(8443))
+			Expect(config.OAuth.Port).To(Equal(uint16(8443)))
 			Expect(config.OAuth.SkipSSLValidation).To(Equal(true))
 			Expect(config.OAuth.ClientName).To(Equal("client-name"))
 			Expect(config.OAuth.ClientSecret).To(Equal("client-secret"))

--- a/handlers/httpstartstop.go
+++ b/handlers/httpstartstop.go
@@ -57,6 +57,7 @@ func (hh *httpStartStopHandler) ServeHTTP(rw http.ResponseWriter, r *http.Reques
 
 	next(rw, r)
 
+	// #nosec G115 - http status codes are `int` values, but dropsonde requires int32. per the RFC, it will only ever be 3 digits so ignore any loss/overflow due to conversion
 	startStopEvent := factories.NewHttpStartStop(r, int32(prw.Status()), int64(prw.Size()), events.PeerType_Server, requestID)
 	startStopEvent.StartTimestamp = proto.Int64(startTime.UnixNano())
 

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -1115,7 +1115,7 @@ var _ = Describe("Router Integration", func() {
 
 		Context("when tls for uaa is disabled", func() {
 			It("fails fast", func() {
-				cfg.OAuth.Port = -1
+				cfg.OAuth.Port = 0
 				writeConfig(cfg, cfgFile)
 
 				gorouterCmd := exec.Command(gorouterPath, "-c", cfgFile)
@@ -1433,11 +1433,12 @@ func uriAndPort(url string) (string, int) {
 	return uri, port
 }
 
-func hostnameAndPort(url string) (string, int) {
+func hostnameAndPort(url string) (string, uint16) {
 	parts := strings.Split(url, ":")
 	hostname := parts[0]
-	port, _ := strconv.Atoi(parts[1])
-	return hostname, port
+	port, err := strconv.ParseUint(parts[1], 10, 16)
+	Expect(err).ToNot(HaveOccurred())
+	return hostname, uint16(port)
 }
 
 func newMessageBus(c *config.Config) (*nats.Conn, error) {

--- a/test_util/helpers.go
+++ b/test_util/helpers.go
@@ -34,7 +34,7 @@ func RegisterAddr(reg *registry.RouteRegistry, path string, addr string, cfg Reg
 	host, portStr, err := net.SplitHostPort(addr)
 	Expect(err).NotTo(HaveOccurred())
 
-	port, err := strconv.Atoi(portStr)
+	port, err := strconv.ParseUint(portStr, 10, 16)
 	Expect(err).NotTo(HaveOccurred())
 	reg.Register(
 		route.Uri(path),

--- a/test_util/ports.go
+++ b/test_util/ports.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	lastPortUsed int
+	lastPortUsed uint16
 	portLock     sync.Mutex
 	once         sync.Once
 )
@@ -19,11 +19,13 @@ func NextAvailPort() uint16 {
 	if lastPortUsed == 0 {
 		once.Do(func() {
 			const portRangeStart = 25000
-			lastPortUsed = portRangeStart + GinkgoParallelProcess()
+			// #nosec G115 - if we have negative or > 65k parallel ginkgo threads there's something worse happening
+			lastPortUsed = portRangeStart + uint16(GinkgoParallelProcess())
 		})
 	}
 
 	suiteCfg, _ := GinkgoConfiguration()
-	lastPortUsed += suiteCfg.ParallelTotal
-	return uint16(lastPortUsed)
+	// #nosec G115 - if we have negative or > 65k parallel ginkgo threads there's something worse happening
+	lastPortUsed += uint16(suiteCfg.ParallelTotal)
+	return lastPortUsed
 }


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
- Convert port related logic to use uint16
- Update access log write counters to use uint64 and convert down to int to reduce chances of overflow and bad logging if 2GB  of data is read from a response in a single chunk
- Update RandomBytes() to use an int, and throw an error if a negative nonce size is requested, rather than wrapping around for negative numbers which theoretically should never occur
- Ignore potential integer overflow related to casting HTTP Status codes because... 3 digit positive integers per the HTTP spec.

Backward Compatibility
---------------
Breaking Change? no