### PR TITLE
Add routing via X-CF-PROCESS-INSTANCE

### DIFF
--- a/common/http/headers.go
+++ b/common/http/headers.go
@@ -9,6 +9,7 @@ const (
 	VcapTraceHeader       = "X-Vcap-Trace"
 	CfInstanceIdHeader    = "X-CF-InstanceID"
 	CfAppInstance         = "X-CF-APP-INSTANCE"
+	CfProcessInstance     = "X-CF-PROCESS-INSTANCE"
 	CfRouterError         = "X-Cf-RouterError"
 )
 

--- a/handlers/lookup.go
+++ b/handlers/lookup.go
@@ -251,20 +251,21 @@ func (l *lookupHandler) lookup(r *http.Request, logger *slog.Logger) (*route.End
 	return l.registry.Lookup(uri), nil
 }
 
+// Regex to match format of `APP_GUID:INSTANCE_ID`
+var appInstanceHeaderRegex = regexp.MustCompile(`^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}:\d+$`)
+
 func validateAppInstanceHeader(appInstanceHeader string) error {
-	// Regex to match format of `APP_GUID:INSTANCE_ID`
-	r := regexp.MustCompile(`^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}:\d+$`)
-	if !r.MatchString(appInstanceHeader) {
+	if !appInstanceHeaderRegex.MatchString(appInstanceHeader) {
 		return fmt.Errorf("Incorrect %s header : %s", CfAppInstance, appInstanceHeader)
 	}
 	return nil
 }
 
+// Regex to match format of `PROCESS_GUID:INSTANCE_ID` and `PROCESS_GUID`
+var processInstanceHeaderRegex = regexp.MustCompile(`^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}(:\d+)?$`)
+
 func validateProcessInstanceHeader(processInstanceHeader string) error {
-	// Regex to match format of `PROCESS_GUID:INSTANCE_ID`
-	//   and to match format of `PROCESS_GUID`
-	r := regexp.MustCompile(`^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}(:\d+)?$`)
-	if !r.MatchString(processInstanceHeader) {
+	if !processInstanceHeaderRegex.MatchString(processInstanceHeader) {
 		return fmt.Errorf("Incorrect %s header : %s", router_http.CfProcessInstance, processInstanceHeader)
 	}
 	return nil

--- a/handlers/lookup.go
+++ b/handlers/lookup.go
@@ -262,7 +262,8 @@ func validateAppInstanceHeader(appInstanceHeader string) error {
 
 func validateProcessInstanceHeader(processInstanceHeader string) error {
 	// Regex to match format of `PROCESS_GUID:INSTANCE_ID`
-	r := regexp.MustCompile(`^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}:\d+$`)
+	//   and to match format of `PROCESS_GUID`
+	r := regexp.MustCompile(`^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}(:\d+)?$`)
 	if !r.MatchString(processInstanceHeader) {
 		return fmt.Errorf("Incorrect %s header : %s", router_http.CfProcessInstance, processInstanceHeader)
 	}
@@ -271,5 +272,8 @@ func validateProcessInstanceHeader(processInstanceHeader string) error {
 
 func splitInstanceHeader(instanceHeader string) (string, string) {
 	details := strings.Split(instanceHeader, ":")
+	if len(details) == 1 {
+		return details[0], ""
+	}
 	return details[0], details[1]
 }

--- a/handlers/lookup.go
+++ b/handlers/lookup.go
@@ -181,7 +181,11 @@ func (l *lookupHandler) handleMissingRoute(rw http.ResponseWriter, r *http.Reque
 
 	if processInstanceHeader := r.Header.Get(router_http.CfProcessInstance); processInstanceHeader != "" {
 		guid, idx := splitInstanceHeader(processInstanceHeader)
-		errorMsg = fmt.Sprintf("Requested instance ('%s') with process guid ('%s') does not exist for route ('%s')", idx, guid, r.Host)
+		if idx == "" {
+			errorMsg = fmt.Sprintf("Requested instance with process guid ('%s') does not exist for route ('%s')", guid, r.Host)
+		} else {
+			errorMsg = fmt.Sprintf("Requested instance ('%s') with process guid ('%s') does not exist for route ('%s')", idx, guid, r.Host)
+		}
 		returnStatus = http.StatusBadRequest
 	}
 

--- a/handlers/lookup_test.go
+++ b/handlers/lookup_test.go
@@ -446,20 +446,38 @@ var _ = Describe("Lookup", func() {
 				pool.Put(exampleEndpoint)
 				reg.LookupWithAppInstanceReturns(pool)
 
-				req.Header.Add("X-CF-Process-Instance", fakeProcessGUID+":1")
 			})
 
 			JustBeforeEach(func() {
 				handler.ServeHTTP(resp, req)
 			})
 
-			It("lookups with instance", func() {
-				Expect(reg.LookupWithProcessInstanceCallCount()).To(Equal(1))
-				uri, processGuid, processIndex := reg.LookupWithProcessInstanceArgsForCall(0)
+			Context("when an index is provided", func() {
+				BeforeEach(func() {
+					req.Header.Add("X-CF-Process-Instance", fakeProcessGUID+":1")
+				})
+				It("lookups with process instance", func() {
+					Expect(reg.LookupWithProcessInstanceCallCount()).To(Equal(1))
+					uri, processGuid, processIndex := reg.LookupWithProcessInstanceArgsForCall(0)
 
-				Expect(uri.String()).To(Equal("example.com"))
-				Expect(processGuid).To(Equal(fakeProcessGUID))
-				Expect(processIndex).To(Equal("1"))
+					Expect(uri.String()).To(Equal("example.com"))
+					Expect(processGuid).To(Equal(fakeProcessGUID))
+					Expect(processIndex).To(Equal("1"))
+				})
+			})
+
+			Context("when an index is not provided", func() {
+				BeforeEach(func() {
+					req.Header.Add("X-CF-Process-Instance", fakeProcessGUID)
+				})
+				It("lookups with process instance", func() {
+					Expect(reg.LookupWithProcessInstanceCallCount()).To(Equal(1))
+					uri, processGuid, processIndex := reg.LookupWithProcessInstanceArgsForCall(0)
+
+					Expect(uri.String()).To(Equal("example.com"))
+					Expect(processGuid).To(Equal(fakeProcessGUID))
+					Expect(processIndex).To(Equal(""))
+				})
 			})
 		})
 

--- a/registry/fakes/fake_registry.go
+++ b/registry/fakes/fake_registry.go
@@ -20,17 +20,30 @@ type FakeRegistry struct {
 	lookupReturnsOnCall map[int]struct {
 		result1 *route.EndpointPool
 	}
-	LookupWithInstanceStub        func(route.Uri, string, string) *route.EndpointPool
-	lookupWithInstanceMutex       sync.RWMutex
-	lookupWithInstanceArgsForCall []struct {
+	LookupWithAppInstanceStub        func(route.Uri, string, string) *route.EndpointPool
+	lookupWithAppInstanceMutex       sync.RWMutex
+	lookupWithAppInstanceArgsForCall []struct {
 		arg1 route.Uri
 		arg2 string
 		arg3 string
 	}
-	lookupWithInstanceReturns struct {
+	lookupWithAppInstanceReturns struct {
 		result1 *route.EndpointPool
 	}
-	lookupWithInstanceReturnsOnCall map[int]struct {
+	lookupWithAppInstanceReturnsOnCall map[int]struct {
+		result1 *route.EndpointPool
+	}
+	LookupWithProcessInstanceStub        func(route.Uri, string, string) *route.EndpointPool
+	lookupWithProcessInstanceMutex       sync.RWMutex
+	lookupWithProcessInstanceArgsForCall []struct {
+		arg1 route.Uri
+		arg2 string
+		arg3 string
+	}
+	lookupWithProcessInstanceReturns struct {
+		result1 *route.EndpointPool
+	}
+	lookupWithProcessInstanceReturnsOnCall map[int]struct {
 		result1 *route.EndpointPool
 	}
 	RegisterStub        func(route.Uri, *route.Endpoint)
@@ -110,18 +123,18 @@ func (fake *FakeRegistry) LookupReturnsOnCall(i int, result1 *route.EndpointPool
 	}{result1}
 }
 
-func (fake *FakeRegistry) LookupWithInstance(arg1 route.Uri, arg2 string, arg3 string) *route.EndpointPool {
-	fake.lookupWithInstanceMutex.Lock()
-	ret, specificReturn := fake.lookupWithInstanceReturnsOnCall[len(fake.lookupWithInstanceArgsForCall)]
-	fake.lookupWithInstanceArgsForCall = append(fake.lookupWithInstanceArgsForCall, struct {
+func (fake *FakeRegistry) LookupWithAppInstance(arg1 route.Uri, arg2 string, arg3 string) *route.EndpointPool {
+	fake.lookupWithAppInstanceMutex.Lock()
+	ret, specificReturn := fake.lookupWithAppInstanceReturnsOnCall[len(fake.lookupWithAppInstanceArgsForCall)]
+	fake.lookupWithAppInstanceArgsForCall = append(fake.lookupWithAppInstanceArgsForCall, struct {
 		arg1 route.Uri
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
-	stub := fake.LookupWithInstanceStub
-	fakeReturns := fake.lookupWithInstanceReturns
-	fake.recordInvocation("LookupWithInstance", []interface{}{arg1, arg2, arg3})
-	fake.lookupWithInstanceMutex.Unlock()
+	stub := fake.LookupWithAppInstanceStub
+	fakeReturns := fake.lookupWithAppInstanceReturns
+	fake.recordInvocation("LookupWithAppInstance", []interface{}{arg1, arg2, arg3})
+	fake.lookupWithAppInstanceMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
 	}
@@ -131,44 +144,107 @@ func (fake *FakeRegistry) LookupWithInstance(arg1 route.Uri, arg2 string, arg3 s
 	return fakeReturns.result1
 }
 
-func (fake *FakeRegistry) LookupWithInstanceCallCount() int {
-	fake.lookupWithInstanceMutex.RLock()
-	defer fake.lookupWithInstanceMutex.RUnlock()
-	return len(fake.lookupWithInstanceArgsForCall)
+func (fake *FakeRegistry) LookupWithAppInstanceCallCount() int {
+	fake.lookupWithAppInstanceMutex.RLock()
+	defer fake.lookupWithAppInstanceMutex.RUnlock()
+	return len(fake.lookupWithAppInstanceArgsForCall)
 }
 
-func (fake *FakeRegistry) LookupWithInstanceCalls(stub func(route.Uri, string, string) *route.EndpointPool) {
-	fake.lookupWithInstanceMutex.Lock()
-	defer fake.lookupWithInstanceMutex.Unlock()
-	fake.LookupWithInstanceStub = stub
+func (fake *FakeRegistry) LookupWithAppInstanceCalls(stub func(route.Uri, string, string) *route.EndpointPool) {
+	fake.lookupWithAppInstanceMutex.Lock()
+	defer fake.lookupWithAppInstanceMutex.Unlock()
+	fake.LookupWithAppInstanceStub = stub
 }
 
-func (fake *FakeRegistry) LookupWithInstanceArgsForCall(i int) (route.Uri, string, string) {
-	fake.lookupWithInstanceMutex.RLock()
-	defer fake.lookupWithInstanceMutex.RUnlock()
-	argsForCall := fake.lookupWithInstanceArgsForCall[i]
+func (fake *FakeRegistry) LookupWithAppInstanceArgsForCall(i int) (route.Uri, string, string) {
+	fake.lookupWithAppInstanceMutex.RLock()
+	defer fake.lookupWithAppInstanceMutex.RUnlock()
+	argsForCall := fake.lookupWithAppInstanceArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeRegistry) LookupWithInstanceReturns(result1 *route.EndpointPool) {
-	fake.lookupWithInstanceMutex.Lock()
-	defer fake.lookupWithInstanceMutex.Unlock()
-	fake.LookupWithInstanceStub = nil
-	fake.lookupWithInstanceReturns = struct {
+func (fake *FakeRegistry) LookupWithAppInstanceReturns(result1 *route.EndpointPool) {
+	fake.lookupWithAppInstanceMutex.Lock()
+	defer fake.lookupWithAppInstanceMutex.Unlock()
+	fake.LookupWithAppInstanceStub = nil
+	fake.lookupWithAppInstanceReturns = struct {
 		result1 *route.EndpointPool
 	}{result1}
 }
 
-func (fake *FakeRegistry) LookupWithInstanceReturnsOnCall(i int, result1 *route.EndpointPool) {
-	fake.lookupWithInstanceMutex.Lock()
-	defer fake.lookupWithInstanceMutex.Unlock()
-	fake.LookupWithInstanceStub = nil
-	if fake.lookupWithInstanceReturnsOnCall == nil {
-		fake.lookupWithInstanceReturnsOnCall = make(map[int]struct {
+func (fake *FakeRegistry) LookupWithAppInstanceReturnsOnCall(i int, result1 *route.EndpointPool) {
+	fake.lookupWithAppInstanceMutex.Lock()
+	defer fake.lookupWithAppInstanceMutex.Unlock()
+	fake.LookupWithAppInstanceStub = nil
+	if fake.lookupWithAppInstanceReturnsOnCall == nil {
+		fake.lookupWithAppInstanceReturnsOnCall = make(map[int]struct {
 			result1 *route.EndpointPool
 		})
 	}
-	fake.lookupWithInstanceReturnsOnCall[i] = struct {
+	fake.lookupWithAppInstanceReturnsOnCall[i] = struct {
+		result1 *route.EndpointPool
+	}{result1}
+}
+
+func (fake *FakeRegistry) LookupWithProcessInstance(arg1 route.Uri, arg2 string, arg3 string) *route.EndpointPool {
+	fake.lookupWithProcessInstanceMutex.Lock()
+	ret, specificReturn := fake.lookupWithProcessInstanceReturnsOnCall[len(fake.lookupWithProcessInstanceArgsForCall)]
+	fake.lookupWithProcessInstanceArgsForCall = append(fake.lookupWithProcessInstanceArgsForCall, struct {
+		arg1 route.Uri
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.LookupWithProcessInstanceStub
+	fakeReturns := fake.lookupWithProcessInstanceReturns
+	fake.recordInvocation("LookupWithProcessInstance", []interface{}{arg1, arg2, arg3})
+	fake.lookupWithProcessInstanceMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeRegistry) LookupWithProcessInstanceCallCount() int {
+	fake.lookupWithProcessInstanceMutex.RLock()
+	defer fake.lookupWithProcessInstanceMutex.RUnlock()
+	return len(fake.lookupWithProcessInstanceArgsForCall)
+}
+
+func (fake *FakeRegistry) LookupWithProcessInstanceCalls(stub func(route.Uri, string, string) *route.EndpointPool) {
+	fake.lookupWithProcessInstanceMutex.Lock()
+	defer fake.lookupWithProcessInstanceMutex.Unlock()
+	fake.LookupWithProcessInstanceStub = stub
+}
+
+func (fake *FakeRegistry) LookupWithProcessInstanceArgsForCall(i int) (route.Uri, string, string) {
+	fake.lookupWithProcessInstanceMutex.RLock()
+	defer fake.lookupWithProcessInstanceMutex.RUnlock()
+	argsForCall := fake.lookupWithProcessInstanceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeRegistry) LookupWithProcessInstanceReturns(result1 *route.EndpointPool) {
+	fake.lookupWithProcessInstanceMutex.Lock()
+	defer fake.lookupWithProcessInstanceMutex.Unlock()
+	fake.LookupWithProcessInstanceStub = nil
+	fake.lookupWithProcessInstanceReturns = struct {
+		result1 *route.EndpointPool
+	}{result1}
+}
+
+func (fake *FakeRegistry) LookupWithProcessInstanceReturnsOnCall(i int, result1 *route.EndpointPool) {
+	fake.lookupWithProcessInstanceMutex.Lock()
+	defer fake.lookupWithProcessInstanceMutex.Unlock()
+	fake.LookupWithProcessInstanceStub = nil
+	if fake.lookupWithProcessInstanceReturnsOnCall == nil {
+		fake.lookupWithProcessInstanceReturnsOnCall = make(map[int]struct {
+			result1 *route.EndpointPool
+		})
+	}
+	fake.lookupWithProcessInstanceReturnsOnCall[i] = struct {
 		result1 *route.EndpointPool
 	}{result1}
 }
@@ -244,8 +320,10 @@ func (fake *FakeRegistry) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.lookupMutex.RLock()
 	defer fake.lookupMutex.RUnlock()
-	fake.lookupWithInstanceMutex.RLock()
-	defer fake.lookupWithInstanceMutex.RUnlock()
+	fake.lookupWithAppInstanceMutex.RLock()
+	defer fake.lookupWithAppInstanceMutex.RUnlock()
+	fake.lookupWithProcessInstanceMutex.RLock()
+	defer fake.lookupWithProcessInstanceMutex.RUnlock()
 	fake.registerMutex.RLock()
 	defer fake.registerMutex.RUnlock()
 	fake.unregisterMutex.RLock()

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -288,15 +288,17 @@ func (r *RouteRegistry) LookupWithProcessInstance(uri route.Uri, processID strin
 	var surgicalPool *route.EndpointPool
 
 	p.Each(func(e *route.Endpoint) {
-		if (e.ProcessId() == processID) && (e.PrivateInstanceIndex == processIndex) {
-			surgicalPool = route.NewPool(&route.PoolOpts{
-				Logger:                 r.logger,
-				RetryAfterFailure:      0,
-				Host:                   p.Host(),
-				ContextPath:            p.ContextPath(),
-				MaxConnsPerBackend:     p.MaxConnsPerBackend(),
-				LoadBalancingAlgorithm: p.LoadBalancingAlgorithm,
-			})
+		if (e.ProcessId() == processID) && (e.PrivateInstanceIndex == processIndex || processIndex == "") {
+			if surgicalPool == nil {
+				surgicalPool = route.NewPool(&route.PoolOpts{
+					Logger:                 r.logger,
+					RetryAfterFailure:      0,
+					Host:                   p.Host(),
+					ContextPath:            p.ContextPath(),
+					MaxConnsPerBackend:     p.MaxConnsPerBackend(),
+					LoadBalancingAlgorithm: p.LoadBalancingAlgorithm,
+				})
+			}
 			surgicalPool.Put(e)
 		}
 	})

--- a/route/pool.go
+++ b/route/pool.go
@@ -122,6 +122,10 @@ func (e *Endpoint) Equal(e2 *Endpoint) bool {
 
 }
 
+func (e *Endpoint) ProcessId() string {
+	return e.Tags["process_id"]
+}
+
 //go:generate counterfeiter -o fakes/fake_endpoint_iterator.go . EndpointIterator
 type EndpointIterator interface {
 	// Next MUST either return the next endpoint available or nil. It MUST NOT return the same endpoint.

--- a/route/pool_test.go
+++ b/route/pool_test.go
@@ -880,4 +880,55 @@ var _ = Describe("EndpointPool", func() {
 			Expect(string(json)).To(Equal(`[{"address":"1.2.3.4:5678","availability_zone":"az-meow","protocol":"http2","tls":false,"ttl":-1,"route_service_url":"https://my-rs.com","tags":{}}]`))
 		})
 	})
+
+	Describe("ProcessId", func() {
+		Context("when there are no tags", func() {
+			It("returns an empty string", func() {
+				e := route.NewEndpoint(&route.EndpointOpts{
+					AvailabilityZone:        "az-meow",
+					Host:                    "1.2.3.4",
+					Port:                    5678,
+					Protocol:                "http2",
+					RouteServiceUrl:         "https://my-rs.com",
+					StaleThresholdInSeconds: -1,
+				})
+
+				Expect(e.ProcessId()).To(BeEmpty())
+			})
+		})
+
+		Context("when there are tags, but no process_id entry", func() {
+			It("returns an empty string", func() {
+				tags := map[string]string{"meow": "meow"}
+				e := route.NewEndpoint(&route.EndpointOpts{
+					AvailabilityZone:        "az-meow",
+					Host:                    "1.2.3.4",
+					Port:                    5678,
+					Protocol:                "http2",
+					RouteServiceUrl:         "https://my-rs.com",
+					StaleThresholdInSeconds: -1,
+					Tags:                    tags,
+				})
+
+				Expect(e.ProcessId()).To(BeEmpty())
+			})
+		})
+
+		Context("when there are tags, and process_id exists", func() {
+			It("returns the process_id", func() {
+				tags := map[string]string{"process_id": "meow"}
+				e := route.NewEndpoint(&route.EndpointOpts{
+					AvailabilityZone:        "az-meow",
+					Host:                    "1.2.3.4",
+					Port:                    5678,
+					Protocol:                "http2",
+					RouteServiceUrl:         "https://my-rs.com",
+					StaleThresholdInSeconds: -1,
+					Tags:                    tags,
+				})
+
+				Expect(e.ProcessId()).To(Equal("meow"))
+			})
+		})
+	})
 })


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
When users do a [canary deploy](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html#canary-deployment-process) there is no easy way to send traffic to the canary instance to make sure it is working properly.

This new header will allow users to route via process_guid and via process_guid + index.

The new header must be provided in the form...
```
X-CF-PROCESS-INSTANCE:GUID:INDEX
or
X-CF-PROCESS-INSTANCE:GUID
```

For example:
```
X-CF-PROCESS-INSTANCE:dfb90cf9-2af4-4ee1-a0c0-67cebd75433e:1
or
X-CF-PROCESS-INSTANCE:dfb90cf9-2af4-4ee1-a0c0-67cebd75433e
```

This was modeled after the X-CF-APP-INSTANCE header.

If an invalid guid or index is provided, then it will return a 400 and error message.


Backward Compatibility
---------------
Breaking Change? No.