### PR TITLE
feat: log local TCP address

### DIFF
--- a/accesslog/schema/access_log_record_test.go
+++ b/accesslog/schema/access_log_record_test.go
@@ -314,6 +314,43 @@ var _ = Describe("AccessLogRecord", func() {
 				Eventually(r).Should(Say(`x_cf_routererror:"-"`))
 			})
 		})
+
+		Context("when extra_fields is set to [local_address]", func() {
+			Context("and the local address is empty", func() {
+				It("makes a record with the local address set to -", func() {
+					record.ExtraFields = []string{"local_address"}
+
+					r := BufferReader(bytes.NewBufferString(record.LogMessage()))
+					Eventually(r).Should(Say(`local_address:"-"`))
+				})
+			})
+			Context("and the local address contains an address", func() {
+				It("makes a record with the local address set to that address", func() {
+					record.ExtraFields = []string{"local_address"}
+					record.LocalAddress = "10.0.0.1:34823"
+
+					r := BufferReader(bytes.NewBufferString(record.LogMessage()))
+					Eventually(r).Should(Say(`local_address:"10.0.0.1:34823"`))
+				})
+			})
+		})
+
+		Context("when extra_fields is set to [foobarbazz]", func() {
+			It("ignores it", func() {
+				record.ExtraFields = []string{"foobarbazz"}
+				record.LocalAddress = "10.0.0.1:34823"
+
+				r := BufferReader(bytes.NewBufferString(record.LogMessage()))
+				Consistently(r).ShouldNot(Say("foobarbazz"))
+			})
+			It("does not log local_address", func() {
+				record.ExtraFields = []string{"foobarbazz"}
+				record.LocalAddress = "10.0.0.1:34823"
+
+				r := BufferReader(bytes.NewBufferString(record.LogMessage()))
+				Consistently(r).ShouldNot(Say(`local_address:"10.0.0.1:34823"`))
+			})
+		})
 	})
 
 	Describe("WriteTo", func() {

--- a/config/config.go
+++ b/config/config.go
@@ -186,6 +186,7 @@ type LoggingConfig struct {
 	RedactQueryParams      string       `yaml:"redact_query_params"`
 	EnableAttemptsDetails  bool         `yaml:"enable_attempts_details"`
 	Format                 FormatConfig `yaml:"format"`
+	ExtraAccessLogFields   []string     `yaml:"extra_access_log_fields"`
 
 	// This field is populated by the `Process` function.
 	JobName string `yaml:"-"`

--- a/handlers/requestinfo.go
+++ b/handlers/requestinfo.go
@@ -71,6 +71,8 @@ type RequestInfo struct {
 	ShouldRouteToInternalRouteService bool
 	FailedAttempts                    int
 
+	LocalAddress string
+
 	// RoundTripSuccessful will be set once a request has successfully reached a backend instance.
 	RoundTripSuccessful bool
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -173,7 +173,7 @@ func NewProxy(
 			n.Use(handlers.NewHTTPLatencyPrometheus(p.promRegistry))
 		}
 	}
-	n.Use(handlers.NewAccessLog(accessLogger, headersToLog, cfg.Logging.EnableAttemptsDetails, logger))
+	n.Use(handlers.NewAccessLog(accessLogger, headersToLog, cfg.Logging.EnableAttemptsDetails, cfg.Logging.ExtraAccessLogFields, logger))
 	n.Use(handlers.NewQueryParam(logger))
 	n.Use(handlers.NewReporter(reporter, logger))
 	n.Use(handlers.NewHTTPRewriteHandler(cfg.HTTPRewrite, headersToAlwaysRemove))

--- a/proxy/round_tripper/proxy_round_tripper.go
+++ b/proxy/round_tripper/proxy_round_tripper.go
@@ -191,6 +191,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 				slog.Float64("dns-lookup-time", trace.DnsTime()),
 				slog.Float64("dial-time", trace.DialTime()),
 				slog.Float64("tls-handshake-time", trace.TlsTime()),
+				slog.String("local-address", trace.LocalAddr()),
 			)
 
 			if err != nil {
@@ -255,6 +256,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 				slog.Float64("dns-lookup-time", trace.DnsTime()),
 				slog.Float64("dial-time", trace.DialTime()),
 				slog.Float64("tls-handshake-time", trace.TlsTime()),
+				slog.String("local-address", trace.LocalAddr()),
 			)
 
 			if err != nil {
@@ -347,6 +349,7 @@ func (rt *roundTripper) RoundTrip(originalRequest *http.Request) (*http.Response
 	reqInfo.DialFinishedAt = trace.DialDone()
 	reqInfo.TlsHandshakeStartedAt = trace.TlsStart()
 	reqInfo.TlsHandshakeFinishedAt = trace.TlsDone()
+	reqInfo.LocalAddress = trace.LocalAddr()
 
 	if res != nil && endpoint.PrivateInstanceId != "" && !requestSentToRouteService(request) {
 		setupStickySession(


### PR DESCRIPTION
Summary
---------------

When troubleshooting issues related to keepalive it is often useful to be able to correlate multiple requests made over the same connection. A first step was to introduce the information on whether the request was made on a re-used connection or not which was done with a7dbf849. This commit adds the local address of the TCP connection which adds the capability to distinguish between multiple, parallel keep-alive connections by looking at the client port of gorouter for the backend connection.

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).


Backward Compatibility
---------------
Breaking Change? **Yes**

