### PR TITLE
Retry new endpoint backends if they are being added while serving the request

### DIFF
--- a/route/pool.go
+++ b/route/pool.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"math/rand"
 	"net/http"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -379,11 +380,10 @@ func (p *EndpointPool) Remove(endpoint *Endpoint) bool {
 func (p *EndpointPool) removeEndpoint(e *endpointElem) {
 	i := e.index
 	es := p.endpoints
-	last := len(es)
-	// re-ordering delete
-	es[last-1], es[i], es = nil, es[last-1], es[:last-1]
-	if i < last-1 {
-		es[i].index = i
+
+	es = slices.Delete(es, i, i+1)
+	for j := i; j < len(es); j++ {
+		es[j].index = j
 	}
 	p.endpoints = es
 

--- a/route/roundrobin_test.go
+++ b/route/roundrobin_test.go
@@ -375,11 +375,11 @@ var _ = Describe("RoundRobin", func() {
 						Expect(iter.Next(0)).To(Equal(epOne))
 						iter.EndpointFailed(&net.OpError{Op: "dial"})
 
-						Expect(iter.Next(0)).To(Equal(epTwo))
-						iter.EndpointFailed(&net.OpError{Op: "dial"})
-
 						Expect(iter.Next(0)).To(Equal(epThree))
 						epThree.Stats.NumberConnections.Increment()
+
+						Expect(iter.Next(0)).To(Equal(epTwo))
+						iter.EndpointFailed(&net.OpError{Op: "dial"})
 
 						Expect(iter.Next(0)).To(Equal(epThree))
 						epThree.Stats.NumberConnections.Increment()


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Support application availability during rolling restarts. During application restart with rolling strategy new instance comes up first and then old instance is removed. If the number of application instances is less than the number of attempts gorouter might not try to serve new instance if it comes up while request is being served. This is because it saves in memory number of instances and only retries up to that number. 

Instead retry next instance in the pool and only leave the loop before the maximum number of attempts if there were no updates to the pool.
When new instance is registered pool gets updated.
When instance is removed shift all instances in the pool instead of moving last registered element in its place. This way last registered element will stay at the end of the pool and loop will get to it faster.


Backward Compatibility
---------------
Breaking Change? **No**
