### PR TITLE
Syslog Improvements (2)

### DIFF
--- a/accesslog/file_and_loggregator_access_logger.go
+++ b/accesslog/file_and_loggregator_access_logger.go
@@ -38,10 +38,50 @@ type FileAndLoggregatorAccessLogger struct {
 	logsender              schema.LogSender
 }
 
-type CustomWriter struct {
-	Name            string
-	Writer          io.Writer
-	PerformTruncate bool
+type CustomWriter interface {
+	Name() string
+	io.Writer
+}
+
+// SyslogWriter sends logs to a [syslog.Writer].
+type SyslogWriter struct {
+	name     string
+	truncate int
+	*syslog.Writer
+}
+
+func (w *SyslogWriter) Name() string {
+	return w.name
+}
+
+func (w *SyslogWriter) Write(b []byte) (int, error) {
+	n := len(b)
+	if w.truncate > 0 && n > w.truncate {
+		n = w.truncate
+	}
+	return w.Writer.Write(b[:n])
+}
+
+// FileWriter sends logs to a [os.File] and appends a new line to each line written to seperate log
+// lines.
+type FileWriter struct {
+	name string
+	*os.File
+}
+
+func (w *FileWriter) Name() string {
+	return w.name
+}
+
+func (w *FileWriter) Write(b []byte) (int, error) {
+	n, err := w.File.Write(b)
+	if err != nil {
+		return n, err
+	}
+
+	// Do not count the extra bytes, we can not return more than len(b).
+	_, err = w.File.Write([]byte{'\n'})
+	return n, err
 }
 
 func CreateRunningAccessLogger(logger *slog.Logger, logsender schema.LogSender, config *config.Config) (AccessLogger, error) {
@@ -66,7 +106,10 @@ func CreateRunningAccessLogger(logger *slog.Logger, logsender schema.LogSender, 
 			return nil, err
 		}
 
-		accessLogger.addWriter(CustomWriter{Name: "accesslog", Writer: file, PerformTruncate: false})
+		accessLogger.addWriter(&FileWriter{
+			name: "accesslog",
+			File: file,
+		})
 	}
 
 	if config.AccessLog.EnableStreaming {
@@ -76,7 +119,11 @@ func CreateRunningAccessLogger(logger *slog.Logger, logsender schema.LogSender, 
 			return nil, err
 		}
 
-		accessLogger.addWriter(CustomWriter{Name: "syslog", Writer: syslogWriter, PerformTruncate: true})
+		accessLogger.addWriter(&SyslogWriter{
+			name:     "syslog",
+			truncate: config.Logging.SyslogTruncate,
+			Writer:   syslogWriter,
+		})
 	}
 
 	go accessLogger.Run()
@@ -88,9 +135,9 @@ func (x *FileAndLoggregatorAccessLogger) Run() {
 		select {
 		case record := <-x.channel:
 			for _, w := range x.writers {
-				_, err := record.WriteTo(w.Writer)
+				_, err := record.WriteTo(w)
 				if err != nil {
-					x.logger.Error(fmt.Sprintf("error-emitting-access-log-to-writer-%s", w.Name), log.ErrAttr(err))
+					x.logger.Error(fmt.Sprintf("error-emitting-access-log-to-writer-%s", w.Name()), log.ErrAttr(err))
 				}
 			}
 			record.SendLog(x.logsender)

--- a/accesslog/file_and_loggregator_access_logger.go
+++ b/accesslog/file_and_loggregator_access_logger.go
@@ -85,7 +85,7 @@ func (w *FileWriter) Write(b []byte) (int, error) {
 }
 
 func CreateRunningAccessLogger(logger *slog.Logger, logsender schema.LogSender, config *config.Config) (AccessLogger, error) {
-	if config.AccessLog.File == "" && !config.Logging.LoggregatorEnabled {
+	if config.AccessLog.File == "" && !config.Logging.LoggregatorEnabled && !config.AccessLog.EnableStreaming {
 		return &NullAccessLogger{}, nil
 	}
 

--- a/accesslog/file_and_loggregator_access_logger.go
+++ b/accesslog/file_and_loggregator_access_logger.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"log/syslog"
 	"os"
 
 	"code.cloudfoundry.org/gorouter/accesslog/schema"
+	"code.cloudfoundry.org/gorouter/accesslog/syslog"
 	"code.cloudfoundry.org/gorouter/config"
 	log "code.cloudfoundry.org/gorouter/logger"
 )
@@ -113,7 +113,7 @@ func CreateRunningAccessLogger(logger *slog.Logger, logsender schema.LogSender, 
 	}
 
 	if config.AccessLog.EnableStreaming {
-		syslogWriter, err := syslog.Dial(config.Logging.SyslogNetwork, config.Logging.SyslogAddr, syslog.LOG_INFO, config.Logging.Syslog)
+		syslogWriter, err := syslog.Dial(config.Logging.SyslogNetwork, config.Logging.SyslogAddr, syslog.SeverityInfo, syslog.FacilityUser, config.Logging.Syslog)
 		if err != nil {
 			logger.Error("error-creating-syslog-writer", log.ErrAttr(err))
 			return nil, err

--- a/accesslog/file_and_loggregator_access_logger_test.go
+++ b/accesslog/file_and_loggregator_access_logger_test.go
@@ -360,7 +360,8 @@ var _ = Describe("AccessLog", func() {
 			cfg.AccessLog.File = ""
 			cfg.AccessLog.EnableStreaming = false
 
-			accessLogger, _ := accesslog.CreateRunningAccessLogger(logger.Logger, ls, cfg)
+			accessLogger, err := accesslog.CreateRunningAccessLogger(logger.Logger, ls, cfg)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(accessLogger.(*accesslog.FileAndLoggregatorAccessLogger).FileWriters()).To(BeEmpty())
 			Expect(accessLogger.(*accesslog.FileAndLoggregatorAccessLogger).WriterCount()).To(Equal(0))
 		})
@@ -369,7 +370,8 @@ var _ = Describe("AccessLog", func() {
 			cfg.AccessLog.File = "/dev/null"
 			cfg.AccessLog.EnableStreaming = false
 
-			accessLogger, _ := accesslog.CreateRunningAccessLogger(logger.Logger, ls, cfg)
+			accessLogger, err := accesslog.CreateRunningAccessLogger(logger.Logger, ls, cfg)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(accessLogger.(*accesslog.FileAndLoggregatorAccessLogger).FileWriters()).ToNot(BeEmpty())
 			Expect(accessLogger.(*accesslog.FileAndLoggregatorAccessLogger).WriterCount()).To(Equal(1))
 		})
@@ -379,7 +381,8 @@ var _ = Describe("AccessLog", func() {
 			cfg.AccessLog.File = "/dev/null"
 			cfg.AccessLog.EnableStreaming = false
 
-			accessLogger, _ := accesslog.CreateRunningAccessLogger(logger.Logger, ls, cfg)
+			accessLogger, err := accesslog.CreateRunningAccessLogger(logger.Logger, ls, cfg)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(accessLogger.(*accesslog.FileAndLoggregatorAccessLogger).FileWriters()).ToNot(BeEmpty())
 			Expect(accessLogger.(*accesslog.FileAndLoggregatorAccessLogger).WriterCount()).To(Equal(1))
 		})
@@ -389,7 +392,8 @@ var _ = Describe("AccessLog", func() {
 			cfg.AccessLog.File = "/dev/null"
 			cfg.AccessLog.EnableStreaming = true
 
-			accessLogger, _ := accesslog.CreateRunningAccessLogger(logger.Logger, ls, cfg)
+			accessLogger, err := accesslog.CreateRunningAccessLogger(logger.Logger, ls, cfg)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(accessLogger.(*accesslog.FileAndLoggregatorAccessLogger).FileWriters()).ToNot(BeNil())
 			Expect(accessLogger.(*accesslog.FileAndLoggregatorAccessLogger).WriterCount()).To(Equal(2))
 		})
@@ -399,7 +403,8 @@ var _ = Describe("AccessLog", func() {
 			cfg.AccessLog.File = "/dev/null"
 			cfg.AccessLog.EnableStreaming = false
 
-			accessLogger, _ := accesslog.CreateRunningAccessLogger(logger.Logger, ls, cfg)
+			accessLogger, err := accesslog.CreateRunningAccessLogger(logger.Logger, ls, cfg)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(accessLogger.(*accesslog.FileAndLoggregatorAccessLogger).FileWriters()).ToNot(BeNil())
 			Expect(accessLogger.(*accesslog.FileAndLoggregatorAccessLogger).WriterCount()).To(Equal(1))
 		})
@@ -409,7 +414,8 @@ var _ = Describe("AccessLog", func() {
 			cfg.AccessLog.File = ""
 			cfg.AccessLog.EnableStreaming = true
 
-			accessLogger, _ := accesslog.CreateRunningAccessLogger(logger.Logger, ls, cfg)
+			accessLogger, err := accesslog.CreateRunningAccessLogger(logger.Logger, ls, cfg)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(accessLogger.(*accesslog.FileAndLoggregatorAccessLogger).FileWriters()).ToNot(BeNil())
 			Expect(accessLogger.(*accesslog.FileAndLoggregatorAccessLogger).WriterCount()).To(Equal(1))
 		})

--- a/accesslog/schema/access_log_record.go
+++ b/accesslog/schema/access_log_record.go
@@ -373,12 +373,8 @@ func formatHeader(headers http.Header, name string, performTruncate bool) string
 
 // WriteTo allows the AccessLogRecord to implement the io.WriterTo interface
 func (r *AccessLogRecord) WriteTo(w io.Writer) (int64, error) {
-	bytesWritten, err := w.Write(r.getRecord(false))
-	if err != nil {
-		return int64(bytesWritten), err
-	}
-	newline, err := w.Write([]byte("\n"))
-	return int64(bytesWritten + newline), err
+	n, err := w.Write(r.getRecord(false))
+	return int64(n), err
 }
 
 func (r *AccessLogRecord) SendLog(ls LogSender) {

--- a/accesslog/schema/access_log_record_test.go
+++ b/accesslog/schema/access_log_record_test.go
@@ -330,7 +330,7 @@ var _ = Describe("AccessLogRecord", func() {
 			Eventually(r).Should(Say(`x_forwarded_proto:"FakeOriginalRequestProto" `))
 			Eventually(r).Should(Say(`vcap_request_id:"abc-123-xyz-pdq" response_time:60.000000 gorouter_time:10.000000 app_id:"FakeApplicationId" `))
 			Eventually(r).Should(Say(`app_index:"3"`))
-			Eventually(r).Should(Say(`x_cf_routererror:"some-router-error"\n`))
+			Eventually(r).Should(Say(`x_cf_routererror:"some-router-error"`))
 		})
 
 		Context("when the AccessLogRecord is too large for UDP", func() {

--- a/accesslog/syslog/syslog.go
+++ b/accesslog/syslog/syslog.go
@@ -1,0 +1,257 @@
+// This file is part of gorouter of Cloud Foundry. The implementation is a modified version of the
+// Go standard library implementation at log/syslog/syslog.go. Any modifications are licensed under
+// the license of gorouter which can be found in the LICENSE file.
+//
+// Original License:
+//
+// Copyright 2009 The Go Authors.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google LLC nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Package syslog implements a syslog writer over UDP and TCP following RFC5424, RFC5426 and
+// RFC6587. It is designed to serve as an access log writer for gorouter and is therefore not
+// general purpose.
+package syslog
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ByteOrderMark as required by RFC5424
+const ByteOrderMark = "\ufeff"
+
+// The Priority is a combination of the syslog facility and
+// severity. For example, [SeverityAlert] | [FacilityFtp] sends an alert severity
+// message from the FTP facility. The default severity is [SeverityEmerg];
+// the default facility is [FacilityKern].
+type Priority int
+
+const severityMask = 0x07
+const facilityMask = 0xf8
+
+const (
+	// Severity.
+
+	// From /usr/include/sys/syslog.h.
+	// These are the same on Linux, BSD, and OS X.
+	SeverityEmerg Priority = iota
+	SeverityAlert
+	SeverityCrit
+	SeverityErr
+	SeverityWarning
+	SeverityNotice
+	SeverityInfo
+	SeverityDebug
+)
+
+const (
+	// Facility.
+
+	// From /usr/include/sys/syslog.h.
+	// These are the same up to LOG_FTP on Linux, BSD, and OS X.
+	FacilityKern Priority = iota << 3
+	FacilityUser
+	FacilityMail
+	FacilityDaemon
+	FacilityAuth
+	FacilitySyslog
+	FacilityLpr
+	FacilityNews
+	FacilityUucp
+	FacilityCron
+	FacilityAuthPriv
+	FacilityFtp
+	_ // unused
+	_ // unused
+	_ // unused
+	_ // unused
+	FacilityLocal0
+	FacilityLocal1
+	FacilityLocal2
+	FacilityLocal3
+	FacilityLocal4
+	FacilityLocal5
+	FacilityLocal6
+	FacilityLocal7
+)
+
+var (
+	ErrInvalidNetwork  = fmt.Errorf("syslog: invalid network")
+	ErrInvalidPriority = fmt.Errorf("syslog: invalid priority")
+)
+
+// A Writer is a connection to a syslog server.
+type Writer struct {
+	priority string
+	hostname string
+	procid   string
+	appName  string
+
+	network string
+	address string
+	needsLF bool
+
+	mu   sync.Mutex // guards buf and conn
+	buf  *bytes.Buffer
+	conn net.Conn
+}
+
+// Dial establishes a connection to a log daemon by connecting to
+// address addr on the specified network.
+func Dial(network, address string, severity, facility Priority, appName string) (*Writer, error) {
+	if !isValidNetwork(network) {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidNetwork, network)
+	}
+
+	priority := (facility & facilityMask) | (severity & severityMask)
+	if priority < 0 || priority > FacilityLocal7|SeverityDebug {
+		return nil, fmt.Errorf("%w: %d", ErrInvalidPriority, priority)
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil && hostname == "" {
+		hostname = "-"
+	}
+
+	w := &Writer{
+		priority: strconv.FormatUint(uint64(priority), 10),
+		hostname: hostname,
+		procid:   strconv.FormatInt(int64(os.Getpid()), 10),
+		appName:  appName,
+		network:  network,
+		address:  address,
+		needsLF:  strings.HasPrefix(network, "tcp"),
+		mu:       sync.Mutex{},
+		buf:      &bytes.Buffer{},
+		conn:     nil,
+	}
+
+	// No need for locking here, we are the only ones with access.
+	err = w.connect()
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
+// connect makes a connection to the syslog server.
+// It must be called with w.mu held.
+func (w *Writer) connect() (err error) {
+	if w.conn != nil {
+		// ignore err from close, it makes sense to continue anyway
+		_ = w.conn.Close()
+		w.conn = nil
+	}
+
+	w.conn, err = net.Dial(w.network, w.address)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Close closes a connection to the syslog daemon.
+func (w *Writer) Close() (err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.conn == nil {
+		return nil
+	}
+
+	err = w.conn.Close()
+	w.conn = nil
+	return err
+}
+
+func (w *Writer) Log(msg string) error {
+	return w.write(msg)
+}
+
+// Write satisfies [io.Writer], however, it is not an [io.Writer] and lies about the number of
+// bytes written to the syslog server.
+func (w *Writer) Write(b []byte) (int, error) {
+	return len(b), w.write(string(b))
+}
+
+// write generates and writes a syslog formatted string. The
+// format is as follows: <PRI>1 TIMESTAMP HOSTNAME gorouter[-]: MSG
+func (w *Writer) write(msg string) error {
+	if w.conn == nil {
+		err := w.connect()
+		if err != nil {
+			return err
+		}
+	}
+
+	w.buf.Reset()
+
+	w.buf.WriteRune('<')
+	w.buf.WriteString(w.priority)
+	w.buf.WriteString(">1 ")
+	w.buf.WriteString(time.Now().Format(time.RFC3339))
+	w.buf.WriteRune(' ')
+	w.buf.WriteString(w.hostname)
+	w.buf.WriteRune(' ')
+	w.buf.WriteString(w.appName)
+	w.buf.WriteRune(' ')
+	w.buf.WriteString(w.procid)
+	w.buf.WriteString(" - ")
+	w.buf.WriteString(ByteOrderMark) // Unicode byte order mark, see RFC5424 section 6.4
+	w.buf.WriteString(msg)
+
+	// For TCP we use non-transparent framing as described in RFC6587 section 3.4.2.
+	if w.needsLF {
+		if !strings.HasSuffix(msg, "\n") {
+			w.buf.WriteRune('\n')
+		}
+	}
+
+	_, err := w.buf.WriteTo(w.conn)
+	return err
+}
+
+var validNetworkPrefixes = []string{"tcp", "udp"}
+
+func isValidNetwork(network string) bool {
+	for _, p := range validNetworkPrefixes {
+		if strings.HasPrefix(network, p) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/accesslog/syslog/syslog_test.go
+++ b/accesslog/syslog/syslog_test.go
@@ -1,0 +1,169 @@
+package syslog_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"testing"
+
+	"code.cloudfoundry.org/gorouter/accesslog/syslog"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+)
+
+func init() {
+	format.TruncatedDiff = false
+}
+
+func TestLogger(t *testing.T) {
+	tests := []struct {
+		name     string
+		network  string
+		severity syslog.Priority
+		facility syslog.Priority
+		appName  string
+		message  string
+		// Since the syslog message contains dynamic parts there is a bit of magic around this
+		// variable. It has two formatting directives: the first is the hostname as a string, the
+		// second the pid as an int. The timestamp will be cut from both the returned and the
+		// provided output to not make this test depend on time.
+		want string
+	}{{
+		"ensure UDP syslog works and the BOM is properly set",
+		"udp",
+		syslog.SeverityCrit,
+		syslog.FacilityDaemon,
+		"vcap.gorouter",
+		"foobar",
+		"<26>1 1970-01-01T00:00:00Z %s vcap.gorouter %d - \ufefffoobar",
+	}, {
+		"ensure UDP syslog does not mangle trailing newlines",
+		"udp",
+		syslog.SeverityCrit,
+		syslog.FacilityFtp,
+		"gorouter",
+		"foobar\n",
+		"<90>1 1970-01-01T00:00:00Z %s gorouter %d - \ufefffoobar\n",
+	}, {
+		"ensure TCP syslog appends a line feed at the end",
+		"tcp",
+		syslog.SeverityCrit,
+		syslog.FacilityFtp,
+		"gorouter",
+		"foobar",
+		"<90>1 1970-01-01T00:00:00Z %s gorouter %d - \ufefffoobar\n",
+	}, {
+		"ensure TCP syslog does not append additional line feeds at the end",
+		"tcp",
+		syslog.SeverityCrit,
+		syslog.FacilityFtp,
+		"gorouter",
+		"foobar\n",
+		"<90>1 1970-01-01T00:00:00Z %s gorouter %d - \ufefffoobar\n",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			var (
+				addr   string
+				result func() string
+			)
+			// we only support tcp and udp
+			switch tt.network {
+			case "tcp":
+				addr, result = testTcp(t)
+			case "udp":
+				addr, result = testUdp(t)
+			default:
+				t.Fatalf("invalid network: %s", tt.network)
+			}
+
+			w, err := syslog.Dial(tt.network, addr, tt.severity, tt.facility, tt.appName)
+			g.Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = w.Close() }()
+
+			err = w.Log(tt.message)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			want := fmt.Sprintf(tt.want, must(os.Hostname), os.Getpid())
+			g.Eventually(func() string {
+				return cutTimestamp(result())
+			}).Should(Equal(cutTimestamp(want)))
+		})
+	}
+}
+
+// testUdp sets up a UDP listener which makes the payload of the first received datagram available
+// via the returned function.
+func testUdp(t *testing.T) (addr string, result func() string) {
+	t.Helper()
+	g := NewWithT(t)
+
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{
+		IP:   net.IP{127, 0, 0, 1},
+		Port: 0,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	out := make([]byte, 65507)
+	read := 0
+	go func() {
+		defer conn.Close()
+		read, _, _ = conn.ReadFrom(out)
+	}()
+
+	return conn.LocalAddr().String(), func() string {
+		return string(out[:read])
+	}
+}
+
+// testTcp sets up a TCP listener which accepts the first connection and makes data sent via that
+// connection available via the returned function.
+func testTcp(t *testing.T) (addr string, result func() string) {
+	t.Helper()
+	g := NewWithT(t)
+
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{
+		IP:   net.IP{127, 0, 0, 1},
+		Port: 0,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	out := &bytes.Buffer{}
+	go func() {
+		defer l.Close()
+
+		conn, err := l.Accept()
+		g.Expect(err).NotTo(HaveOccurred())
+		defer conn.Close()
+
+		_, _ = io.Copy(out, conn)
+	}()
+
+	return l.Addr().String(), func() string {
+		return out.String()
+	}
+}
+
+func cutTimestamp(in string) string {
+	parts := strings.SplitN(in, " ", 3)
+	if len(parts) < 3 {
+		return ""
+	}
+	return parts[0] + " 1970-01-01T00:00:00Z " + parts[2]
+}
+
+func must[T any, F func() (T, error)](f F) T {
+	t, err := f()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return t
+}

--- a/config/config.go
+++ b/config/config.go
@@ -177,6 +177,7 @@ type LoggingConfig struct {
 	Syslog                 string       `yaml:"syslog"`
 	SyslogAddr             string       `yaml:"syslog_addr"`
 	SyslogNetwork          string       `yaml:"syslog_network"`
+	SyslogTruncate         int          `yaml:"syslog_truncate"`
 	Level                  string       `yaml:"level"`
 	LoggregatorEnabled     bool         `yaml:"loggregator_enabled"`
 	MetronAddress          string       `yaml:"metron_address"`

--- a/config/config.go
+++ b/config/config.go
@@ -218,6 +218,8 @@ var defaultLoggingConfig = LoggingConfig{
 	JobName:               "gorouter",
 	RedactQueryParams:     REDACT_QUERY_PARMS_NONE,
 	EnableAttemptsDetails: false,
+	SyslogNetwork:         "udp",
+	SyslogAddr:            "127.0.0.1:514",
 }
 
 type HeaderNameValue struct {

--- a/integration/access_log_test.go
+++ b/integration/access_log_test.go
@@ -1,0 +1,96 @@
+package integration
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/gorouter/test/common"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Access Log", func() {
+	var (
+		testState *testState
+		done      chan bool
+		logs      <-chan string
+	)
+
+	BeforeEach(func() {
+		testState = NewTestState()
+	})
+
+	JustBeforeEach(func() {
+		testState.StartGorouterOrFail()
+	})
+
+	AfterEach(func() {
+		testState.StopAndCleanup()
+	})
+
+	Context("when using syslog", func() {
+		BeforeEach(func() {
+			// disable file logging
+			testState.cfg.AccessLog.EnableStreaming = true
+			testState.cfg.AccessLog.File = ""
+			// generic tag
+			testState.cfg.Logging.Syslog = "gorouter"
+		})
+
+		Context("via UDP", func() {
+			BeforeEach(func() {
+				testState.cfg.Logging.SyslogNetwork = "udp"
+				done = make(chan bool)
+				testState.cfg.Logging.SyslogAddr, logs = common.TestUdp(done)
+			})
+
+			AfterEach(func() {
+				close(done)
+			})
+
+			It("properly emits access logs", func() {
+				req := testState.newGetRequest("https://foobar.cloudfoundry.org")
+				res, err := testState.client.Do(req)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(http.StatusNotFound))
+
+				log := <-logs
+
+				Expect(log).To(ContainSubstring(`x_cf_routererror:"unknown_route"`))
+				Expect(log).To(ContainSubstring(`"GET / HTTP/1.1" 404`))
+				Expect(log).To(ContainSubstring("foobar.cloudfoundry.org"))
+
+				// ensure we don't see any excess access logs
+				Consistently(func() int { return len(logs) }).Should(Equal(0))
+			})
+		})
+
+		Context("via TCP", func() {
+			BeforeEach(func() {
+				testState.cfg.Logging.SyslogNetwork = "tcp"
+				done = make(chan bool)
+				testState.cfg.Logging.SyslogAddr, logs = common.TestTcp(done)
+			})
+
+			AfterEach(func() {
+				close(done)
+			})
+
+			It("properly emits successful requests", func() {
+				req := testState.newGetRequest("https://foobar.cloudfoundry.org")
+				res, err := testState.client.Do(req)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(http.StatusNotFound))
+
+				log := <-logs
+
+				Expect(log).To(ContainSubstring(`x_cf_routererror:"unknown_route"`))
+				Expect(log).To(ContainSubstring(`"GET / HTTP/1.1" 404`))
+				Expect(log).To(ContainSubstring("foobar.cloudfoundry.org"))
+
+				// ensure we don't see any excess access logs
+				Consistently(func() int { return len(logs) }).Should(Equal(0))
+			})
+		})
+	})
+})

--- a/integration/backend_keepalive_test.go
+++ b/integration/backend_keepalive_test.go
@@ -42,7 +42,7 @@ var _ = Describe("KeepAlive (HTTP Persistent Connections) to backends", func() {
 
 	doRequest := func() {
 		assertRequestSucceeds(testState.client,
-			testState.newRequest(fmt.Sprintf("http://%s", testAppRoute)))
+			testState.newGetRequest(fmt.Sprintf("http://%s", testAppRoute)))
 	}
 
 	Context("when KeepAlives are disabled", func() {

--- a/integration/common_integration_test.go
+++ b/integration/common_integration_test.go
@@ -176,7 +176,7 @@ func (s *testState) newPostRequest(url string, body io.Reader) *http.Request {
 	return req
 }
 
-func (s *testState) newRequest(url string) *http.Request {
+func (s *testState) newGetRequest(url string) *http.Request {
 	req, err := http.NewRequest("GET", url, nil)
 	Expect(err).NotTo(HaveOccurred())
 	port := s.cfg.Port

--- a/integration/error_writer_test.go
+++ b/integration/error_writer_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Error Writers", func() {
 		body       []byte
 
 		doRequest = func() {
-			req := testState.newRequest(fmt.Sprintf("http://not-%s", hostname))
+			req := testState.newGetRequest(fmt.Sprintf("http://not-%s", hostname))
 
 			resp, err := testState.client.Do(req)
 			Expect(err).NotTo(HaveOccurred())

--- a/integration/gdpr_test.go
+++ b/integration/gdpr_test.go
@@ -45,7 +45,7 @@ var _ = Describe("GDPR", func() {
 			hostname := "basic-app.some.domain"
 			testState.register(testApp, hostname)
 
-			req := testState.newRequest(fmt.Sprintf("http://%s", hostname))
+			req := testState.newGetRequest(fmt.Sprintf("http://%s", hostname))
 			req.Header.Add("X-FORWARDED-FOR", "192.168.0.1")
 
 			resp, err := testState.client.Do(req)
@@ -120,7 +120,7 @@ var _ = Describe("GDPR", func() {
 			hostname := "basic-app.some.domain"
 			testState.register(testApp, hostname)
 
-			req := testState.newRequest(fmt.Sprintf("http://%s", hostname))
+			req := testState.newGetRequest(fmt.Sprintf("http://%s", hostname))
 			req.Header.Set("User-Agent", "foo-agent")
 
 			resp, err := testState.client.Do(req)

--- a/integration/header_test.go
+++ b/integration/header_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Headers", func() {
 		})
 
 		It("returns a header that was set by the app", func() {
-			req := testState.newRequest(fmt.Sprintf("http://%s", testAppRoute))
+			req := testState.newGetRequest(fmt.Sprintf("http://%s", testAppRoute))
 			resp, err := testState.client.Do(req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(200))
@@ -82,7 +82,7 @@ var _ = Describe("Headers", func() {
 		})
 
 		It("returns a header that was set by the gorouter", func() {
-			req := testState.newRequest(fmt.Sprintf("http://%s", testAppRoute))
+			req := testState.newGetRequest(fmt.Sprintf("http://%s", testAppRoute))
 			req.Header.Set("Connection", "X-Forwarded-Proto")
 			resp, err := testState.client.Do(req)
 			Expect(err).NotTo(HaveOccurred())
@@ -110,7 +110,7 @@ var _ = Describe("Headers", func() {
 		})
 
 		It("removes the header specified in the config", func() {
-			req := testState.newRequest(fmt.Sprintf("http://%s", testAppRoute))
+			req := testState.newGetRequest(fmt.Sprintf("http://%s", testAppRoute))
 			resp, err := testState.client.Do(req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(200))
@@ -142,7 +142,7 @@ var _ = Describe("Headers", func() {
 		})
 
 		It("adds the header specified in the config", func() {
-			req := testState.newRequest(fmt.Sprintf("http://%s", testAppRoute))
+			req := testState.newGetRequest(fmt.Sprintf("http://%s", testAppRoute))
 			resp, err := testState.client.Do(req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(200))
@@ -191,7 +191,7 @@ var _ = Describe("Headers", func() {
 			)
 
 			testState.client.Transport.(*http.Transport).TLSClientConfig.Certificates = testState.trustedClientTLSConfig.Certificates
-			req := testState.newRequest(fmt.Sprintf("https://%s", appHostname))
+			req := testState.newGetRequest(fmt.Sprintf("https://%s", appHostname))
 			resp, err := testState.client.Do(req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(400))
@@ -213,7 +213,7 @@ var _ = Describe("Headers", func() {
 			})
 
 			It("fails with 502 when the app exceeds the limit", func() {
-				req := testState.newRequest(fmt.Sprintf("http://%s", testAppRoute))
+				req := testState.newGetRequest(fmt.Sprintf("http://%s", testAppRoute))
 				resp, err := testState.client.Do(req)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))

--- a/integration/large_request_test.go
+++ b/integration/large_request_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Large requests", func() {
 		pathSize := 2 * 1024 // 2kb
 		path := strings.Repeat("a", pathSize)
 
-		req := testState.newRequest(fmt.Sprintf("http://%s/%s", appURL, path))
+		req := testState.newGetRequest(fmt.Sprintf("http://%s/%s", appURL, path))
 
 		resp, err := testState.client.Do(req)
 		Expect(err).NotTo(HaveOccurred())

--- a/integration/redirect_test.go
+++ b/integration/redirect_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Headers", func() {
 		})
 
 		It("does not follow the redirect and instead forwards it to the client", func() {
-			req := testState.newRequest(fmt.Sprintf("http://%s", testAppRoute))
+			req := testState.newGetRequest(fmt.Sprintf("http://%s", testAppRoute))
 
 			// this makes the test client NOT follow redirects, so that we can
 			// test that the return code is indeed 3xx

--- a/integration/retry_test.go
+++ b/integration/retry_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Retries", func() {
 			_ = conn.Close()
 
 			Consistently(func() bool {
-				res, err := testState.client.Do(testState.newRequest("http://" + appURL))
+				res, err := testState.client.Do(testState.newGetRequest("http://" + appURL))
 				return err == nil && res.StatusCode == http.StatusTeapot
 			}).Should(Equal(true))
 		})

--- a/integration/route_services_test.go
+++ b/integration/route_services_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Route services", func() {
 					sigHeader := r.Header.Get("X-Cf-Proxy-Signature")
 					metadata := r.Header.Get("X-Cf-Proxy-Metadata")
 
-					req := testState.newRequest(forwardedURL)
+					req := testState.newGetRequest(forwardedURL)
 
 					req.Header.Add("X-CF-Forwarded-Url", forwardedURL)
 					req.Header.Add("X-Cf-Proxy-Metadata", metadata)
@@ -99,7 +99,7 @@ var _ = Describe("Route services", func() {
 			})
 
 			It("succeeds", func() {
-				req := testState.newRequest(
+				req := testState.newGetRequest(
 					fmt.Sprintf("https://%s", appHostname),
 				)
 
@@ -112,7 +112,7 @@ var _ = Describe("Route services", func() {
 			})
 
 			It("properly URL-encodes and decodes", func() {
-				req := testState.newRequest(
+				req := testState.newGetRequest(
 					fmt.Sprintf("https://%s?%s", appHostname, "param=a%0Ab"),
 				)
 
@@ -166,7 +166,7 @@ var _ = Describe("Route services", func() {
 			tlsTestApp2 = setupAppInstance(1)
 
 			// Verify we get app1 if we request it while it's running
-			req := testState.newRequest(
+			req := testState.newGetRequest(
 				fmt.Sprintf("https://%s", appHostname),
 			)
 			Eventually(func(g Gomega) {
@@ -184,7 +184,7 @@ var _ = Describe("Route services", func() {
 		})
 
 		It("prunes the stale endpoint", func() {
-			req := testState.newRequest(
+			req := testState.newGetRequest(
 				fmt.Sprintf("https://%s", appHostname),
 			)
 			time.Sleep(100 * time.Millisecond)
@@ -207,7 +207,7 @@ var _ = Describe("Route services", func() {
 							sigHeader := r.Header.Get("X-Cf-Proxy-Signature")
 							metadata := r.Header.Get("X-Cf-Proxy-Metadata")
 
-							req := testState.newRequest(forwardedURL)
+							req := testState.newGetRequest(forwardedURL)
 
 							req.Header.Add("X-CF-Forwarded-Url", forwardedURL)
 							req.Header.Add("X-Cf-Proxy-Metadata", metadata)
@@ -238,7 +238,7 @@ var _ = Describe("Route services", func() {
 			})
 
 			It("still prunes the stale endpoint", func() {
-				req := testState.newRequest(
+				req := testState.newGetRequest(
 					fmt.Sprintf("https://%s", appHostname),
 				)
 				time.Sleep(100 * time.Millisecond)
@@ -278,7 +278,7 @@ var _ = Describe("Route services", func() {
 			})
 
 			It("fails with a 502", func() {
-				req := testState.newRequest(
+				req := testState.newGetRequest(
 					fmt.Sprintf("https://%s", appHostname),
 				)
 
@@ -296,7 +296,7 @@ var _ = Describe("Route services", func() {
 			})
 
 			It("succeeds", func() {
-				req := testState.newRequest(
+				req := testState.newGetRequest(
 					fmt.Sprintf("https://%s", appHostname),
 				)
 
@@ -336,7 +336,7 @@ var _ = Describe("Route services", func() {
 			})
 
 			It("fails with a 502", func() {
-				req := testState.newRequest(
+				req := testState.newGetRequest(
 					fmt.Sprintf("https://%s", appHostname),
 				)
 
@@ -355,7 +355,7 @@ var _ = Describe("Route services", func() {
 			})
 
 			It("succeeds", func() {
-				req := testState.newRequest(
+				req := testState.newGetRequest(
 					fmt.Sprintf("https://%s", appHostname),
 				)
 

--- a/integration/w3c_tracing_test.go
+++ b/integration/w3c_tracing_test.go
@@ -30,7 +30,7 @@ var _ = Describe("W3C tracing headers", func() {
 		appReceivedHeaders = make(chan http.Header, 1)
 
 		doRequest = func(headers http.Header) {
-			req := testState.newRequest(fmt.Sprintf("http://%s", hostname))
+			req := testState.newGetRequest(fmt.Sprintf("http://%s", hostname))
 
 			for headerName, headerVals := range headers {
 				for _, headerVal := range headerVals {

--- a/integration/x_forwarded_proto_integration_test.go
+++ b/integration/x_forwarded_proto_integration_test.go
@@ -98,7 +98,7 @@ var _ = Describe("modifications of X-Forwarded-Proto header", func() {
 			testState.StartGorouterOrFail()
 
 			doRequest := func(testCase testCase, hostname string) {
-				req := testState.newRequest(fmt.Sprintf("%s://%s", testCase.clientRequestScheme, hostname))
+				req := testState.newGetRequest(fmt.Sprintf("%s://%s", testCase.clientRequestScheme, hostname))
 				req.Header.Set("X-Forwarded-Proto", testCase.clientRequestHeader)
 
 				resp, err := testState.client.Do(req)
@@ -210,7 +210,7 @@ var _ = Describe("modifications of X-Forwarded-Proto header", func() {
 				testState.StartGorouterOrFail()
 
 				doRequest := func(testCase rsTestCase, hostname string) {
-					req := testState.newRequest(fmt.Sprintf("%s://%s", testCase.clientRequestScheme, hostname))
+					req := testState.newGetRequest(fmt.Sprintf("%s://%s", testCase.clientRequestScheme, hostname))
 					req.Header.Set("X-Forwarded-Proto", testCase.clientRequestHeader)
 					resp, err := testState.client.Do(req)
 					Expect(err).NotTo(HaveOccurred())
@@ -234,7 +234,7 @@ var _ = Describe("modifications of X-Forwarded-Proto header", func() {
 					w.WriteHeader(200)
 					url, err := url.Parse(r.Header.Get(routeservice.HeaderKeyForwardedURL))
 					Expect(err).ToNot(HaveOccurred())
-					newRequest := testState.newRequest(fmt.Sprintf("%s://%s", testCase.rsRequestScheme, url.Host))
+					newRequest := testState.newGetRequest(fmt.Sprintf("%s://%s", testCase.rsRequestScheme, url.Host))
 
 					// routes service does not change headers
 					for k, v := range r.Header {
@@ -269,7 +269,7 @@ var _ = Describe("modifications of X-Forwarded-Proto header", func() {
 					w.WriteHeader(200)
 					url, err := url.Parse(r.Header.Get(routeservice.HeaderKeyForwardedURL))
 					Expect(err).ToNot(HaveOccurred())
-					newRequest := testState.newRequest(fmt.Sprintf("%s://%s", testCase.rsRequestScheme, url.Host))
+					newRequest := testState.newGetRequest(fmt.Sprintf("%s://%s", testCase.rsRequestScheme, url.Host))
 
 					// route service does not change headers
 					for k, v := range r.Header {

--- a/integration/xfcc_integration_test.go
+++ b/integration/xfcc_integration_test.go
@@ -117,7 +117,7 @@ var _ = Describe("modifications of X-Forwarded-Client-Cert", func() {
 				testState.StartGorouterOrFail()
 
 				doRequest := func(scheme, hostname string, addXFCCHeader bool) {
-					req := testState.newRequest(fmt.Sprintf("%s://%s", scheme, hostname))
+					req := testState.newGetRequest(fmt.Sprintf("%s://%s", scheme, hostname))
 					if addXFCCHeader {
 						req.Header.Add("X-Forwarded-Client-Cert", "some-client-xfcc")
 					}
@@ -141,7 +141,7 @@ var _ = Describe("modifications of X-Forwarded-Client-Cert", func() {
 					w.WriteHeader(200)
 
 					url := r.Header.Get(routeservice.HeaderKeyForwardedURL)
-					newRequest := testState.newRequest(url)
+					newRequest := testState.newGetRequest(url)
 					for k, v := range r.Header {
 						newRequest.Header[k] = v
 					}

--- a/test/common/network.go
+++ b/test/common/network.go
@@ -1,0 +1,67 @@
+package common
+
+import (
+	"bufio"
+	"io"
+	"net"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestUdp sets up a UDP listener which accepts the first connection and reads individual datagrams
+// sent over it into the returned channel. The channel is buffered. The listen address is returned
+// as well.
+func TestUdp(done <-chan bool) (string, <-chan string) {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{
+		IP:   net.IP{127, 0, 0, 1},
+		Port: 0,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	go closeDone(done, conn)
+
+	out := make(chan string, 10)
+	go func() {
+		var (
+			n   int
+			err error
+			buf = make([]byte, 65_535)
+		)
+		for err == nil {
+			n, _, err = conn.ReadFrom(buf)
+			out <- string(buf[:n])
+		}
+	}()
+
+	return conn.LocalAddr().String(), out
+}
+
+// TestTcp sets up a TCP listener which accepts the first connection and reads individual lines
+// sent over it into the returned channel. The channel is buffered. The listen address is returned
+// as well.
+func TestTcp(done <-chan bool) (string, <-chan string) {
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{
+		IP:   net.IP{127, 0, 0, 1},
+		Port: 0,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	go closeDone(done, l)
+
+	out := make(chan string, 10)
+	go func() {
+		conn, err := l.Accept()
+		Expect(err).NotTo(HaveOccurred())
+		go closeDone(done, conn)
+
+		scanner := bufio.NewScanner(conn)
+		for scanner.Scan() {
+			out <- scanner.Text()
+		}
+	}()
+
+	return l.Addr().String(), out
+}
+
+func closeDone(done <-chan bool, closer io.Closer) {
+	<-done
+	_ = closer.Close()
+}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

This PR corrects and improves the direct-to-syslog logging of access logs for Gorouter.

* does not log an empty new line when writing to syslog
* allows the operator to configure truncation on syslog, as syslog servers usually have a message limit
* significant performance improvement to the syslog implementation

The syslog implementation in Go has not been maintained by the Go authors since around 2015. While there are forks of the syslog code, all of them are also dormant. This PR inlines and significantly rewrites the syslog implementation, focusing on the following performance improvements:

* No use of the expensive fmt.Sprintf
* Determine all "static" fields (e.g. the PID) on initialization, not per message
* Correct handling of UTF-8 BOM according to [RFC5424](https://datatracker.ietf.org/doc/html/rfc5424)

Limitations:
* Only TCP and UDP are supported, as described in the routing-release property for the syslog network. All other means (unix sockets, etc.) are not supported.

Backward Compatibility
---------------
Breaking Change? **Yes**
 * This PR moves the syslog implementation from the BSD-style syslog format, which is not standardised, to the [RFC5424](https://datatracker.ietf.org/doc/html/rfc5424) format.
