### PR TITLE
Introduce response header limits

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -460,7 +460,7 @@ type Config struct {
 	DisableKeepAlives            bool `yaml:"disable_keep_alives"`
 	MaxIdleConns                 int  `yaml:"max_idle_conns,omitempty"`
 	MaxIdleConnsPerHost          int  `yaml:"max_idle_conns_per_host,omitempty"`
-	MaxHeaderBytes               int  `yaml:"max_header_bytes"`
+	MaxRequestHeaderBytes        int  `yaml:"max_request_header_bytes"`
 	KeepAlive100ContinueRequests bool `yaml:"keep_alive_100_continue_requests"`
 
 	HTTPRewrite HTTPRewrite `yaml:"http_rewrite,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -461,6 +461,7 @@ type Config struct {
 	MaxIdleConns                 int  `yaml:"max_idle_conns,omitempty"`
 	MaxIdleConnsPerHost          int  `yaml:"max_idle_conns_per_host,omitempty"`
 	MaxRequestHeaderBytes        int  `yaml:"max_request_header_bytes"`
+	MaxResponseHeaderBytes       int  `yaml:"max_response_header_bytes"`
 	KeepAlive100ContinueRequests bool `yaml:"keep_alive_100_continue_requests"`
 
 	HTTPRewrite HTTPRewrite `yaml:"http_rewrite,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -462,6 +462,8 @@ type Config struct {
 	MaxIdleConnsPerHost          int  `yaml:"max_idle_conns_per_host,omitempty"`
 	MaxRequestHeaderBytes        int  `yaml:"max_request_header_bytes"`
 	MaxResponseHeaderBytes       int  `yaml:"max_response_header_bytes"`
+	MaxRequestHeaders            int  `yaml:"max_request_headers"`
+	MaxResponseHeaders           int  `yaml:"max_response_headers"`
 	KeepAlive100ContinueRequests bool `yaml:"keep_alive_100_continue_requests"`
 
 	HTTPRewrite HTTPRewrite `yaml:"http_rewrite,omitempty"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -213,13 +213,13 @@ status:
 		})
 		It("sets MaxHeaderBytes", func() {
 			var b = []byte(`
-max_header_bytes: 10
+max_request_header_bytes: 10
 `)
 
 			err := config.Initialize(b)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(config.MaxHeaderBytes).To(Equal(10))
+			Expect(config.MaxRequestHeaderBytes).To(Equal(10))
 		})
 
 		It("sets prometheus endpoint config", func() {

--- a/handlers/max_request_size.go
+++ b/handlers/max_request_size.go
@@ -21,7 +21,7 @@ const ONE_MB = 1024 * 1024 // bytes * kb
 // NewAccessLog creates a new handler that handles logging requests to the
 // access log
 func NewMaxRequestSize(cfg *config.Config, logger *slog.Logger) *MaxRequestSize {
-	maxSize := cfg.MaxHeaderBytes
+	maxSize := cfg.MaxRequestHeaderBytes
 
 	if maxSize < 1 {
 		maxSize = ONE_MB

--- a/handlers/max_request_size_test.go
+++ b/handlers/max_request_size_test.go
@@ -166,6 +166,17 @@ var _ = Describe("MaxRequestSize", func() {
 			Expect(result.StatusCode).To(Equal(http.StatusRequestHeaderFieldsTooLarge))
 		})
 	})
+	Context("when a repeated header has a short value and long key taking it over the limit", func() {
+		BeforeEach(func() {
+			for i := 0; i < 10; i++ {
+				header.Add("foobar", "m")
+			}
+		})
+		It("throws an http 431", func() {
+			handleRequest()
+			Expect(result.StatusCode).To(Equal(http.StatusRequestHeaderFieldsTooLarge))
+		})
+	})
 	Context("when enough normally-sized headers put the request over the limit", func() {
 		BeforeEach(func() {
 			header.Add("header1", "smallRequest")

--- a/handlers/max_request_size_test.go
+++ b/handlers/max_request_size_test.go
@@ -63,7 +63,7 @@ var _ = Describe("MaxRequestSize", func() {
 
 	BeforeEach(func() {
 		cfg = &config.Config{
-			MaxHeaderBytes:           89,
+			MaxRequestHeaderBytes:    89,
 			LoadBalance:              config.LOAD_BALANCE_RR,
 			StickySessionCookieNames: config.StringSet{"blarg": struct{}{}},
 		}
@@ -216,7 +216,7 @@ var _ = Describe("MaxRequestSize", func() {
 	Describe("NewMaxRequestSize()", func() {
 		Context("when using a custom MaxHeaderBytes", func() {
 			BeforeEach(func() {
-				cfg.MaxHeaderBytes = 1234
+				cfg.MaxRequestHeaderBytes = 1234
 			})
 			It("returns a new requestSizeHandler using the provided size", func() {
 				Expect(rh.MaxSize).To(Equal(1234))
@@ -225,7 +225,7 @@ var _ = Describe("MaxRequestSize", func() {
 
 		Context("when using a negative MaxHeaderBytes", func() {
 			BeforeEach(func() {
-				cfg.MaxHeaderBytes = -1
+				cfg.MaxRequestHeaderBytes = -1
 			})
 			It("defaults to 1mb", func() {
 				Expect(rh.MaxSize).To(Equal(1024 * 1024))
@@ -233,7 +233,7 @@ var _ = Describe("MaxRequestSize", func() {
 		})
 		Context("when using a zero-value MaxHeaderBytes", func() {
 			BeforeEach(func() {
-				cfg.MaxHeaderBytes = 0
+				cfg.MaxRequestHeaderBytes = 0
 			})
 			It("defaults to 1mb", func() {
 				Expect(rh.MaxSize).To(Equal(1024 * 1024))
@@ -242,7 +242,7 @@ var _ = Describe("MaxRequestSize", func() {
 
 		Context("when using a >1mb MaxHeaderBytes", func() {
 			BeforeEach(func() {
-				cfg.MaxHeaderBytes = handlers.ONE_MB * 2
+				cfg.MaxRequestHeaderBytes = handlers.ONE_MB * 2
 			})
 			It("defaults  to 1mb if the provided size", func() {
 				Expect(rh.MaxSize).To(Equal(1024 * 1024))

--- a/integration/common_integration_test.go
+++ b/integration/common_integration_test.go
@@ -137,7 +137,7 @@ func NewTestState() *testState {
 	}
 	cfg.OAuth.TokenEndpoint, cfg.OAuth.Port = hostnameAndPort(oauthServer.Addr())
 
-	cfg.MaxHeaderBytes = 48 * 1024 //1kb
+	cfg.MaxRequestHeaderBytes = 48 * 1024 //1kb
 
 	return &testState{
 		cfg: cfg,

--- a/integration/large_request_test.go
+++ b/integration/large_request_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Large requests", func() {
 		testState = NewTestState()
 		testState.EnableAccessLog()
 		testState.EnableMetron()
-		testState.cfg.MaxHeaderBytes = 1 * 1024 // 1kb
+		testState.cfg.MaxRequestHeaderBytes = 1 * 1024 // 1kb
 		testState.StartGorouterOrFail()
 
 		appURL = "echo-app." + test_util.LocalhostDNS

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -84,25 +84,27 @@ func NewProxy(
 
 	roundTripperFactory := &round_tripper.FactoryImpl{
 		BackendTemplate: &http.Transport{
-			DialContext:           dialer.DialContext,
-			DisableKeepAlives:     cfg.DisableKeepAlives,
-			MaxIdleConns:          cfg.MaxIdleConns,
-			IdleConnTimeout:       90 * time.Second, // setting the value to golang default transport
-			MaxIdleConnsPerHost:   cfg.MaxIdleConnsPerHost,
-			DisableCompression:    true,
-			TLSClientConfig:       backendTLSConfig,
-			TLSHandshakeTimeout:   cfg.TLSHandshakeTimeout,
-			ExpectContinueTimeout: 1 * time.Second,
+			DialContext:            dialer.DialContext,
+			DisableKeepAlives:      cfg.DisableKeepAlives,
+			MaxIdleConns:           cfg.MaxIdleConns,
+			IdleConnTimeout:        90 * time.Second, // setting the value to golang default transport
+			MaxIdleConnsPerHost:    cfg.MaxIdleConnsPerHost,
+			DisableCompression:     true,
+			TLSClientConfig:        backendTLSConfig,
+			TLSHandshakeTimeout:    cfg.TLSHandshakeTimeout,
+			ExpectContinueTimeout:  1 * time.Second,
+			MaxResponseHeaderBytes: int64(cfg.MaxResponseHeaderBytes),
 		},
 		RouteServiceTemplate: &http.Transport{
-			DialContext:           dialer.DialContext,
-			DisableKeepAlives:     cfg.DisableKeepAlives,
-			MaxIdleConns:          cfg.MaxIdleConns,
-			IdleConnTimeout:       90 * time.Second, // setting the value to golang default transport
-			MaxIdleConnsPerHost:   cfg.MaxIdleConnsPerHost,
-			DisableCompression:    true,
-			TLSClientConfig:       routeServiceTLSConfig,
-			ExpectContinueTimeout: 1 * time.Second,
+			DialContext:            dialer.DialContext,
+			DisableKeepAlives:      cfg.DisableKeepAlives,
+			MaxIdleConns:           cfg.MaxIdleConns,
+			IdleConnTimeout:        90 * time.Second, // setting the value to golang default transport
+			MaxIdleConnsPerHost:    cfg.MaxIdleConnsPerHost,
+			DisableCompression:     true,
+			TLSClientConfig:        routeServiceTLSConfig,
+			ExpectContinueTimeout:  1 * time.Second,
+			MaxResponseHeaderBytes: int64(cfg.MaxResponseHeaderBytes),
 		},
 		IsInstrumented: cfg.SendHttpStartStopClientEvent,
 	}

--- a/proxy/round_tripper/dropsonde_round_tripper.go
+++ b/proxy/round_tripper/dropsonde_round_tripper.go
@@ -45,16 +45,17 @@ func (t *FactoryImpl) New(expectedServerName string, isRouteService bool, isHttp
 	customTLSConfig := utils.TLSConfigWithServerName(expectedServerName, template.TLSClientConfig, isRouteService)
 
 	newTransport := &http.Transport{
-		DialContext:           template.DialContext,
-		DisableKeepAlives:     template.DisableKeepAlives,
-		MaxIdleConns:          template.MaxIdleConns,
-		IdleConnTimeout:       template.IdleConnTimeout,
-		MaxIdleConnsPerHost:   template.MaxIdleConnsPerHost,
-		DisableCompression:    template.DisableCompression,
-		TLSClientConfig:       customTLSConfig,
-		TLSHandshakeTimeout:   template.TLSHandshakeTimeout,
-		ForceAttemptHTTP2:     isHttp2,
-		ExpectContinueTimeout: template.ExpectContinueTimeout,
+		DialContext:            template.DialContext,
+		DisableKeepAlives:      template.DisableKeepAlives,
+		MaxIdleConns:           template.MaxIdleConns,
+		IdleConnTimeout:        template.IdleConnTimeout,
+		MaxIdleConnsPerHost:    template.MaxIdleConnsPerHost,
+		DisableCompression:     template.DisableCompression,
+		TLSClientConfig:        customTLSConfig,
+		TLSHandshakeTimeout:    template.TLSHandshakeTimeout,
+		ForceAttemptHTTP2:      isHttp2,
+		ExpectContinueTimeout:  template.ExpectContinueTimeout,
+		MaxResponseHeaderBytes: template.MaxResponseHeaderBytes,
 	}
 	if t.IsInstrumented {
 		return NewDropsondeRoundTripper(newTransport)

--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -40,7 +40,7 @@ const (
 
 var (
 	NoEndpointsAvailable   = errors.New("No endpoints available")
-	TooManyResponseHeaders = errors.New("too many response headers")
+	TooManyResponseHeaders = errors.New("Too many response headers")
 )
 
 //go:generate counterfeiter -o fakes/fake_proxy_round_tripper.go . ProxyRoundTripper


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
* Fix the header accounting on requests.
* (internal) Rename the config field MaxHeaderBytes to MaxRequestHeaderBytes.
* Add MaxRequestHeaderBytes and the corresponding logic.

A request with too large response headers will now look like this:

```sh
$ curl -i "https://net-tools.cf.local/headers?foobarbazz=$(python3 -c 'print("a" * 1000)')"
HTTP/2 502
content-type: text/plain; charset=utf-8
x-cf-routererror: endpoint_failure (net/http: HTTP/1.x transport connection broken: net/http: server response headers exceeded 1024 bytes; aborted)
x-content-type-options: nosniff
date: Thu, 07 Nov 2024 09:24:09 GMT
content-length: 67

502 Bad Gateway: Registered endpoint failed to handle the request.
```


Backward Compatibility
---------------
Breaking Change? **No**