### PR TITLE
refactor: rename lb_algo to loadbalancing

### DIFF
--- a/mbus/subscriber.go
+++ b/mbus/subscriber.go
@@ -41,7 +41,7 @@ type RegistryMessage struct {
 }
 
 type RegistryMessageOpts struct {
-	LoadBalancingAlgorithm string `json:"lb_algo"`
+	LoadBalancingAlgorithm string `json:"loadbalancing"`
 }
 
 func (rm *RegistryMessage) makeEndpoint(http2Enabled bool) (*route.Endpoint, error) {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Renaming the `lb_algo` property to `loadbalancing` to align with cloud controller.
The per-route options feature ([RFC 0027](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0027-generic-per-route-features.md)) is not live yet, so this is not a breaking change.
See https://github.com/cloudfoundry/community/pull/1039 for an overview of all related PRs



Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
